### PR TITLE
give the option to print hyperparameters to console

### DIFF
--- a/flare/gp.py
+++ b/flare/gp.py
@@ -139,7 +139,8 @@ class GaussianProcess:
     def train(self, output=None, custom_bounds=None,
               grad_tol: float = 1e-4,
               x_tol: float = 1e-5,
-              line_steps: int = 20):
+              line_steps: int = 20,
+              print_progress: bool = False):
         """Train Gaussian Process model on training data. Tunes the
         hyperparameters to maximize the likelihood, then computes L and alpha
         (related to the covariance matrix of the training set).
@@ -160,7 +161,7 @@ class GaussianProcess:
 
         args = (self.training_data, self.training_labels_np,
                 self.kernel_grad, self.cutoffs, output,
-                self.no_cpus)
+                self.no_cpus, print_progress)
         res = None
 
         if self.algo == 'L-BFGS-B':

--- a/flare/gp_algebra.py
+++ b/flare/gp_algebra.py
@@ -174,6 +174,7 @@ def get_ky_and_hyp(hyps: np.ndarray, training_data: list,
 
     return hyp_mat, ky_mat
 
+
 def get_ky_mat_par(hyps: np.ndarray, training_data: list,
                    kernel, cutoffs=None, ncpus:int =None):
     """
@@ -438,7 +439,7 @@ def get_like_grad_from_mats(ky_mat, hyp_mat, training_labels_np):
 
 def get_neg_likelihood(hyps, training_data: list,
                        training_labels_np,
-                       kernel, cutoffs=None, output = None,
+                       kernel, cutoffs=None, output=None,
                        ncpus=1):
     """compute the negative log likelihood
 
@@ -474,7 +475,7 @@ def get_neg_likelihood(hyps, training_data: list,
 def get_neg_like_grad(hyps, training_data: list,
                       training_labels_np: np.ndarray,
                       kernel_grad, cutoffs=None,
-                      output = None, ncpus=1):
+                      output=None, ncpus=1, print_progress=False):
     """compute the log likelihood and its gradients
 
     :param hyps: list of hyper-parameters
@@ -503,5 +504,10 @@ def get_neg_like_grad(hyps, training_data: list,
 
     if output is not None:
         output.write_hyps(None, hyps, None, like, like_grad, name="hyps")
+
+    if print_progress:
+        print('\nhyperparameters: '+str(hyps))
+        print('likelihood: ' + str(like))
+        print('likelihood gradient: ' + str(like_grad))
 
     return -like, -like_grad


### PR DESCRIPTION
Closes #147 

Gives the option to print hyperparameters, likelihood, and likelihood gradient during hyperparameter optimization. Defaults to false.