### PR TITLE
Bugfix: OTF ignores structure species, when using pre-trained GP

### DIFF
--- a/flare/otf.py
+++ b/flare/otf.py
@@ -103,9 +103,8 @@ class OTF:
         positions, species, cell, masses = \
             self.dft_module.parse_dft_input(self.dft_input)
 
-        _, coded_species = struc.get_unique_species(species)
 
-        self.structure = struc.Structure(cell=cell, species=coded_species,
+        self.structure = struc.Structure(cell=cell, species=species,
                                          positions=positions,
                                          mass_dict=masses,
                                          prev_positions=prev_pos_init,


### PR DESCRIPTION
If you use a previously trained GP, which kept track of species by their atomic number (for instance, hydrogen as 1 and oxygen as 8), and then wanted to run an OTF run on it, the OTF engine by default encodes the species into integers: so, if hydrogen came first, it would be designated as 0, and if oxygen second, it would be designated as 1. This would cause the model to think oxygen was hydrogen and hydrogen was something it had never seen before. (This example is not hypothetical-- I caught this bug trying to use a previously existing GP to power an OTF run).

 I'm pretty sure that this line is a holdover from before we changed over to species-as-integers, which is now built into struc anyway by assigning elements to their atomic numbers.