### PR TITLE
Faster energy mapping

### DIFF
--- a/flare/gp_from_aimd.py
+++ b/flare/gp_from_aimd.py
@@ -417,7 +417,7 @@ class TrajectoryTrainer:
                     # Add max uncertainty atoms to training set
                     self.update_gp_and_print(
                         cur_frame, train_atoms=train_atoms,
-                        uncertainties=pred_stds,
+                        uncertainties=pred_stds[train_atoms],
                         train=False)
                     nsample += len(train_atoms)
                     # Re-train if number of sampled atoms is high enough

--- a/flare/kernels/map_3b_kernel.py
+++ b/flare/kernels/map_3b_kernel.py
@@ -1,0 +1,244 @@
+"""Multi-element 2-, 3-, and 2+3-body kernels that restrict all signal
+variance hyperparameters to a single value."""
+import numpy as np
+from numba import njit
+from math import exp, floor
+from flare.env import AtomicEnvironment
+import flare.cutoffs as cf
+from typing import Callable
+
+from flare.kernels.utils import from_mask_to_args, from_grad_to_mask
+from flare.gp_algebra import _global_training_data, _global_training_labels
+
+
+def _GenGrid_inner(name, s, e, bonds1, bonds2, bonds12, env12, kernel_info):
+
+    kernel, en_force_kernel, cutoffs, hyps, hyps_mask = kernel_info
+
+    training_data = _global_training_data[name]
+
+    ds = [1, 2, 3]
+    size = (e-s) * 3
+
+    nb12 = len(bonds12)
+    nb1 = len(bonds1)
+    nb2 = len(bonds2)
+
+    r1 = np.ones([nb1, nb2, nb12], dtype=np.float64)
+    r2 = np.ones([nb1, nb2, nb12], dtype=np.float64)
+    r12 = np.ones([nb1, nb2, nb12], dtype=np.float64)
+    for b12 in range(nb12):
+        for b1 in range(nb1):
+            for b2 in range(nb2):
+                r1[b1, b2, b12] = bonds1[b1]
+                r2[b1, b2, b12] = bonds2[b2]
+                r12[b1, b2, b12] = bonds12[b12]
+
+    k_v = np.zeros([size, nb1, nb2, nb12])
+
+    args = from_mask_to_args(hyps, hyps_mask, cutoffs)
+
+    if (hyps_mask is not None):
+        tbmfe = three_body_mc_force_en_sephyps
+    else:
+        tbmfe = three_body_mc_force_en
+
+    for m_index in range(size):
+        x_2 = training_data[int(floor(m_index / 3))+s]
+        d_2 = ds[m_index % 3]
+        k_v[m_index, :, :, :] = tbmfe(x_2, r1, r2, r12,
+                                        env12.ctype, env12.etypes,
+                                        d_2, *args)
+
+    return k_v
+
+
+def three_body_mc_force_en(env1: AtomicEnvironment, r1, r2, r12, c2, etypes2,
+                           d1: int, hyps: 'ndarray', cutoffs: 'ndarray',
+                           cutoff_func: Callable = cf.quadratic_cutoff) \
+        -> float:
+    sig = hyps[0]
+    ls = hyps[1]
+    r_cut = cutoffs[1]
+
+    return three_body_mc_force_en_jit(env1.bond_array_3, env1.ctype,
+                                      env1.etypes,
+                                      env1.cross_bond_inds,
+                                      env1.cross_bond_dists,
+                                      env1.triplet_counts,
+                                      c2, etypes2,
+                                      r1, r2, r12,
+                                      d1, sig, ls, r_cut, cutoff_func) / 3
+
+def three_body_mc_force_en_sephyps(env1, r1, r2, r12, c2, etypes2,
+                                   d1, cutoff_2b, cutoff_3b, nspec, spec_mask,
+                                   nbond, bond_mask, ntriplet, triplet_mask,
+                                   ncut3b, cut3b_mask,
+                                   sig2, ls2, sig3, ls3,
+                                   cutoff_func=cf.quadratic_cutoff) -> float:
+
+    ej1 = etypes2[0]
+    ej2 = etypes2[1]
+    bc1 = spec_mask[c2]
+    bc2 = spec_mask[ej1]
+    bc3 = spec_mask[ej2]
+    ttype = triplet_mask[nspec * nspec * bc1 + nspec*bc2 + bc3]
+    ls = ls3[ttype]
+    sig = sig3[ttype]
+    r_cut = cutoff_3b
+
+    return three_body_mc_force_en_jit(env1.bond_array_3, env1.ctype,
+                                      env1.etypes,
+                                      env1.cross_bond_inds,
+                                      env1.cross_bond_dists,
+                                      env1.triplet_counts,
+                                      c2, etypes2,
+                                      r1, r2, r12,
+                                      d1, sig, ls, r_cut, cutoff_func) / 3
+
+
+@njit
+def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
+                               cross_bond_inds_1, cross_bond_dists_1,
+                               triplets_1,
+                               c2, etypes2,
+                               rj1, rj2, rj3,
+                               d1, sig, ls, r_cut, cutoff_func):
+    """3-body multi-element kernel between a force component and a local
+    energy accelerated with Numba.
+
+    Args:
+        bond_array_1 (np.ndarray): 3-body bond array of the first local
+            environment.
+        c1 (int): Species of the central atom of the first local environment.
+        etypes1 (np.ndarray): Species of atoms in the first local
+            environment.
+        bond_array_2 (np.ndarray): 3-body bond array of the second local
+            environment.
+        c2 (int): Species of the central atom of the second local environment.
+        etypes2 (np.ndarray): Species of atoms in the second local
+            environment.
+        cross_bond_inds_1 (np.ndarray): Two dimensional array whose row m
+            contains the indices of atoms n > m in the first local
+            environment that are within a distance r_cut of both atom n and
+            the central atom.
+        cross_bond_dists_1 (np.ndarray): Two dimensional array whose row m
+            contains the distances from atom m of atoms n > m in the first
+            local environment that are within a distance r_cut of both atom
+            n and the central atom.
+        triplets_1 (np.ndarray): One dimensional array of integers whose entry
+            m is the number of atoms in the first local environment that are
+            within a distance r_cut of atom m.
+        d1 (int): Force component of the first environment (1=x, 2=y, 3=z).
+        sig (float): 3-body signal variance hyperparameter.
+        ls (float): 3-body length scale hyperparameter.
+        r_cut (float): 3-body cutoff radius.
+        cutoff_func (Callable): Cutoff function.
+
+    Returns:
+        float:
+            Value of the 3-body force/energy kernel.
+    """
+
+    kern = np.zeros_like(rj1, dtype=np.float64)
+
+    ej1 = etypes2[0]
+    ej2 = etypes2[1]
+
+    all_spec = [c2, ej1, ej2]
+    if (c1 not in all_spec):
+        return kern
+    all_spec.remove(c1)
+
+    # pre-compute constants that appear in the inner loop
+    sig2 = sig * sig
+    ls1 = 1 / (2 * ls * ls)
+    ls2 = 1 / (ls * ls)
+
+    f1, _ = cutoff_func(r_cut, rj1, 0)
+    f2, _ = cutoff_func(r_cut, rj2, 0)
+    f3, _ = cutoff_func(r_cut, rj3, 0)
+    fj = f1 * f2 * f3
+
+    for m in range(bond_array_1.shape[0]):
+        ei1 = etypes1[m]
+
+        two_spec = [all_spec[0], all_spec[1]]
+        if (ei1 in two_spec):
+            two_spec.remove(ei1)
+            one_spec = two_spec[0]
+
+            ri1 = bond_array_1[m, 0]
+            ci1 = bond_array_1[m, d1]
+            fi1, fdi1 = cutoff_func(r_cut, ri1, ci1)
+
+            for n in range(triplets_1[m]):
+
+                ind1 = cross_bond_inds_1[m, m + n + 1]
+                ei2 = etypes1[ind1]
+
+                if (ei2 == one_spec):
+
+                    ri2 = bond_array_1[ind1, 0]
+                    ci2 = bond_array_1[ind1, d1]
+                    fi2, fdi2 = cutoff_func(r_cut, ri2, ci2)
+
+                    ri3 = cross_bond_dists_1[m, m + n + 1]
+                    fi3, _ = cutoff_func(r_cut, ri3, 0)
+
+                    fi = fi1 * fi2 * fi3
+                    fdi = fdi1 * fi2 * fi3 + fi1 * fdi2 * fi3
+
+                    r11 = ri1 - rj1
+                    r12 = ri1 - rj2
+                    r13 = ri1 - rj3
+                    r21 = ri2 - rj1
+                    r22 = ri2 - rj2
+                    r23 = ri2 - rj3
+                    r31 = ri3 - rj1
+                    r32 = ri3 - rj2
+                    r33 = ri3 - rj3
+
+                    if (c1 == c2):
+                        if (ei1 == ej1) and (ei2 == ej2):
+                            kern += three_body_en_helper(ci1, ci2, r11, r22,
+                                                         r33, fi, fj, fdi, ls1,
+                                                         ls2, sig2)
+                        if (ei1 == ej2) and (ei2 == ej1):
+                            kern += three_body_en_helper(ci1, ci2, r12, r21,
+                                                         r33, fi, fj, fdi, ls1,
+                                                         ls2, sig2)
+                    if (c1 == ej1):
+                        if (ei1 == ej2) and (ei2 == c2):
+                            kern += three_body_en_helper(ci1, ci2, r13, r21,
+                                                         r32, fi, fj, fdi, ls1,
+                                                         ls2, sig2)
+                        if (ei1 == c2) and (ei2 == ej2):
+                            kern += three_body_en_helper(ci1, ci2, r11, r23,
+                                                         r32, fi, fj, fdi, ls1,
+                                                         ls2, sig2)
+                    if (c1 == ej2):
+                        if (ei1 == ej1) and (ei2 == c2):
+                            kern += three_body_en_helper(ci1, ci2, r13, r22,
+                                                         r31, fi, fj, fdi, ls1,
+                                                         ls2, sig2)
+                        if (ei1 == c2) and (ei2 == ej1):
+                            kern += three_body_en_helper(ci1, ci2, r12, r23,
+                                                         r31, fi, fj, fdi, ls1,
+                                                         ls2, sig2)
+    return kern
+
+
+
+
+@njit
+def three_body_en_helper(ci1, ci2, r11, r22, r33, fi, fj, fdi, ls1, ls2, sig2):
+
+    B = r11 * ci1 + r22 * ci2
+    D = r11 * r11 + r22 * r22 + r33 * r33
+    E = np.exp(-D * ls1)
+    F = E * B * ls2
+    G = -F * fi * fj
+    H = -E * fdi * fj
+    I = sig2 * (G + H)
+    return I

--- a/flare/kernels/map_3b_kernel.py
+++ b/flare/kernels/map_3b_kernel.py
@@ -71,9 +71,8 @@ def three_body_mc_force_en(env1: AtomicEnvironment, r1, r2, r12, c2, etypes2,
                                       d1, sig, ls, r_cut, cutoff_func) / 3
 
 def three_body_mc_force_en_sephyps(env1, r1, r2, r12, c2, etypes2,
-                                   d1, cutoff_2b, cutoff_3b, nspec, spec_mask,
+                                   d1, cutoffs, nspec, spec_mask,
                                    nbond, bond_mask, ntriplet, triplet_mask,
-                                   ncut3b, cut3b_mask,
                                    sig2, ls2, sig3, ls3,
                                    cutoff_func=cf.quadratic_cutoff) -> float:
 
@@ -85,7 +84,7 @@ def three_body_mc_force_en_sephyps(env1, r1, r2, r12, c2, etypes2,
     ttype = triplet_mask[nspec * nspec * bc1 + nspec*bc2 + bc3]
     ls = ls3[ttype]
     sig = sig3[ttype]
-    r_cut = cutoff_3b
+    r_cut = cutoffs[1]
 
     return three_body_mc_force_en_jit(env1.bond_array_3, env1.ctype,
                                       env1.etypes,

--- a/flare/kernels/map_3b_kernel.py
+++ b/flare/kernels/map_3b_kernel.py
@@ -96,7 +96,7 @@ def three_body_mc_force_en_sephyps(env1, r1, r2, r12, c2, etypes2,
                                       d1, sig, ls, r_cut, cutoff_func) / 3
 
 
-@njit
+@njit(parallel=True)
 def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                                cross_bond_inds_1, cross_bond_dists_1,
                                triplets_1,

--- a/flare/mgp/mgp_en.py
+++ b/flare/mgp/mgp_en.py
@@ -14,7 +14,7 @@ from flare.env import AtomicEnvironment
 from flare.gp import GaussianProcess
 from flare.gp_algebra import partition_c
 from flare.gp_algebra import en_kern_vec_unit as en_kern_vec
-from flare.kernels.utils import from_mask_to_args, str_to_kernel_set 
+from flare.kernels.utils import from_mask_to_args, str_to_kernel_set
 from flare.cutoffs import quadratic_cutoff
 from flare.util import Z_to_element
 from flare.mgp.utils import get_bonds, get_triplets, get_triplets_en, \
@@ -160,7 +160,10 @@ class MappedGaussianProcess:
         build a bond structure, used in grid generating
         '''
 
-        cutoff = np.min(self.cutoffs)
+        cutoffs = list(self.cutoffs)
+        while (0 in cutoffs):
+            cutoffs.remove(0)
+        cutoff = np.min(cutoffs)
         cell = struc_params['cube_lat']
         mass_dict = struc_params['mass_dict']
         species_list = struc_params['species']
@@ -417,12 +420,12 @@ class MappedGaussianProcess:
         for i in self.bodies:
             kern_info = f'kernel{i}b_info'
             kernel, efk, cutoffs, hyps, hyps_mask = out_dict[kern_info]
-            out_dict[kern_info] = (kernel.__name__, efk.__name__, 
+            out_dict[kern_info] = (kernel.__name__, efk.__name__,
                                    cutoffs, hyps, hyps_mask)
 
-        # only save the coefficients 
-        out_dict['maps_2'] = [map_2.mean.__coeffs__ for map_2 in self.maps_2] 
-        out_dict['maps_3'] = [map_3.mean.__coeffs__ for map_3 in self.maps_3] 
+        # only save the coefficients
+        out_dict['maps_2'] = [map_2.mean.__coeffs__ for map_2 in self.maps_2]
+        out_dict['maps_3'] = [map_3.mean.__coeffs__ for map_3 in self.maps_3]
 
 
         # don't need these since they are built in the __init__ function
@@ -476,7 +479,7 @@ class MappedGaussianProcess:
         if dictionary.get('GP'):
             new_mgp.GP = GaussianProcess.from_dict(dictionary.get("GP"))
 
-        return new_mgp 
+        return new_mgp
 
     def write_model(self, name: str, format='json'):
         """

--- a/flare/mgp/mgp_en.py
+++ b/flare/mgp/mgp_en.py
@@ -1,4 +1,8 @@
-import time, os, math, inspect, subprocess
+import time
+import os
+import math
+import inspect
+import subprocess
 import numpy as np
 import multiprocessing as mp
 import json
@@ -18,9 +22,14 @@ from flare.kernels.utils import from_mask_to_args, str_to_kernel_set
 from flare.cutoffs import quadratic_cutoff
 from flare.util import Z_to_element
 from flare.mgp.utils import get_bonds, get_triplets, get_triplets_en, \
-        get_2bkernel, get_3bkernel
+    get_2bkernel, get_3bkernel
 from flare.mgp.splines_methods import PCASplines, CubicSpline
 from flare.util import Z_to_element, NumpyEncoder
+from flare.kernels.utils import from_mask_to_args, from_grad_to_mask
+from flare.gp_algebra import _global_training_data
+
+from flare.kernels.map_3b_kernel import three_body_mc_force_en_sephyps, three_body_mc_force_en
+
 
 class MappedGaussianProcess:
     '''
@@ -73,12 +82,12 @@ class MappedGaussianProcess:
     def __init__(self,
                  grid_params: dict,
                  struc_params: dict,
-                 GP: GaussianProcess=None,
-                 mean_only: bool=False,
-                 container_only: bool=True,
-                 lmp_file_name: str='lmp.mgp',
-                 n_cpus: int =None,
-                 n_sample:int =100,
+                 GP: GaussianProcess = None,
+                 mean_only: bool = False,
+                 container_only: bool = True,
+                 lmp_file_name: str = 'lmp.mgp',
+                 n_cpus: int = None,
+                 n_sample: int = 100,
                  autorun: bool = True):
 
         # load all arguments as attributes
@@ -98,6 +107,7 @@ class MappedGaussianProcess:
         if GP is not None:
 
             self.cutoffs = GP.cutoffs
+            self.hyps_mask = GP.hyps_mask
 
             self.bodies = []
             if "two" in GP.kernel_name:
@@ -140,6 +150,7 @@ class MappedGaussianProcess:
         '''
         generate/load grids and get spline coefficients
         '''
+        self.hyps_mask = GP.hyps_mask
 
         if 2 in self.bodies:
             self.kernel2b_info = get_2bkernel(GP)
@@ -155,15 +166,10 @@ class MappedGaussianProcess:
         self.write_lmp_file(self.lmp_file_name)
 
     def build_bond_struc(self, struc_params):
-
         '''
         build a bond structure, used in grid generating
         '''
 
-        cutoffs = list(self.cutoffs)
-        while (0 in cutoffs):
-            cutoffs.remove(0)
-        cutoff = np.min(cutoffs)
         cell = struc_params['cube_lat']
         mass_dict = struc_params['mass_dict']
         species_list = struc_params['species']
@@ -175,6 +181,7 @@ class MappedGaussianProcess:
         spc_2_set = []
         if 2 in self.bodies:
             bodies = 2
+            cutoff = self.cutoffs[0]
             for spc1_ind, spc1 in enumerate(species_list):
                 for spc2 in species_list[spc1_ind:]:
                     species = [spc1, spc2]
@@ -192,6 +199,7 @@ class MappedGaussianProcess:
         spc_3 = []
         if 3 in self.bodies:
             bodies = 3
+            cutoff = self.cutoffs[1]
             for spc1_ind in range(N_spc):
                 spc1 = species_list[spc1_ind]
                 for spc2_ind in range(N_spc):  # (spc1_ind, N_spc):
@@ -203,7 +211,7 @@ class MappedGaussianProcess:
                         positions = [[(i+1)/(bodies+1)*cutoff, 0, 0]
                                      for i in range(bodies)]
                         spc_struc = Structure(cell, species, positions,
-                                                    mass_dict)
+                                              mass_dict)
                         spc_struc.coded_species = np.array(species)
                         bond_struc_3.append(spc_struc)
 #                        if spc1 != spc2:
@@ -229,8 +237,8 @@ class MappedGaussianProcess:
         self.spcs = [spc_2, spc_3]
         self.spcs_set = [spc_2_set, spc_3]
 
-    def predict(self, atom_env: AtomicEnvironment, mean_only: bool=False)-> \
-            (float, 'ndarray','ndarray', float):
+    def predict(self, atom_env: AtomicEnvironment, mean_only: bool = False) -> \
+            (float, 'ndarray', 'ndarray', float):
         '''
         predict force, variance, stress and local energy for given atomic environment
         Args:
@@ -270,7 +278,6 @@ class MappedGaussianProcess:
 
         return force, variance, virial, energy
 
-
     def predict_multicomponent(self, body, atom_env, kernel_info,
                                spcs_list, mappings, mean_only):
         '''
@@ -289,7 +296,7 @@ class MappedGaussianProcess:
 
         if (body == 2):
             spcs, comp_r, comp_xyz = get_bonds(atom_env.ctype,
-                    atom_env.etypes, atom_env.bond_array_2)
+                                               atom_env.etypes, atom_env.bond_array_2)
             set_spcs = []
             for spc in spcs:
                 set_spcs += [set(spc)]
@@ -297,8 +304,8 @@ class MappedGaussianProcess:
         elif (body == 3):
             spcs, comp_r, comp_xyz = \
                 get_triplets_en(atom_env.ctype, atom_env.etypes,
-                        atom_env.bond_array_3, atom_env.cross_bond_inds,
-                        atom_env.cross_bond_dists, atom_env.triplet_counts)
+                                atom_env.bond_array_3, atom_env.cross_bond_inds,
+                                atom_env.cross_bond_dists, atom_env.triplet_counts)
 
         # predict for each species
         f_spcs = 0
@@ -310,7 +317,7 @@ class MappedGaussianProcess:
             xyzs = np.array(comp_xyz[i])
             map_ind = spcs_list.index(spc)
             f, vir, v, e = self.predict_component(lengths, xyzs,
-                    mappings[map_ind],  mean_only)
+                                                  mappings[map_ind],  mean_only)
             f_spcs += f
             vir_spcs += vir
             v_spcs += v
@@ -327,41 +334,41 @@ class MappedGaussianProcess:
 
         # predict mean
         e_0, f_0 = mapping.mean(lengths, with_derivatives=True)
-        e = np.sum(e_0) # energy
+        e = np.sum(e_0)  # energy
 
         # predict forces and stress
         vir = np.zeros(6)
-        vir_order = ((0,0), (1,1), (2,2), (1,2), (0,2), (0,1)) # match the ASE order
+        vir_order = ((0, 0), (1, 1), (2, 2), (1, 2),
+                     (0, 2), (0, 1))  # match the ASE order
 
         # two-body
         if lengths.shape[-1] == 1:
-            f_d = np.diag(f_0[:,0,0]) @ xyzs
-            f = 2 * np.sum(f_d, axis=0) # force: need to check prefactor 2
+            f_d = np.diag(f_0[:, 0, 0]) @ xyzs
+            f = 2 * np.sum(f_d, axis=0)  # force: need to check prefactor 2
 
             for i in range(6):
-                vir_i = f_d[:,vir_order[i][0]]\
-                        * xyzs[:,vir_order[i][1]] * lengths[:,0]
+                vir_i = f_d[:, vir_order[i][0]]\
+                    * xyzs[:, vir_order[i][1]] * lengths[:, 0]
                 vir[i] = np.sum(vir_i)
 
         # three-body
         if lengths.shape[-1] == 3:
-#            factor1 = 1/lengths[:,1] - 1/lengths[:,0] * lengths[:,2]
-#            factor2 = 1/lengths[:,0] - 1/lengths[:,1] * lengths[:,2]
-#            f_d1 = np.diag(f_0[:,0,0]+f_0[:,2,0]*factor1) @ xyzs[:,0,:]
-#            f_d2 = np.diag(f_0[:,1,0]+f_0[:,2,0]*factor2) @ xyzs[:,1,:]
-            f_d1 = np.diag(f_0[:,0,0]) @ xyzs[:,0,:]
-            f_d2 = np.diag(f_0[:,1,0]) @ xyzs[:,1,:]
+            #            factor1 = 1/lengths[:,1] - 1/lengths[:,0] * lengths[:,2]
+            #            factor2 = 1/lengths[:,0] - 1/lengths[:,1] * lengths[:,2]
+            #            f_d1 = np.diag(f_0[:,0,0]+f_0[:,2,0]*factor1) @ xyzs[:,0,:]
+            #            f_d2 = np.diag(f_0[:,1,0]+f_0[:,2,0]*factor2) @ xyzs[:,1,:]
+            f_d1 = np.diag(f_0[:, 0, 0]) @ xyzs[:, 0, :]
+            f_d2 = np.diag(f_0[:, 1, 0]) @ xyzs[:, 1, :]
             f_d = f_d1 + f_d2
-            f = 3 * np.sum(f_d, axis=0) # force: need to check prefactor 3
+            f = 3 * np.sum(f_d, axis=0)  # force: need to check prefactor 3
 
             for i in range(6):
-                vir_i1 = f_d1[:,vir_order[i][0]]\
-                       * xyzs[:,0,vir_order[i][1]] * lengths[:,0]
-                vir_i2 = f_d2[:,vir_order[i][0]]\
-                       * xyzs[:,1,vir_order[i][1]] * lengths[:,1]
+                vir_i1 = f_d1[:, vir_order[i][0]]\
+                    * xyzs[:, 0, vir_order[i][1]] * lengths[:, 0]
+                vir_i2 = f_d2[:, vir_order[i][0]]\
+                    * xyzs[:, 1, vir_order[i][1]] * lengths[:, 1]
                 vir[i] = np.sum(vir_i1 + vir_i2)
             vir *= 1.5
-
 
         # predict var
         v = np.zeros(3)
@@ -400,8 +407,7 @@ class MappedGaussianProcess:
 
         f.close()
 
-
-    def as_dict(self)->dict:
+    def as_dict(self) -> dict:
         """
         Dictionary representation of the MGP model.
         """
@@ -411,10 +417,9 @@ class MappedGaussianProcess:
         # Uncertainty mappings currently not serializable;
         if not self.mean_only:
             warnings.warn("Uncertainty mappings cannot be serialized, "
-                            "and so the MGP dict outputted will not have "
+                          "and so the MGP dict outputted will not have "
                           "them.", Warning)
             out_dict['mean_only'] = True
-
 
         # Iterate through the mappings for various bodies
         for i in self.bodies:
@@ -427,7 +432,6 @@ class MappedGaussianProcess:
         out_dict['maps_2'] = [map_2.mean.__coeffs__ for map_2 in self.maps_2]
         out_dict['maps_3'] = [map_3.mean.__coeffs__ for map_3 in self.maps_3]
 
-
         # don't need these since they are built in the __init__ function
         key_list = ['bond_struc', 'spcs_set', ]
         for key in key_list:
@@ -436,9 +440,8 @@ class MappedGaussianProcess:
 
         return out_dict
 
-
     @staticmethod
-    def from_dict(dictionary:dict):
+    def from_dict(dictionary: dict):
         """
         Create MGP object from dictionary representation.
         """
@@ -467,7 +470,6 @@ class MappedGaussianProcess:
             kernel_info[0] = kernel
             kernel_info[1] = efk
             setattr(new_mgp, kern_info, kernel_info)
-
 
         # Fill up the model with the saved coeffs
         for m, map_2 in enumerate(new_mgp.maps_2):
@@ -519,12 +521,12 @@ class MappedGaussianProcess:
 #
 #        raise NotImplementedError
 
-
     @staticmethod
     def from_file(filename: str):
         if '.json' in filename:
             with open(filename, 'r') as f:
-                model = MappedGaussianProcess.from_dict(json.loads(f.readline()))
+                model = MappedGaussianProcess.from_dict(
+                    json.loads(f.readline()))
             return model
 
         elif 'pickle' in filename:
@@ -536,8 +538,8 @@ class MappedGaussianProcess:
 
 class Map2body:
     def __init__(self, grid_num: int, bounds, bond_struc: Structure,
-                 svd_rank=0, mean_only: bool=False, n_cpus: int=None,
-                 n_sample: int=100):
+                 svd_rank=0, mean_only: bool = False, n_cpus: int = None,
+                 n_sample: int = 100):
         '''
         Build 2-body MGP
 
@@ -561,9 +563,7 @@ class Map2body:
 
         self.build_map_container()
 
-
     def GenGrid(self, GP):
-
         '''
         To use GP to predict value on each grid point, we need to generate the
         kernel vector kv whose length is the same as the training set size.
@@ -592,40 +592,46 @@ class Map2body:
             bond_vars = np.zeros([nop, len(GP.alpha)])
         else:
             bond_vars = None
-        env12 = AtomicEnvironment(self.bond_struc, 0, GP.cutoffs)
 
-        with mp.Pool(processes=processes) as pool:
-            # A_list = pool.map(self._GenGrid_inner_most, pool_list)
-            # break it into pieces
+        env12 = AtomicEnvironment(self.bond_struc, 0, GP.cutoffs, GP.hyps_mask)
+
+        if (processes == 1):
             size = len(GP.training_data)
-            block_id, nbatch = partition_c(self.n_sample, size, processes)
+            k12_v_all = self._GenGrid_inner(
+                GP.name, 0, size, bond_lengths, env12, kernel_info)
+        else:
+            with mp.Pool(processes=processes) as pool:
+                # A_list = pool.map(self._GenGrid_inner_most, pool_list)
+                # break it into pieces
+                size = len(GP.training_data)
+                block_id, nbatch = partition_c(self.n_sample, size, processes)
 
-            k12_slice = []
-            k12_v_all = np.zeros([len(bond_lengths), size*3])
-            count = 0
-            base = 0
-            for ibatch in range(nbatch):
-                s, e = block_id[ibatch]
-                k12_slice.append(pool.apply_async(self._GenGrid_inner,
-                                                  args=(GP.name, s, e,
-                                                        bond_lengths,
-                                                        env12, kernel_info)))
-                count += 1
-                if (count > processes*2):
+                k12_slice = []
+                k12_v_all = np.zeros([len(bond_lengths), size*3])
+                count = 0
+                base = 0
+                for ibatch in range(nbatch):
+                    s, e = block_id[ibatch]
+                    k12_slice.append(pool.apply_async(self._GenGrid_inner,
+                                                      args=(GP.name, s, e,
+                                                            bond_lengths,
+                                                            env12, kernel_info)))
+                    count += 1
+                    if (count > processes*2):
+                        for ibase in range(count):
+                            s, e = block_id[ibase+base]
+                            k12_v_all[:, s*3:e*3] = k12_slice[ibase].get()
+                        del k12_slice
+                        k12_slice = []
+                        count = 0
+                        base = ibatch+1
+                if (count > 0):
                     for ibase in range(count):
                         s, e = block_id[ibase+base]
                         k12_v_all[:, s*3:e*3] = k12_slice[ibase].get()
                     del k12_slice
-                    k12_slice = []
-                    count = 0
-                    base = ibatch+1
-            if (count > 0):
-               for ibase in range(count):
-                   s, e = block_id[ibase+base]
-                   k12_v_all[:, s*3:e*3] = k12_slice[ibase].get()
-               del k12_slice
-            pool.close()
-            pool.join()
+                pool.close()
+                pool.join()
 
         for b, r in enumerate(bond_lengths):
             k12_v = k12_v_all[b, :]
@@ -642,10 +648,8 @@ class Map2body:
 
         return bond_means, bond_vars
 
-
     def _GenGrid_inner(self, name, s, e, bond_lengths,
                        env12, kernel_info):
-
         '''
         Calculate kv segments of the given batch of training data for all grids
         '''
@@ -660,9 +664,7 @@ class Map2body:
                                       hyps, cutoffs, hyps_mask)
         return k12_v
 
-
     def build_map_container(self):
-
         '''
         build 1-d spline function for mean, 2-d for var
         '''
@@ -704,12 +706,11 @@ class Map2body:
         f.write('\n')
 
 
-
 class Map3body:
 
     def __init__(self, grid_num, bounds, bond_struc: Structure,
-                 svd_rank: int=0, mean_only: bool=False, load_grid: str='',
-                 update: bool=True, n_cpus=None, n_sample=100):
+                 svd_rank: int = 0, mean_only: bool = False, load_grid: str = '',
+                 update: bool = True, n_cpus=None, n_sample=100):
         '''
         Build 3-body MGP
 
@@ -727,7 +728,7 @@ class Map3body:
 
         spc = bond_struc.coded_species
         self.species_code = Z_to_element(spc[0]) + '_' + \
-                            Z_to_element(spc[1]) + '_' + Z_to_element(spc[2])
+            Z_to_element(spc[1]) + '_' + Z_to_element(spc[2])
         self.kv3name = f'kv3_{self.species_code}'
 
         self.build_map_container()
@@ -735,9 +736,7 @@ class Map3body:
         self.bounds = bounds
         self.mean_only = mean_only
 
-
     def GenGrid(self, GP):
-
         '''
         To use GP to predict value on each grid point, we need to generate the
         kernel vector kv whose length is the same as the training set size.
@@ -761,8 +760,8 @@ class Map3body:
 
         # ------ construct grids ------
         n1, n2, n12 = self.grid_num
-        bonds1  = np.linspace(self.bounds[0][0], self.bounds[1][0], n1)
-        bonds2  = np.linspace(self.bounds[0][0], self.bounds[1][0], n2)
+        bonds1 = np.linspace(self.bounds[0][0], self.bounds[1][0], n1)
+        bonds2 = np.linspace(self.bounds[0][0], self.bounds[1][0], n2)
         bonds12 = np.linspace(self.bounds[0][2], self.bounds[1][2], n12)
         grid_means = np.zeros([n1, n2, n12])
 
@@ -771,7 +770,7 @@ class Map3body:
         else:
             grid_vars = None
 
-        env12 = AtomicEnvironment(self.bond_struc, 0, GP.cutoffs)
+        env12 = AtomicEnvironment(self.bond_struc, 0, GP.cutoffs, GP.hyps_mask)
         size = len(GP.training_data)
 
         if processes == 1:
@@ -782,13 +781,14 @@ class Map3body:
                 k12_v_all = self._GenGrid_inner(GP.name, 0, size, bonds1,
                                                 bonds2, bonds12, env12,
                                                 kernel_info)
+                k12_v_all = np.moveaxis(k12_v_all, 0, -1)
         else:
             with mp.Pool(processes=processes) as pool:
 
                 if self.update:
 
                     raise NotImplementedError("the update function is "
-                            "not yet implemented")
+                                              "not yet implemented")
 
                     if self.kv3name in os.listdir():
                         subprocess.run(['rm', '-rf', self.kv3name])
@@ -799,7 +799,7 @@ class Map3body:
                     kv_filename = f'{self.kv3name}/{0}'
                     if kv_filename in os.listdir(self.kv3name):
                         old_kv_file = np.load(kv_filename+'.npy')
-                        last_size = int(old_kv_file[0,0])
+                        last_size = int(old_kv_file[0, 0])
                         new_kv_file[i, :, :last_size] = old_kv_file
 
                         k12_v_all = np.zeros([len(bonds1), len(bonds2), len(bonds12),
@@ -807,9 +807,10 @@ class Map3body:
 
                         for i in range(n12):
                             if f'{self.kv3name}/{i}.npy' in os.listdir(self.kv3name):
-                                old_kv_file = np.load(f'{self.kv3name}/{i}.npy')
-                                last_size = int(old_kv_file[0,0])
-                                #TODO k12_v_all[]
+                                old_kv_file = np.load(
+                                    f'{self.kv3name}/{i}.npy')
+                                last_size = int(old_kv_file[0, 0])
+                                # TODO k12_v_all[]
                             else:
                                 last_size = 0
 
@@ -836,14 +837,15 @@ class Map3body:
                             k12_v_all[:, :, s:e, :] = k12_slice[ibatch].get()
 
                 else:
-                    block_id, nbatch = partition_c(self.n_sample, size, processes)
+                    block_id, nbatch = partition_c(
+                        self.n_sample, size, processes)
 
                     k12_slice = []
                     #print('before for', ns, nsample, time.time())
                     count = 0
                     base = 0
-                    k12_v_all = np.zeros([len(bonds1), len(bonds2), len(bonds12),
-                                          size * 3])
+                    k12_v_all = np.zeros(
+                        [size*3, len(bonds1), len(bonds2), len(bonds12)])
                     for ibatch in range(nbatch):
                         s, e = block_id[ibatch]
                         k12_slice.append(pool.apply_async(self._GenGrid_inner,
@@ -855,19 +857,23 @@ class Map3body:
                         if (count > processes*2):
                             for ibase in range(count):
                                 s, e = block_id[ibase+base]
-                                k12_v_all[:, :, :, s*3:e*3] = k12_slice[ibase].get()
+                                k12_v_all[s*3:e*3, :, :,
+                                          :] = k12_slice[ibase].get()
+
                             del k12_slice
                             k12_slice = []
                             count = 0
                             base = ibatch+1
                     if (count > 0):
-                       for ibase in range(count):
-                           s, e = block_id[ibase+base]
-                           k12_v_all[:, :, :, s*3:e*3] = k12_slice[ibase].get()
-                       del k12_slice
+                        for ibase in range(count):
+                            s, e = block_id[ibase+base]
+                            k12_v_all[s*3:e*3, :, :,
+                                      :] = k12_slice[ibase].get()
+                        del k12_slice
 
                 pool.close()
                 pool.join()
+                k12_v_all = np.moveaxis(k12_v_all, 0, -1)
 
         for b12 in range(len(bonds12)):
             for b1 in range(len(bonds1)):
@@ -876,8 +882,7 @@ class Map3body:
                     grid_means[b1, b2, b12] = np.matmul(k12_v, GP.alpha)
                     if not self.mean_only:
                         grid_vars[b1, b2, b12, :] = solve_triangular(GP.l_mat,
-                            k12_v, lower=True)
-
+                                                                     k12_v, lower=True)
 
         # Construct file names according to current mapping
 
@@ -887,59 +892,54 @@ class Map3body:
 
         return grid_means, grid_vars
 
-    def _GenGrid_inner(self, name, s, e, bonds1, bonds2, bonds12, env12, kernel_info):
+        def _GenGrid_inner(self, name, s, e, bonds1, bonds2, bonds12, env12, kernel_info):
 
-        '''
-        Calculate kv segments of the given batch of training data for all grids
-        '''
+            if self.update:
+                raise NotImplementedError("the update function is not yet"
+                                          "implemented")
 
-        kernel, en_force_kernel, cutoffs, hyps, hyps_mask = kernel_info
-        # open saved k vector file, and write to new file
-        size =  (e - s) * 3
-        k12_v = np.zeros([len(bonds1), len(bonds2), len(bonds12), size])
-        for b12, r12 in enumerate(bonds12):
-            for b1, r1 in enumerate(bonds1):
-                for b2, r2 in enumerate(bonds2):
+            kernel, en_force_kernel, cutoffs, hyps, hyps_mask = kernel_info
 
-                    env12.bond_array_3 = np.array([[r1, 1, 0, 0],
-                                                   [r2, 0, 0, 0]])
-                    env12.cross_bond_dists = np.array([[0, r12], [r12, 0]])
-                    k12_v[b1, b2, b12, :] = en_kern_vec(name, s, e,
-                                                        env12, en_force_kernel,
-                                                        hyps, cutoffs, hyps_mask)
+            training_data = _global_training_data[name]
 
-        # open saved k vector file, and write to new file
-        if self.update:
-
-            raise NotImplementedError("the update function is not yet"\
-                    "implemented")
-
-            s, e = block
-            chunk = e - s
-            new_kv_file = np.zeros((chunk,
-                                    self.grid_num[0]*self.grid_num[1]+1,
-                                    total_size))
-            new_kv_file[:,0,0] = np.ones(chunk) * total_size
-            for i in range(s, e):
-                kv_filename = f'{self.kv3name}/{i}'
-                if kv_filename in os.listdir(self.kv3name):
-                    old_kv_file = np.load(kv_filename+'.npy')
-                    last_size = int(old_kv_file[0,0])
-                    new_kv_file[i, :, :last_size] = old_kv_file
-                else:
-                    last_size = 0
             ds = [1, 2, 3]
-            nop = self.grid_num[0]
+            size = (e-s) * 3
 
-            k12_v = new_kv_file[:,1:,:]
-            for i in range(s, e):
-                np.save(f'{self.kv3name}/{i}', new_kv_file[i,:,:])
+            nb12 = len(bonds12)
+            nb1 = len(bonds1)
+            nb2 = len(bonds2)
 
-        return k12_v
+            r1 = np.ones([nb1, nb2, nb12], dtype=np.float64)
+            r2 = np.ones([nb1, nb2, nb12], dtype=np.float64)
+            r12 = np.ones([nb1, nb2, nb12], dtype=np.float64)
+            for b12 in range(nb12):
+                for b1 in range(nb1):
+                    for b2 in range(nb2):
+                        r1[b1, b2, b12] = bonds1[b1]
+                        r2[b1, b2, b12] = bonds2[b2]
+                        r12[b1, b2, b12] = bonds12[b12]
+
+            k_v = np.zeros([size, nb1, nb2, nb12])
+
+            args = from_mask_to_args(hyps, hyps_mask, cutoffs)
+
+            if (hyps_mask is not None):
+                tbmfe = three_body_mc_force_en_sephyps
+            else:
+                tbmfe = three_body_mc_force_en
+
+            for m_index in range(size):
+                x_2 = training_data[int(floor(m_index / 3))+s]
+                d_2 = ds[m_index % 3]
+                k_v[m_index, :, :, :] = tbmfe(x_2, r1, r2, r12,
+                                                env12.ctype, env12.etypes,
+                                                d_2, *args)
+
+            return k_v
+
 
 
     def build_map_container(self):
-
         '''
         build 3-d spline function for mean,
         3-d for the low rank approximation of L^{-1}k*
@@ -961,10 +961,10 @@ class Map3body:
             y_mean, y_var = self.GenGrid(GP)
         # If load grid is blank string '' or pre-fix, load in
         else:
-            y_mean = np.load(self.load_grid+'grid3_mean_'+\
-                    self.species_code+'.npy')
-            y_var = np.load(self.load_grid+'grid3_var_'+\
-                    self.species_code+'.npy')
+            y_mean = np.load(self.load_grid+'grid3_mean_' +
+                             self.species_code+'.npy')
+            y_var = np.load(self.load_grid+'grid3_var_' +
+                            self.species_code+'.npy')
 
         self.mean.set_values(y_mean)
         if not self.mean_only:
@@ -1000,5 +1000,3 @@ class Map3body:
                     n += 1
 
         f.write('\n')
-
-

--- a/flare/mgp/utils.py
+++ b/flare/mgp/utils.py
@@ -37,7 +37,7 @@ def get_2bkernel(GP):
                 ori_hyps[hm[i]]=h
         else:
             ori_hyps = original_hyps
-        n2b = o_hyps_mask['nbond']
+        n2b = o_hyps_mask.get('nbond', 0)
         hyps = np.hstack([ori_hyps[:n2b*2], ori_hyps[-1]])
         hyps_mask = {'nbond':n2b, 'ntriplet':0,
               'nspec':o_hyps_mask['nspec'],
@@ -73,9 +73,9 @@ def get_3bkernel(GP):
                 ori_hyps[hm[i]]=h
         else:
             ori_hyps = original_hyps
-        n2b = o_hyps_mask['nbond']
-        n3b = o_hyps_mask['ntriplet']
-        hyps = ori_hyps[n2b*2:]
+        n2b = o_hyps_mask.get('nbond', 0)
+        n3b = o_hyps_mask.get('ntriplet', 0)
+        hyps = np.hstack([ori_hyps[n2b*2:n2b*2+n3b*2], ori_hyps[-1]])
         hyps_mask = {'ntriplet':n3b,'nbond':0,
                 'nspec':o_hyps_mask['nspec'],
                 'spec_mask':o_hyps_mask['spec_mask'],


### PR DESCRIPTION
This branch should be further polished after the manybody mapping and energy label training branch are pulled.

- new May3body._GenGrid_inner is written for three-body energy mapping in mgp.mgp_en
- add a new module kernels.map_3b_kernel 
- The originally loop over 3-D grid points is shifted from the May3body._GenGrid_inner to the energy_force kernel njit function.
- Inside the njit function, the triple loop over grid points is replaced by matrices representing the bond lengths. So the number of for loops are reduced from 7 to 2 by increasing the memory footprint. 
- multiprocessing is completely removed from Map3body. njit(parallel=True) is used for the new mapping kernels.

This revision can accelerate the three-body mapping for ~6 times. Here's a test for one three-body component of a 6000-training-data GP model.

| grid number |  after | before | speed up |
|:----:|:----:|:----:|:----:|
|  4  |     18    |    4 | 0.26 |
| 16 |      37   |   161 | 4.26 |
| 64 |    1523 |    9000 | 5.91 |

Originally: The multiprocessing and initial setup overhead is still heavy. If grid number is smaller than 4, the overhead takes over (but the time needed in this case is negligible anyway). There may still be some room for improvement.
Now: after removing the multiprocessing, and solely use the njit parallel. The overhead should be very small.
