### PR TITLE
Added from_file convenience method to GP

### DIFF
--- a/flare/gp.py
+++ b/flare/gp.py
@@ -502,3 +502,27 @@ class GaussianProcess:
         else:
             raise ValueError("Output format not supported: try from "
                              "{}".format(supported_formats))
+
+    @staticmethod
+    def from_file(filename: str, format: str=''):
+        """
+        One-line convenience method to load a GP from a file stored using
+        write_file
+
+        Args:
+            filename (str): path to GP model
+            format (str): json or pickle if format is not in filename
+        :return:
+        """
+
+        if '.json' in filename or 'json' in format:
+            with open(filename, 'r') as f:
+                return GaussianProcess.from_dict(json.loads(f.readline()))
+
+        elif '.pickle' in filename or 'pickle' in format:
+            with open(filename, 'rb') as f:
+                return pickle.load(f)
+
+        else:
+            raise ValueError("Warning: Format unspecified or file is not "
+                             ".json or .pickle format.")

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -269,8 +269,7 @@ def test_load_and_reload(two_body_gp, test_point):
 
     two_body_gp.write_model('two_body.pickle', 'pickle')
 
-    with open('two_body.pickle', 'rb') as f:
-        new_gp = pickle.load(f)
+    new_gp = GaussianProcess.from_file('two_body.pickle')
 
     for d in [0, 1, 2]:
         assert np.all(two_body_gp.predict(x_t=test_point, d=d) ==
@@ -278,8 +277,7 @@ def test_load_and_reload(two_body_gp, test_point):
     os.remove('two_body.pickle')
 
     two_body_gp.write_model('two_body.json')
-    with open('two_body.json', 'r') as f:
-        new_gp = GaussianProcess.from_dict(json.loads(f.readline()))
+    new_gp = GaussianProcess.from_file('two_body.json')
     for d in [0, 1, 2]:
         assert np.all(two_body_gp.predict(x_t=test_point, d=d) ==
                       new_gp.predict(x_t=test_point, d=d))
@@ -287,5 +285,9 @@ def test_load_and_reload(two_body_gp, test_point):
 
     with raises(ValueError):
         two_body_gp.write_model('two_body.pickle', 'cucumber')
+
+    with raises(ValueError):
+        two_body_gp.from_file('WRONG_FILENAME')
+
 
 


### PR DESCRIPTION
New method which helps make loading a GP from a file a one-liner (it previously was a two-liner for json loading). These things help to reduce the friction of using FLARE.
This is also now integrated into the unit testing suite.
Now it's:
`gp = GaussianProcess.from_file('my_model.json')`