### PR TITLE
Shorten/fix gp aimd test

### DIFF
--- a/tests/test_gp_from_aimd.py
+++ b/tests/test_gp_from_aimd.py
@@ -85,7 +85,7 @@ def test_load_one_frame_and_run():
     tt = TrajectoryTrainer(frames,
                            gp=the_gp, shuffle_frames=True,
                            rel_std_tolerance=0,
-                           abs_std_tolerance=1,
+                           abs_std_tolerance=0,
                            skip=15)
 
     tt.run()

--- a/tests/test_gp_from_aimd.py
+++ b/tests/test_gp_from_aimd.py
@@ -68,7 +68,6 @@ def test_load_trained_gp_and_run(methanol_gp):
     tt.run()
     os.system('rm ./gp_from_aimd.out')
 
-
 def test_load_one_frame_and_run():
     the_gp = GaussianProcess(kernel=two_plus_three_body_mc,
                              kernel_grad=two_plus_three_body_mc_grad,
@@ -85,8 +84,8 @@ def test_load_one_frame_and_run():
 
     tt = TrajectoryTrainer(frames,
                            gp=the_gp, shuffle_frames=True,
-                           rel_std_tolerance=1,
-                           abs_std_tolerance=.01,
+                           rel_std_tolerance=0,
+                           abs_std_tolerance=1,
                            skip=15)
 
     tt.run()


### PR DESCRIPTION
Fixes #43 : Will no longer attempt to train the GP while testing the TrajectoryTrainer, will just run it with a data set and pre-set hyper parameters.

I can open a new issue to tighten up the unit tests, but this should solve the issue of it hanging / failing on other people's computers.

Tagging @jonpvandermause just to get one more pair of eyes on it and to pull the trigger (Amazon rules, I think, make sense here). 

I tried a clean install of this branch on odyssey and the test_gp_from_aimd worked for me in 8 seconds total (for all 5 tests).