### PR TITLE
Quick fix to suppress pymatgen warnings

### DIFF
--- a/tests/test_flare_io.py
+++ b/tests/test_flare_io.py
@@ -6,6 +6,9 @@ from flare.struc import Structure, get_unique_species
 from flare.dft_interface.vasp_util import md_trajectory_from_vasprun
 from flare.flare_io import md_trajectory_to_file, md_trajectory_from_file
 
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning",\
+    "ignore::pymatgen.io.vasp.outputs.UnconvergedVASPWarning")
+
 def test_read_write_trajectory():
     structures = md_trajectory_from_vasprun('test_files/test_vasprun.xml')
     fname = 'tst_traj.json'

--- a/tests/test_vasp_util.py
+++ b/tests/test_vasp_util.py
@@ -3,7 +3,7 @@ import os
 import sys
 import numpy as np
 from pymatgen.io.vasp.inputs import Poscar
-from pymatgen.io.vasp.outputs import Vasprun, UnconvergedVASPWarning
+from pymatgen.io.vasp.outputs import Vasprun
 from flare.struc import Structure, get_unique_species
 from flare.dft_interface.vasp_util import parse_dft_forces, run_dft, \
     edit_dft_input_positions, dft_input_to_structure,\

--- a/tests/test_vasp_util.py
+++ b/tests/test_vasp_util.py
@@ -3,12 +3,15 @@ import os
 import sys
 import numpy as np
 from pymatgen.io.vasp.inputs import Poscar
-from pymatgen.io.vasp.outputs import Vasprun
+from pymatgen.io.vasp.outputs import Vasprun, UnconvergedVASPWarning
 from flare.struc import Structure, get_unique_species
 from flare.dft_interface.vasp_util import parse_dft_forces, run_dft, \
     edit_dft_input_positions, dft_input_to_structure,\
     parse_dft_forces_and_energy, md_trajectory_from_vasprun,\
     check_vasprun
+
+pytestmark = pytest.mark.filterwarnings("ignore::UserWarning",\
+    "ignore::pymatgen.io.vasp.outputs.UnconvergedVASPWarning")
 
 def cleanup_vasp_run(target: str = None):
     os.system('rm POSCAR')


### PR DESCRIPTION
The test_vasprun.xml is small and unconverged so it produces a warning. I suppressed this warning along with one that warns about a missing POTCAR file.