### PR TITLE
Reducing memory footprint of GP to assist in parallelizations

### DIFF
--- a/flare/gp.py
+++ b/flare/gp.py
@@ -84,6 +84,9 @@ class GaussianProcess:
             self.training_labels.append(forces_curr)
 
         # create numpy array of training labels
+
+        self.training_labels_np = np.array(self.training_labels).flatten()
+
         self.training_labels_np = self.force_list_to_np(self.training_labels)
 
     def add_one_env(self, env: AtomicEnvironment,

--- a/flare/gp_from_aimd.py
+++ b/flare/gp_from_aimd.py
@@ -37,7 +37,7 @@ class TrajectoryTrainer(object):
                  pre_train_max_iter: int = 50,
                  max_atoms_from_frame: int = np.inf, max_trains: int = np.inf,
                  min_atoms_added: int = 1, shuffle_frames: bool = False,
-                 verbose: int = 0, model_write: str = '',
+                 verbose: int = 0,
                  pre_train_on_skips: int = -1,
                  pre_train_seed_frames: List[Structure] = None,
                  pre_train_seed_envs: List[Tuple[AtomicEnvironment,
@@ -69,7 +69,6 @@ class TrajectoryTrainer(object):
         :param n_cpus: Number of CPUs to parallelize over
         :param shuffle_frames: Randomize order of frames for better training
         :param verbose: 0: Silent, 1: Minimal, 2: Lots of information
-        :param model_write: Where to write output model
         :param pre_train_on_skips: Train model on every n frames before running
         :param pre_train_seed_frames: Frames to train on before running
         :param pre_train_seed_envs: Environments to train on before running
@@ -140,7 +139,6 @@ class TrajectoryTrainer(object):
 
         # Output parameters
         self.checkpoint_interval = checkpoint_interval
-        self.model_write = model_write
         self.model_format = model_format
 
     def pre_run(self):
@@ -301,8 +299,8 @@ class TrajectoryTrainer(object):
 
         self.output.conclude_run()
 
-        if self.model_write:
-            self.gp.write_model(self.model_write, self.model_format)
+        if self.model_format:
+            self.gp.write_model(self.output_name+'_model', self.model_format)
 
     def update_gp_and_print(self, frame: Structure, train_atoms: List[int],
                             train: bool = True):
@@ -357,5 +355,5 @@ class TrajectoryTrainer(object):
 
         if self.checkpoint_interval \
                 and self.train_count % self.checkpoint_interval == 0 \
-                and self.model_write:
-            self.gp.write_model(self.model_write, self.model_format)
+                and self.model_format:
+            self.gp.write_model(self.model_output+'_model', self.model_format)

--- a/flare/output.py
+++ b/flare/output.py
@@ -220,7 +220,8 @@ class Output():
         if self.always_flush:
             self.outfiles['log'].flush()
 
-    def write_xyz(self, curr_step, pos, species, filename, header=""):
+    def write_xyz(self, curr_step, pos, species, filename, header="",
+                  forces=None, stds=None, true_fs=None):
         """
         write atomic configuration in xyz file
         :param curr_step: Int, number of frames to note in the comment line
@@ -228,6 +229,9 @@ class Output():
         :param species:   n element list of symbols
         :param filename:  file to print
         :param header:    header printed in comments
+        :param forces: list of forces on atoms predicted by GP
+        :param stds: uncertainties predicted by GP
+        :param true_fs: true forces from ab initio source
         :return:
         """
 
@@ -241,8 +245,19 @@ class Output():
         # Construct atom-by-atom description
         for i in range(natom):
             string += f'{species[i]} '
-            string += f'{pos[i, 0]} {pos[i, 1]} {pos[i, 2]}\n'
+            string += f'{pos[i, 0]:10.3} {pos[i, 1]:10.3} {pos[i, 2]:10.3}'
 
+            if forces and stds and true_fs:
+
+                string += f' {forces[i, 0]:10.3} {forces[i, 1]:10.3} ' \
+                          f'{forces[i, 2]:10.3}'
+                string += f' {stds[i, 0]:10.3} {stds[i, 1]:10.3} ' \
+                          f'{stds[i, 2]:10.3}'
+                string += f' {true_fs[i, 0]:10.3} {true_fs[i,1]:10.3} ' \
+                          f'{true_fs[i, 2]:10.3}\n'
+
+            else:
+                string += '\n'
         self.outfiles[filename].write(string)
 
         if self.always_flush:


### PR DESCRIPTION
Lixin and I have been brainstorming ways to reduce the memory footprint of the GP models so as to reduce overhead when passing the GP for parallel implementation. This PR reflects ways to bring it down without impeding function of the GP.