### PR TITLE
Attempt to solve unit tests failing due to pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numba
 ase
 pymatgen
 nptyping
+pytest>=4.6


### PR DESCRIPTION
Travis logs indicate that pytest is at too low a version (perhaps due to a change in some requirement by another library). I have fixed this by adding a minimum version to pytest in the requirements.txt.