### PR TITLE
new output class and add configuration output in ".xyz" format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@ pwscf.save/
 /tests/*.xyz
 /docs/source/_build/html
 /tests/*-bak
-/tests/*otf*out
+/tests/*.out
+/tests/*dat
 /tests/alog
 /tests/gp_from_aimd.out
 /tests/h2_otf.out-f.xyz-bak

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,12 @@ pwscf.save/
 /tests/ase_otf/kv3/
 /tests/ase_otf/grid3*
 /tests/test_outputs/*
+/tests/*.xyz
 /docs/source/_build/html
+/tests/*-bak
+/tests/*otf*out
+/tests/alog
+/tests/gp_from_aimd.out
+/tests/h2_otf.out-f.xyz-bak
+/tests/pwscf.xml
+

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -24,7 +24,7 @@ class GaussianProcess:
                  energy_kernel: Callable = None,
                  opt_algorithm: str = 'L-BFGS-B',
                  maxiter=10, par=False,
-                 monitor=False):
+                 output=None):
         """Initialize GP parameters and training data."""
 
         self.kernel = kernel
@@ -45,7 +45,7 @@ class GaussianProcess:
         self.likelihood = None
         self.likelihood_gradient = None
         self.par = par
-        self.monitor = monitor
+        self.output = output
 
     # TODO unit test custom range
     def update_db(self, struc: Structure, forces: list,
@@ -112,7 +112,7 @@ class GaussianProcess:
 
         return forces_np
 
-    def train(self, monitor=False, custom_bounds=None,
+    def train(self, output=None, custom_bounds=None,
               grad_tol: float = 1e-4,
               x_tol: float = 1e-5,
               line_steps: int = 20):
@@ -126,7 +126,7 @@ class GaussianProcess:
         x_0 = self.hyps
 
         args = (self.training_data, self.training_labels_np,
-                self.kernel_grad, self.cutoffs, monitor,
+                self.kernel_grad, self.cutoffs, output,
                 self.par)
 
         if self.algo == 'L-BFGS-B':

--- a/flare/gp_algebra.py
+++ b/flare/gp_algebra.py
@@ -261,11 +261,11 @@ def get_like_grad_from_mats(ky_mat, hyp_mat, training_labels_np):
 
 def get_neg_likelihood(hyps: np.ndarray, training_data: list,
                        training_labels_np: np.ndarray,
-                       kernel, cutoffs=None, monitor: bool = False,
+                       kernel, cutoffs=None, output = None,
                        par=False):
 
-    if monitor:
-        print('hyps: ' + str(hyps))
+    if output is not None:
+        output.write_to_log('hyps: ' + str(hyps), name="hyps")
 
     if par:
         ky_mat = \
@@ -278,9 +278,8 @@ def get_neg_likelihood(hyps: np.ndarray, training_data: list,
 
     like = get_like_from_ky_mat(ky_mat, training_labels_np)
 
-    if monitor:
-        print('like: ' + str(like))
-        print('\n')
+    if output is not None:
+        output.write_to_log('like: ' + str(like)+'\n', name="hyps")
 
     return -like
 
@@ -288,10 +287,10 @@ def get_neg_likelihood(hyps: np.ndarray, training_data: list,
 def get_neg_like_grad(hyps: np.ndarray, training_data: list,
                       training_labels_np: np.ndarray,
                       kernel_grad, cutoffs=None,
-                      monitor: bool = False, par=False):
+                      output = None, par=False):
 
-    if monitor:
-        print('hyps: ' + str(hyps))
+    if output is not None:
+        output.write_to_log('hyps: ' + str(hyps)+'\n', name="hyps")
 
     if par:
         hyp_mat, ky_mat = \
@@ -305,9 +304,8 @@ def get_neg_like_grad(hyps: np.ndarray, training_data: list,
     like, like_grad = \
         get_like_grad_from_mats(ky_mat, hyp_mat, training_labels_np)
 
-    if monitor:
-        print('like grad: ' + str(like_grad))
-        print('like: ' + str(like))
-        print('\n')
+    if output is not None:
+        output.write_to_log('like grad: ' + str(like_grad)+'\n', name="hyps")
+        output.write_to_log('like: ' + str(like)+'\n', name="hyps")
 
     return -like, -like_grad

--- a/flare/gp_from_aimd.py
+++ b/flare/gp_from_aimd.py
@@ -15,7 +15,7 @@ from flare.env import AtomicEnvironment
 import numpy as np
 from copy import deepcopy
 import pickle
-import flare.output as output
+from flare.output import Output
 
 
 class TrajectoryTrainer(object):
@@ -27,7 +27,7 @@ class TrajectoryTrainer(object):
                  parallel: bool = False,
                  skip: int = 0,
                  calculate_energy: bool = False,
-                 output_name: str = 'gp_from_aimd.out',
+                 output_name: str = 'gp_from_aimd',
                  max_atoms_from_frame: int = np.inf, max_trains: int = np.inf,
                  min_atoms_added: int = 1,
                  n_cpus: int = 1, shuffle_frames: bool = False,
@@ -92,7 +92,7 @@ class TrajectoryTrainer(object):
             else:
                 self.pred_func = predict_on_structure
 
-        self.output_name = output_name
+        self.output = Output(output_name)
 
         # set number of cpus for parallelization
         self.n_cpus = n_cpus
@@ -119,16 +119,15 @@ class TrajectoryTrainer(object):
         training set, then seed with at least one atom from each
         """
 
-        output.write_header(self.gp.cutoffs,
-                            self.gp.kernel_name,
-                            self.gp.hyps,
-                            self.gp.algo,
-                            dt=0,
-                            Nsteps=len(self.frames),
-                            structure=self.frames[0],
-                            std_tolerance=(self.rel_std_tolerance,
-                                           self.abs_std_tolerance),
-                            output_name=self.output_name)
+        self.output.write_header(self.gp.cutoffs,
+                                 self.gp.kernel_name,
+                                 self.gp.hyps,
+                                 self.gp.algo,
+                                 dt=0,
+                                 Nsteps=len(self.frames),
+                                 structure=self.frames[0],
+                                 std_tolerance=(self.rel_std_tolerance,
+                                                self.abs_std_tolerance))
 
         self.start_time = time.time()
 
@@ -190,9 +189,9 @@ class TrajectoryTrainer(object):
             mae = np.mean(np.abs(cur_frame.forces - dft_forces)) * 1000
             mac = np.mean(np.abs(dft_forces)) * 1000
 
-            output.write_gp_dft_comparison(
+            self.output.write_gp_dft_comparison(
                 curr_step=i, frame=cur_frame,
-                start_time=time.time(), output_name=self.output_name,
+                start_time=time.time(),
                 dft_forces=dft_forces,
                 mae=mae, mac=mac, local_energies=None)
 
@@ -207,8 +206,7 @@ class TrajectoryTrainer(object):
                 if self.train_count < self.max_trains:
                     self.train_gp()
 
-        output.conclude_run(self.output_name)
-        output.close_files()
+        self.output.conclude_run()
 
         if self.pickle_name:
             with open(self.pickle_name, 'wb') as f:
@@ -226,13 +224,11 @@ class TrajectoryTrainer(object):
         :return:
         """
 
-        output.write_to_output('\nAdding atom(s) {} to the '
-                               'training set.\n'
-                               .format(train_atoms, ),
-                               self.output_name)
-        output.write_to_output('Uncertainties: {}.\n'
-                               .format(frame.stds[train_atoms]),
-                               self.output_name)
+        self.output.write_to_log('\nAdding atom(s) {} to the '
+                                 'training set.\n'
+                                 .format(train_atoms, ))
+        self.output.write_to_log('Uncertainties: {}.\n'
+                                 .format(frame.stds[train_atoms]))
 
         # update gp model
         self.gp.update_db(frame, frame.forces, custom_range=train_atoms)
@@ -247,9 +243,9 @@ class TrajectoryTrainer(object):
         """
         self.gp.train(monitor=True if self.verbose >= 2 else False)
 
-        output.write_hyps(self.gp.hyp_labels, self.gp.hyps,
-                          self.start_time, self.output_name,
-                          self.gp.like, self.gp.like_grad)
+        self.output.write_hyps(self.gp.hyp_labels, self.gp.hyps,
+                               self.start_time,
+                               self.gp.like, self.gp.like_grad)
         self.train_count += 1
 
     def is_std_in_bound(self, frame: Structure)->(bool, List[int]):

--- a/flare/gp_from_aimd.py
+++ b/flare/gp_from_aimd.py
@@ -165,7 +165,7 @@ class TrajectoryTrainer(object):
         if (self.gp.l_mat is None) \
                 or (self.seed_frames is not None
                     or self.seed_envs is not None):
-            self.gp.train(monitor=self.verbose)
+            self.gp.train(output=self.output if self.verbose > 0 else None)
 
     def run(self):
         """
@@ -241,7 +241,7 @@ class TrajectoryTrainer(object):
         """
         Train the Gaussian process and write the results to the output file.
         """
-        self.gp.train(monitor=True if self.verbose >= 2 else False)
+        self.gp.train(output=self.output if self.verbose >= 2 else None)
 
         self.output.write_hyps(self.gp.hyp_labels, self.gp.hyps,
                                self.start_time,

--- a/flare/gp_from_aimd.py
+++ b/flare/gp_from_aimd.py
@@ -208,6 +208,7 @@ class TrajectoryTrainer(object):
                     self.train_gp()
 
         output.conclude_run(self.output_name)
+        output.close_files()
 
         if self.pickle_name:
             with open(self.pickle_name, 'wb') as f:

--- a/flare/md_run.py
+++ b/flare/md_run.py
@@ -6,7 +6,7 @@ import time
 import datetime
 import concurrent.futures
 from flare import md
-from flare import output
+from flare.output import Output
 
 
 class MD:
@@ -42,12 +42,11 @@ class MD:
         self.pes = []
         self.kes = []
 
-        self.output_name = output_name
+        self.output = Output(output_name)
 
     def run(self):
-        output.write_header(self.gp.cutoffs, self.gp.kernel_name, self.gp.hyps,
-                            self.gp.algo, self.dt, self.Nsteps, self.structure,
-                            self.output_name)
+        self.output.write_header(self.gp.cutoffs, self.gp.kernel_name, self.gp.hyps,
+                                 self.gp.algo, self.dt, self.Nsteps, self.structure)
         self.start_time = time.time()
 
         while self.curr_step < self.Nsteps:
@@ -59,7 +58,7 @@ class MD:
             self.update_positions(new_pos)
             self.curr_step += 1
 
-        output.conclude_run(self.output_name)
+        self.output.conclude_run()
 
     def predict_on_structure_en(self):
         for n in range(self.structure.nat):
@@ -110,6 +109,8 @@ class MD:
     def record_state(self):
         self.pes.append(np.sum(self.local_energies))
         self.kes.append(self.KE)
-        output.write_md_config(self.dt, self.curr_step, self.structure,
-                               self.temperature, self.KE, self.local_energies,
-                               self.start_time, self.output_name)
+        self.output.write_md_config(self.dt, self.curr_step, self.structure,
+                                    self.temperature, self.KE, self.local_energies,
+                                    self.start_time)
+        self.output.write_xyz_config(self.curr_step, self.structure,
+                                     self.dft_step)

--- a/flare/otf.py
+++ b/flare/otf.py
@@ -7,7 +7,8 @@ import copy
 import multiprocessing as mp
 import subprocess
 import concurrent.futures
-from flare import struc, gp, env, qe_util, md, output
+from flare import struc, gp, env, qe_util, md
+from flare.output import Output
 
 
 class OTF(object):
@@ -16,7 +17,7 @@ class OTF(object):
                  std_tolerance_factor: float = 1,
                  prev_pos_init: np.ndarray=None, par: bool=False,
                  skip: int=0, init_atoms: List[int]=None,
-                 calculate_energy=False, output_name='otf_run.out',
+                 calculate_energy=False, output_name='otf_run',
                  max_atoms_added=1, freeze_hyps=10,
                  rescale_steps=[], rescale_temps=[],
                  no_cpus=1):
@@ -78,16 +79,17 @@ class OTF(object):
         self.rescale_steps = rescale_steps
         self.rescale_temps = rescale_temps
 
-        self.output_name = output_name
+        self.output = Output(output_name)
 
         # set number of cpus for qe runs
         self.no_cpus = no_cpus
 
     def run(self):
-        output.write_header(self.gp.cutoffs, self.gp.kernel_name, self.gp.hyps,
-                            self.gp.algo, self.dt, self.number_of_steps,
-                            self.structure, self.output_name,
-                            self.std_tolerance)
+        self.output.write_header(self.gp.cutoffs, self.gp.kernel_name,
+                                 self.gp.hyps, self.gp.algo,
+                                 self.dt, self.number_of_steps,
+                                 self.structure,
+                                 self.std_tolerance)
         counter = 0
         self.start_time = time.time()
 
@@ -137,12 +139,10 @@ class OTF(object):
                     mae = np.mean(np.abs(gp_frcs - dft_frcs))
                     mac = np.mean(np.abs(dft_frcs))
 
-                    output.write_to_output('\nmean absolute error:'
-                                           ' %.4f eV/A \n'
-                                           % mae, self.output_name)
-                    output.write_to_output('mean absolute dft component:'
-                                           ' %.4f eV/A \n' % mac,
-                                           self.output_name)
+                    self.output.write_to_log('\nmean absolute error:'
+                                             ' %.4f eV/A \n' % mae)
+                    self.output.write_to_log('mean absolute dft component:'
+                                           ' %.4f eV/A \n' % mac)
 
                     # add max uncertainty atoms to training set
                     self.update_gp(target_atoms, dft_frcs)
@@ -159,8 +159,7 @@ class OTF(object):
             self.update_positions(new_pos)
             self.curr_step += 1
 
-        output.conclude_run(self.output_name)
-        output.close_files()
+        self.output.conclude_run()
 
     def predict_on_atom(self, atom):
         chemenv = env.AtomicEnvironment(self.structure, atom, self.gp.cutoffs)
@@ -225,8 +224,7 @@ class OTF(object):
             self.local_energies[n] = self.gp.predict_local_energy(chemenv)
 
     def run_dft(self):
-        output.write_to_output('\nCalling Quantum Espresso...\n',
-                               self.output_name)
+        self.output.write_to_log('\nCalling Quantum Espresso...\n')
 
         # calculate DFT forces
         forces = qe_util.run_espresso_par(self.qe_input, self.structure,
@@ -235,20 +233,16 @@ class OTF(object):
 
         # write wall time of DFT calculation
         self.dft_count += 1
-        output.write_to_output('QE run complete.\n', self.output_name)
+        self.output.write_to_log('QE run complete.\n')
         time_curr = time.time() - self.start_time
-        output.write_to_output('number of DFT calls: %i \n' % self.dft_count,
-                               self.output_name)
-        output.write_to_output('wall time from start: %.2f s \n' % time_curr,
-                               self.output_name)
+        self.output.write_to_log('number of DFT calls: %i \n' % self.dft_count)
+        self.output.write_to_log('wall time from start: %.2f s \n' % time_curr)
 
     def update_gp(self, train_atoms, dft_frcs):
-        output.write_to_output('\nAdding atom {} to the training set.\n'
-                               .format(train_atoms),
-                               self.output_name)
-        output.write_to_output('Uncertainty: {}.\n'
-                               .format(self.structure.stds[train_atoms[0]]),
-                               self.output_name)
+        self.output.write_to_log('\nAdding atom {} to the training set.\n'
+                                 .format(train_atoms))
+        self.output.write_to_log('Uncertainty: {}.\n'
+                                 .format(self.structure.stds[train_atoms[0]]))
 
         # update gp model
         self.gp.update_db(self.structure, dft_frcs,
@@ -263,9 +257,9 @@ class OTF(object):
 
     def train_gp(self):
         self.gp.train(True)
-        output.write_hyps(self.gp.hyp_labels, self.gp.hyps,
-                          self.start_time, self.output_name,
-                          self.gp.like, self.gp.like_grad)
+        self.output.write_hyps(self.gp.hyp_labels, self.gp.hyps,
+                               self.start_time,
+                               self.gp.like, self.gp.like_grad)
 
     def is_std_in_bound(self):
         # set uncertainty threshold
@@ -310,10 +304,10 @@ class OTF(object):
         self.velocities = velocities
 
     def record_state(self):
-        output.write_md_config(self.dt, self.curr_step, self.structure,
-                               self.temperature, self.KE,
-                               self.local_energies, self.start_time,
-                               self.output_name, self.dft_step,
-                               self.velocities)
-        output.write_xyz_config(self.curr_step, self.structure,
-                                self.dft_step, self.output_name)
+        self.output.write_md_config(self.dt, self.curr_step, self.structure,
+                                    self.temperature, self.KE,
+                                    self.local_energies, self.start_time,
+                                    self.dft_step,
+                                    self.velocities)
+        self.output.write_xyz_config(self.curr_step, self.structure,
+                                     self.dft_step)

--- a/flare/otf.py
+++ b/flare/otf.py
@@ -316,4 +316,4 @@ class OTF(object):
                                self.output_name, self.dft_step,
                                self.velocities)
         output.write_xyz_config(self.curr_step, self.structure,
-                                self.dft_step, self.output_name):
+                                self.dft_step, self.output_name)

--- a/flare/otf.py
+++ b/flare/otf.py
@@ -160,6 +160,7 @@ class OTF(object):
             self.curr_step += 1
 
         output.conclude_run(self.output_name)
+        output.close_files()
 
     def predict_on_atom(self, atom):
         chemenv = env.AtomicEnvironment(self.structure, atom, self.gp.cutoffs)
@@ -314,3 +315,5 @@ class OTF(object):
                                self.local_energies, self.start_time,
                                self.output_name, self.dft_step,
                                self.velocities)
+        output.write_xyz_config(self.curr_step, self.structure,
+                                self.dft_step, self.output_name):

--- a/flare/otf.py
+++ b/flare/otf.py
@@ -256,7 +256,7 @@ class OTF(object):
         #     self.gp.update_L_alpha()
 
     def train_gp(self):
-        self.gp.train(True)
+        self.gp.train(self.output)
         self.output.write_hyps(self.gp.hyp_labels, self.gp.hyps,
                                self.start_time,
                                self.gp.like, self.gp.like_grad)

--- a/flare/output.py
+++ b/flare/output.py
@@ -19,14 +19,8 @@ class Output():
         filesuffix = {'log':'.out', 'xyz':'.xyz', 'fxyz':'-f.xyz'}
 
         for filetype in ['log', 'xyz', 'fxyz']:
+            self.open_new_log(filetype, filesuffix[filetype])
 
-            filename = self.basename+filesuffix[filetype]
-
-            # if the file exists, back up
-            if os.path.isfile(filename):
-                shutil.copy(filename, filename+"-bak")
-
-            self.outfiles[filetype] = open(filename, "w+")
 
     def conclude_run(self):
         """
@@ -39,11 +33,22 @@ class Output():
         del self.outfiles
         self.outfiles = {}
 
-    def write_to_log(self, logstring):
+    def open_new_log(self, filetype, suffix):
+
+        filename = self.basename+suffix
+
+        # if the file exists, back up
+        if os.path.isfile(filename):
+            shutil.copy(filename, filename+"-bak")
+
+        self.outfiles[filetype] = open(filename, "w+")
+
+
+    def write_to_log(self, logstring, name="log"):
         """
         write any string to logfile
         """
-        self.outfiles['log'].write(logstring)
+        self.outfiles[name].write(logstring)
 
     def write_header(self, cutoffs, kernel_name,
                      hyps, algo, dt, Nsteps, structure,

--- a/flare/output.py
+++ b/flare/output.py
@@ -12,7 +12,7 @@ class Output():
     :param basename
     """
 
-    def __init__(self, basename='otf_run'):
+    def __init__(self, basename: str='otf_run'):
         """
         open files with the basename and different suffices.
         """
@@ -48,9 +48,9 @@ class Output():
         else:
             self.outfiles[filetype] = open(filename, "w+")
 
-    def write_to_log(self, logstring, name="log"):
+    def write_to_log(self, logstring: str, name: str="log"):
         """
-        write any string to logfile
+        Write any string to logfile
         """
         self.outfiles[name].write(logstring)
 

--- a/flare/output.py
+++ b/flare/output.py
@@ -2,7 +2,9 @@ import time
 import datetime
 import numpy as np
 import multiprocessing
-import os, shutil
+import os
+import shutil
+
 
 class Output():
     """
@@ -16,11 +18,10 @@ class Output():
         """
         self.basename = "{}".format(basename)
         self.outfiles = {}
-        filesuffix = {'log':'.out', 'xyz':'.xyz', 'fxyz':'-f.xyz'}
+        filesuffix = {'log': '.out', 'xyz': '.xyz', 'fxyz': '-f.xyz'}
 
         for filetype in ['log', 'xyz', 'fxyz']:
             self.open_new_log(filetype, filesuffix[filetype])
-
 
     def conclude_run(self):
         """
@@ -42,7 +43,6 @@ class Output():
             shutil.copy(filename, filename+"-bak")
 
         self.outfiles[filetype] = open(filename, "w+")
-
 
     def write_to_log(self, logstring, name="log"):
         """
@@ -77,7 +77,8 @@ class Output():
                 std_tolerance[1])
         elif std_tolerance < 0:
             std_string = \
-                'uncertainty tolerance: {} eV/A\n'.format(np.abs(std_tolerance))
+                'uncertainty tolerance: {} eV/A\n'.format(
+                    np.abs(std_tolerance))
         elif std_tolerance > 0:
             std_string = \
                 'uncertainty tolerance: {} times noise \n' \
@@ -113,12 +114,12 @@ class Output():
         for i in range(len(structure.positions)):
             headerstring += str(structure.species_labels[i]) + ' '
             for j in range(3):
-                headerstring += str("%.8f" % structure.prev_positions[i][j]) + ' '
+                headerstring += str("%.8f" %
+                                    structure.prev_positions[i][j]) + ' '
             headerstring += '\n'
         headerstring += '-' * 80 + '\n'
 
         f.write(headerstring)
-
 
     def write_md_config(self, dt, curr_step, structure,
                         temperature, KE, local_energies,
@@ -190,7 +191,6 @@ class Output():
 
         self.outfiles['log'].write(string)
 
-
     def write_xyz_config(self, curr_step, structure, dft_step):
         """
         write atomic configuration in xyz file
@@ -259,7 +259,6 @@ class Output():
     def write_gp_dft_comparison(self, curr_step, frame,
                                 start_time, dft_forces,
                                 mae, mac, local_energies=None, KE=None):
-
         """
         write the comparison to logfile
         :param dft_forces:

--- a/flare/output.py
+++ b/flare/output.py
@@ -40,6 +40,9 @@ class Output():
         self.outfiles = {}
 
     def write_to_log(self, logstring):
+        """
+        write any string to logfile
+        """
         self.outfiles['log'].write(logstring)
 
     def write_header(self, cutoffs, kernel_name,
@@ -48,7 +51,15 @@ class Output():
                      optional: dict = None):
         """
         write header to the log function
-        :param cutoffs
+        :param cutoffs:
+        :param kernel_name:
+        :param hyps:
+        :param algo:
+        :param dt:
+        :param Nsteps:
+        :param structure:
+        :param std_tolerance:
+        :param optional:
         """
 
         f = self.outfiles['log']
@@ -107,6 +118,21 @@ class Output():
     def write_md_config(self, dt, curr_step, structure,
                         temperature, KE, local_energies,
                         start_time, dft_step, velocities):
+        """
+        write md configuration in log file
+        :param dt:
+        :param curr_step:
+        :param structure:
+        :param temperature:
+        :param KE:
+        :param local_energies:
+        :param start_time:
+        :param dft_step:
+        :param velocities:
+        :return:
+        """
+        :return:
+        """
 
         string = ''
 

--- a/flare/output.py
+++ b/flare/output.py
@@ -42,7 +42,11 @@ class Output():
         if os.path.isfile(filename):
             shutil.copy(filename, filename+"-bak")
 
-        self.outfiles[filetype] = open(filename, "w+")
+        if filetype in self.outfiles.keys():
+            if self.outfiles[filetype].closed:
+                self.outfiles[filetype] = open(filename, "w+")
+        else:
+            self.outfiles[filetype] = open(filename, "w+")
 
     def write_to_log(self, logstring, name="log"):
         """

--- a/flare/output.py
+++ b/flare/output.py
@@ -8,6 +8,7 @@ outfiles = {}
 def close_files():
     for (k, v) in outfiles.items():
         v.close()
+        del outfiles[k]
 
 def find_files(output_name: str = 'otf_run.out'):
     if (output_name in outfiles.keys()):
@@ -152,7 +153,7 @@ def write_xyz_config(curr_step, structure, dft_step, output_name):
     for i in range(natom):
         pos = structure.positions[i]
         string += '{} {} {} {}\n'.format(
-            structure.species[i], pos[0], pos[1], pos[2])
+            structure.species_labels[i], pos[0], pos[1], pos[2])
 
     write_to_output(string, output_name+".xyz")
 
@@ -169,7 +170,7 @@ def write_xyz_config(curr_step, structure, dft_step, output_name):
     for i in range(natom):
         pos = structure.forces[i]
         string += '{} {} {} {}\n'.format(
-            structure.species[i], pos[0], pos[1], pos[2])
+            structure.species_labels[i], pos[0], pos[1], pos[2])
 
     write_to_output(string, output_name+"_forces.xyz")
 

--- a/flare/output.py
+++ b/flare/output.py
@@ -12,7 +12,7 @@ class Output():
     :param basename
     """
 
-    def __init__(self, basename: str='otf_run'):
+    def __init__(self, basename: str = 'otf_run'):
         """
         open files with the basename and different suffices.
         """
@@ -48,7 +48,7 @@ class Output():
         else:
             self.outfiles[filetype] = open(filename, "w+")
 
-    def write_to_log(self, logstring: str, name: str="log"):
+    def write_to_log(self, logstring: str, name: str = "log"):
         """
         Write any string to logfile
         """

--- a/flare/output.py
+++ b/flare/output.py
@@ -18,9 +18,9 @@ class Output():
         """
         self.basename = "{}".format(basename)
         self.outfiles = {}
-        filesuffix = {'log': '.out', 'xyz': '.xyz', 'fxyz': '-f.xyz'}
+        filesuffix = {'log': '.out', 'xyz': '.xyz', 'fxyz': '-f.xyz', 'hyps':"-hyps.dat"}
 
-        for filetype in ['log', 'xyz', 'fxyz']:
+        for filetype in filesuffix.keys():
             self.open_new_log(filetype, filesuffix[filetype])
 
     def conclude_run(self):

--- a/flare/output.py
+++ b/flare/output.py
@@ -189,11 +189,9 @@ class Output():
     def write_xyz_config(self, curr_step, structure, dft_step):
         """
         write atomic configuration in xyz file
-        :param hyp_labels:
-        :param hyps:
-        :param start_time:
-        :param like:
-        :param like_grad:
+        :param curr_step: Int, number of frames to note in the comment line
+        :param structure: Structure, contain positions and forces
+        :param dft_step:  Boolean, whether this is a DFT call.
         :return:
         """
 

--- a/flare/output.py
+++ b/flare/output.py
@@ -131,8 +131,6 @@ class Output():
         :param velocities:
         :return:
         """
-        :return:
-        """
 
         string = ''
 

--- a/flare/output.py
+++ b/flare/output.py
@@ -8,15 +8,14 @@ outfiles = {}
 def close_files():
     for (k, v) in outfiles.items():
         v.close()
-        del outfiles[k]
 
 def find_files(output_name: str = 'otf_run.out'):
     if (output_name in outfiles.keys()):
-        f = outfiles[output_name]
+        if outfiles[output_name].closed:
+           outfiles[output_name] = open(output_name, 'w', 1)
     else:
         outfiles[output_name] = open(output_name, 'w', 1)
-        f = outfiles[output_name]
-    return f
+    return outfiles[output_name]
 
 
 def write_to_output(string: str, output_file: str = 'otf_run.out'):

--- a/flare/qe_util.py
+++ b/flare/qe_util.py
@@ -9,7 +9,7 @@ from typing import List
 def run_espresso(qe_input, structure, pw_loc):
     run_qe_path = qe_input
     edit_qe_input_positions(run_qe_path, structure)
-    qe_command = 'mpirun {0} < {1} > {2}'.format(pw_loc, run_qe_path,
+    qe_command = '{0} < {1} > {2}'.format(pw_loc, run_qe_path,
                                                  'pwscf.out')
     # os.system(qe_command)
     call(qe_command, shell=True)
@@ -24,6 +24,8 @@ def run_espresso_par(qe_input, structure, pw_loc, no_cpus):
         'mpirun -np {0} {1} < {2} > {3}'.format(no_cpus, pw_loc, run_qe_path,
                                                 'pwscf.out')
 
+    with open("alog", "a+") as fout:
+        print(qe_command, file=fout)
     # os.system(qe_command)
     call(qe_command, shell=True)
 

--- a/tests/test_OTF.py
+++ b/tests/test_OTF.py
@@ -56,7 +56,7 @@ def test_otf_h2():
     otf = OTF(qe_input, dt, number_of_steps, gp, pw_loc,
               std_tolerance_factor, init_atoms=[0],
               calculate_energy=True, max_atoms_added=1,
-              output_name='h2_otf.out')
+              output_name='h2_otf')
 
     otf.run()
     os.system('mkdir test_outputs')
@@ -98,7 +98,7 @@ def test_otf_al():
 
     otf = OTF(qe_input, dt, number_of_steps, gp, pw_loc,
               std_tolerance_factor, init_atoms=[0],
-              calculate_energy=True, output_name='al_otf.out',
+              calculate_energy=True, output_name='al_otf',
               freeze_hyps=freeze_hyps, skip=5,
               max_atoms_added=max_atoms_added)
 

--- a/tests/test_gp_from_aimd.py
+++ b/tests/test_gp_from_aimd.py
@@ -67,6 +67,8 @@ def test_load_trained_gp_and_run(methanol_gp):
 
     tt.run()
     os.system('rm ./gp_from_aimd.out')
+    os.system('rm ./gp_from_aimd.xyz')
+    os.system('rm ./gp_from_aimd-f.xyz')
 
 
 def test_load_one_frame_and_run():
@@ -91,6 +93,8 @@ def test_load_one_frame_and_run():
 
     tt.run()
     os.system('rm ./gp_from_aimd.out')
+    os.system('rm ./gp_from_aimd.xyz')
+    os.system('rm ./gp_from_aimd-f.xyz')
 
 
 def test_seed_and_run():
@@ -126,6 +130,8 @@ def test_seed_and_run():
         tt.run()
 
         os.system('rm ./gp_from_aimd.out')
+        os.system('rm ./gp_from_aimd.xyz')
+        os.system('rm ./gp_from_aimd-f.xyz')
         os.system('rm ./test_methanol_gp.pickle')
 
 


### PR DESCRIPTION
A new class Output is set to replace the original output module. The class opens a log file and two xyz files at the init function and closes all files in conclude_run() function. All the original functions in the output module now become function members in the Output class, with the same arguments.
new class for output and write atomic configurations to xyz files
The new class avoid open/close the log file too often and also automatically back up the old log file if it exists before the current run starts.

write_xyz_config(...) function is also added to print configs in xyz format. It is called in the record_state function in otf.py and md_run.py.

Completely:
- issue #36 