### PR TITLE
Add setuptools_scm as setup_requires dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/mir-group/flare",
     python_requires=">=3.6",
+    setup_requires="setuptools_scm",
     install_requires=dependencies,
     license="MIT",
     classifiers=[


### PR DESCRIPTION
This causes anything under version control (particularly requirements.txt) to be included in sdists and wheels and should therefore make the package installable from PyPI again (cf. #134) the next time it gets published.