### PR TITLE
Edit lammps calculator

### DIFF
--- a/flare/lammps/lammps_calculator.py
+++ b/flare/lammps/lammps_calculator.py
@@ -47,50 +47,99 @@ quantities to get dumped.
     return np.array(forces)
 
 
-class Lammps_Calculator:
-    def __init__(self, struc, style_string, coeff_string, lammps_folder,
-                 lammps_executable, atom_types, atom_masses, species,
-                 charges=None):
-        self.struc = struc
-        self.style_string = style_string
-        self.coeff_string = coeff_string
-        self.lammps_folder = lammps_folder
-        self.lammps_executable = lammps_executable
-        self.atom_types = atom_types
-        self.atom_masses = atom_masses
-        self.species = species
-        self.charges = charges
+def lammps_dat(struc, atom_types, atom_masses):
+    dat_text = """Header of the LAMMPS data file
 
-        self.input_file = lammps_folder + '/tmp.in'
-        self.output_file = lammps_folder + '/tmp.out'
-        self.dat_file = lammps_folder + '/tmp.data'
-        self.dump_file = lammps_folder + '/tmp.dump'
+%i atoms
+%i atom types
+""" % (struc.nat, len(atom_types))
 
-        self.input_text = self.lammps_input()
-        self.dat_text = self.lammps_dat()
+    dat_text += lammps_cell_text(struc)
+    dat_text += """
+Masses
 
-    def get_forces(self):
-        self.lammps_generator()
-        self.run_ewald()
-        forces = self.lammps_parser()
-        return forces
+"""
+    mass_text = ''
+    for atom_type, atom_mass in zip(atom_types, atom_masses):
+        mass_text += '%i %i\n' % (atom_type, atom_mass)
+    dat_text += mass_text
+    dat_text += """
+Atoms
+"""
+    dat_text += lammps_pos_text(struc, atom_types)
 
-    def run_ewald(self):
-        # create input and data files
-        self.lammps_generator()
+    return dat_text
 
-        # run lammps
-        lammps_command = '%s < %s > %s' % (self.lammps_executable,
-                                           self.input_file,
-                                           self.output_file)
-        os.system(lammps_command)
 
-    def lammps_generator(self):
-        self.write_file(self.input_file, self.input_text)
-        self.write_file(self.dat_file, self.dat_text)
+def lammps_dat_charged(struc, atom_types, atom_charges, atom_masses):
+    dat_text = """Header of the LAMMPS data file
 
-    def lammps_input(self):
-        input_text = """# lammps input file created with eam.py.
+%i atoms
+%i atom types
+""" % (struc.nat, len(atom_types))
+
+    dat_text += lammps_cell_text(struc)
+    dat_text += """
+Masses
+
+"""
+    mass_text = ''
+    for atom_type, atom_mass in zip(atom_types,
+                                    atom_masses):
+        mass_text += '%i %i\n' % (atom_type, atom_mass)
+    dat_text += mass_text
+    dat_text += """
+Atoms
+"""
+    dat_text += lammps_pos_text_charged(struc, atom_charges, atom_types)
+
+    return dat_text
+
+
+def lammps_cell_text(struc):
+    """ Write cell from structure object. Assumes orthorombic periodic
+    cell."""
+
+    cell_text = """
+0.0 %f  xlo xhi
+0.0 %f  ylo yhi
+0.0 %f  zlo zhi
+%f %f %f  xy xz yz
+""" % (struc.cell[0, 0],
+       struc.cell[1, 1],
+       struc.cell[2, 2],
+       struc.cell[1, 0],
+       struc.cell[2, 0],
+       struc.cell[2, 1])
+
+    return cell_text
+
+
+def lammps_pos_text(struc, species):
+    pos_text = '\n'
+    for count, (pos, spec) in enumerate(zip(struc.positions,
+                                            species)):
+        pos_text += '%i %i %f %f %f \n' % \
+            (count+1, spec, pos[0], pos[1], pos[2])
+    return pos_text
+
+
+def lammps_pos_text_charged(struc, charges, species):
+    pos_text = '\n'
+    for count, (pos, chrg, spec) in enumerate(zip(struc.positions, charges,
+                                                  species)):
+        pos_text += '%i %i %f %f %f %f \n' % \
+            (count+1, spec, chrg, pos[0], pos[1], pos[2])
+    return pos_text
+
+
+def write_input(file, text):
+    with open(file, 'w') as fin:
+        fin.write(text)
+
+
+def generic_lammps_input(dat_file, style_string, coeff_string, dump_file):
+    input_text = """# generic lammps input file.
 units metal
 atom_style atomic
 dimension  3
@@ -105,93 +154,6 @@ thermo_style one
 dump 1 all custom 1 %s id type x y z fx fy fz
 dump_modify 1 sort id
 run 0
-""" % (self.dat_file, self.style_string, self.coeff_string, self.dump_file)
+""" % (dat_file, style_string, coeff_string, dump_file)
 
-        return input_text
-
-    def lammps_dat(self):
-        dat_text = """Header of the LAMMPS data file
-
-%i atoms
-%i atom types
-""" % (self.struc.nat, len(self.atom_types))
-
-        dat_text += self.lammps_cell_text()
-        dat_text += """
-Masses
-
-"""
-        mass_text = ''
-        for atom_type, atom_mass in zip(self.atom_types, self.atom_masses):
-            mass_text += '%i %i\n' % (atom_type, atom_mass)
-        dat_text += mass_text
-        dat_text += """
-Atoms
-"""
-        dat_text += self.lammps_pos_text()
-
-        return dat_text
-
-    def lammps_dat_charged(self):
-        dat_text = """Header of the LAMMPS data file
-
-%i atoms
-%i atom types
-""" % (self.struc.nat, len(self.atom_types))
-
-        dat_text += self.lammps_cell_text()
-        dat_text += """
-Masses
-
-"""
-        mass_text = ''
-        for atom_type, atom_mass in zip(self.atom_types,
-                                        self.atom_masses):
-            mass_text += '%i %i\n' % (atom_type, atom_mass)
-        dat_text += mass_text
-        dat_text += """
-Atoms
-"""
-        dat_text += self.lammps_pos_text_charged()
-
-        return dat_text
-
-    def lammps_cell_text(self):
-        """ Write cell from structure object. Assumes orthorombic periodic
-        cell."""
-
-        cell_text = """
-0.0 %f  xlo xhi
-0.0 %f  ylo yhi
-0.0 %f  zlo zhi
-%f %f %f  xy xz yz
-""" % (self.struc.cell[0, 0],
-            self.struc.cell[1, 1],
-            self.struc.cell[2, 2],
-            self.struc.cell[1, 0],
-            self.struc.cell[2, 0],
-            self.struc.cell[2, 1])
-
-        return cell_text
-
-    def lammps_pos_text(self):
-        pos_text = '\n'
-        for count, (pos, spec) in enumerate(zip(self.struc.positions,
-                                                self.species)):
-            pos_text += '%i %i %f %f %f \n' % \
-                (count+1, spec, pos[0], pos[1], pos[2])
-        return pos_text
-
-    def lammps_pos_text_charged(self):
-        pos_text = '\n'
-        for count, (pos, chrg, spec) in enumerate(zip(self.struc.positions,
-                                                      self.charges,
-                                                      self.species)):
-            pos_text += '%i %i %f %f %f %f \n' % \
-                (count+1, spec, chrg, pos[0], pos[1], pos[2])
-        return pos_text
-
-    @staticmethod
-    def write_file(file, text):
-        with open(file, 'w') as fin:
-            fin.write(text)
+    return input_text

--- a/tests/test_mff.py
+++ b/tests/test_mff.py
@@ -102,23 +102,32 @@ def test_parse_header():
     forces = otf_object.force_list[-1]
     structure = struc.Structure(otf_cell, species, positions)
 
-    # compute forces on structure with lammps potential
-    style_string = 'mff'
-    coeff_string = '* * {} 47 53 yes yes'.format(lammps_location)
-    lammps_folder = '.'
-    lammps_executable = '$lmp'
-
     atom_types = [1, 2]
     atom_masses = [108, 127]
     atom_species = [1, 2] * 27
 
-    lammps_calc = \
-        lammps_calculator.Lammps_Calculator(structure, style_string,
-                                            coeff_string, lammps_folder,
-                                            lammps_executable, atom_types,
-                                            atom_masses, atom_species)
+    # create data file
+    data_file_name = 'tmp.data'
+    data_text = lammps_calculator.lammps_dat(structure, atom_types,
+                                             atom_masses, atom_species)
+    lammps_calculator.write_text(data_file_name, data_text)
 
-    lammps_forces = lammps_calc.get_forces()
+    # create lammps input
+    style_string = 'mff'
+    coeff_string = '* * {} 47 53 yes yes'.format(lammps_location)
+    lammps_executable = '$lmp'
+    dump_file_name = 'tmp.dump'
+    input_file_name = 'tmp.in'
+    output_file_name = 'tmp.out'
+    input_text = \
+        lammps_calculator.generic_lammps_input(data_file_name, style_string,
+                                               coeff_string, dump_file_name)
+    lammps_calculator.write_text(input_file_name, input_text)
+
+    lammps_calculator.run_lammps(lammps_executable, input_file_name,
+                                 output_file_name)
+
+    lammps_forces = lammps_calculator.lammps_parser(dump_file_name)
 
     # check that lammps agrees with gp to within 1 meV/A
     assert(np.abs(lammps_forces[0, 1] - forces[0, 1]) < 1e-3)


### PR DESCRIPTION
The lammps calculator in flare/lammps is now more flexible, decoupling input, output, and data file generation (for both charged and uncharged systems). This file is mainly used for the long range AgI project, making it easy to perform Ewald sums and single point force calculations with generic pair styles.

The mff test has been updated to account for these changes.