### PR TITLE
Steven/feature/gp write choice

### DIFF
--- a/flare/gp.py
+++ b/flare/gp.py
@@ -797,6 +797,9 @@ class GaussianProcess:
         if max(indexes) > len(self.training_data):
             raise ValueError("Index out of range of data")
 
+        if len(indexes) == 0:
+            return [], []
+
         # Get in reverse order so that modifying higher indexes doesn't affect
         # lower indexes
         indexes.sort(reverse=True)

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -705,14 +705,21 @@ class GaussianProcess:
         :return:
         """
         ky_mat = self.ky_mat
-        l_mat = np.linalg.cholesky(ky_mat)
-        l_mat_inv = np.linalg.inv(l_mat)
-        ky_mat_inv = l_mat_inv.T @ l_mat_inv
-        alpha = np.matmul(ky_mat_inv, self.all_labels)
 
-        self.l_mat = l_mat
-        self.alpha = alpha
-        self.ky_mat_inv = ky_mat_inv
+        if ky_mat is None or \
+                (isinstance(ky_mat, np.ndarray) and not np.any(
+                ky_mat)):
+            Warning("Warning: Covariance matrix was not loaded but "
+                    "compute_matrices was called. Computing covariance "
+                    "matrix and proceeding...")
+            self.set_L_alpha()
+
+        else:
+            self.l_mat = np.linalg.cholesky(ky_mat)
+            self.l_mat_inv = np.linalg.inv(self.l_mat)
+            self.ky_mat_inv = self.l_mat_inv.T @ self.l_mat_inv
+            self.alpha = np.matmul(self.ky_mat_inv, self.all_labels)
+
 
     def adjust_cutoffs(self, new_cutoffs: Union[list, tuple, 'np.ndarray'],
                        reset_L_alpha=True, train=True, new_hyps_mask=None):

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -13,7 +13,7 @@ from copy import deepcopy
 from numpy.random import random
 from scipy.linalg import solve_triangular
 from scipy.optimize import minimize
-from typing import List, Callable, Union, Tuple
+from typing import List, Callable, Union, Tuple, Sequence
 
 from flare.env import AtomicEnvironment
 from flare.gp_algebra import get_like_from_mats, get_neg_like_grad, \
@@ -59,7 +59,7 @@ class GaussianProcess:
         name (str, optional): Name for the GP instance.
     """
 
-    def __init__(self, kernels: list = ['two', 'three'],
+    def __init__(self, kernels: List[str] = ['two', 'three'],
                  component: str = 'mc',
                  hyps: 'ndarray' = None, cutoffs={},
                  hyps_mask: dict = {},
@@ -810,7 +810,7 @@ class GaussianProcess:
 
         return removed_data, removed_labels
 
-    def write_model(self, name: str, format: str = 'json',
+    def write_model(self, name: str, format: str = None,
                     split_matrix_size_cutoff: int = 5000):
         """
         Write model in a variety of formats to a file for later re-use.
@@ -835,14 +835,28 @@ class GaussianProcess:
             self.alpha = None
             self.ky_mat_inv = None
 
+        # Automatically detect output format from name variable
+
+        for detect in ['json','pickle','binary']:
+            if detect in name.lower():
+                format = detect
+                break
+
+        if format is None:
+            format = 'json'
+
         supported_formats = ['json', 'pickle', 'binary']
 
         if format.lower() == 'json':
-            with open(f'{name}.json', 'w') as f:
+            if '.json' != name[-5:]:
+                name += '.json'
+            with open(name, 'w') as f:
                 json.dump(self.as_dict(), f, cls=NumpyEncoder)
 
         elif format.lower() == 'pickle' or format.lower() == 'binary':
-            with open(f'{name}.pickle', 'wb') as f:
+            if '.pickle' != name[-7:]:
+                name += '.pickle'
+            with open(name, 'wb') as f:
                 pickle.dump(self, f)
 
         else:

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -825,6 +825,12 @@ class GaussianProcess:
                     split_matrix_size_cutoff: int = 5000):
         """
         Write model in a variety of formats to a file for later re-use.
+        JSON files are open to visual inspection and are easier to use 
+        across different versions of FLARE or GP implementations. However,
+        they are larger and loading them in takes longer (by setting up a
+        new GP from the specifications). Pickled files can be faster to
+        read & write, and they take up less memory.
+        
         Args:
             name (str): Output name.
             format (str): Output format.

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -673,20 +673,24 @@ class GaussianProcess:
         new_gp.n_envs_prev = len(new_gp.training_data)
 
         # Save time by attempting to load in computed attributes
-        if len(new_gp.training_data) > 5000:
+        if dictionary.get('ky_mat_file'):
             try:
                 new_gp.ky_mat = np.load(dictionary['ky_mat_file'])
                 new_gp.compute_matrices()
+                new_gp.ky_mat_file = None
+
             except FileNotFoundError:
                 new_gp.ky_mat = None
                 new_gp.l_mat = None
                 new_gp.alpha = None
                 new_gp.ky_mat_inv = None
-                filename = dictionary['ky_mat_file']
-                logger = logging.getLogger(self.logger_name)
+                filename = dictionary.get('ky_mat_file')
+                logger = logging.getLogger(new_gp.logger_name)
                 logger.warning("the covariance matrices are not loaded"
                                f"because {filename} cannot be found")
         else:
+            new_gp.ky_mat = np.array(dictionary['ky_mat']) \
+                if dictionary.get('ky_mat') is not None else None
             new_gp.ky_mat_inv = np.array(dictionary['ky_mat_inv']) \
                 if dictionary.get('ky_mat_inv') is not None else None
             new_gp.ky_mat = np.array(dictionary['ky_mat']) \

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -304,6 +304,9 @@ class TestIO():
         # Test logic for auto-detecting format in write command
         for format in ['json', 'pickle']:
             write_string = 'format_write_test.'+format
+            if os.path.exists(write_string):
+                os.remove(write_string)
+
             test_gp.write_model(write_string)
             assert os.path.exists(write_string)
             os.remove(write_string)

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -311,7 +311,6 @@ class TestIO():
             assert os.path.exists(write_string)
             os.remove(write_string)
 
-
     def test_load_reload_huge(self, all_gps):
         """
         Unit tests that loading and reloading a huge GP works.
@@ -323,19 +322,20 @@ class TestIO():
         dummy_gp = deepcopy(test_gp)
 
         N_data = len(dummy_gp.training_data)
-
         prev_ky_mat = deepcopy(dummy_gp.ky_mat)
         prev_l_mat = deepcopy(dummy_gp.l_mat)
 
-        for format in ['json', 'pickle']:
-
-            test_gp.write_model('test_gp_write', format, N_data-1)
-            new_gp = GaussianProcess.from_file(f'test_gp_write.{format}')
-            assert np.array_equal(prev_ky_mat, new_gp.ky_mat)
-            assert np.array_equal(prev_l_mat, new_gp.l_mat)
+        for model_format in ['pickle','json']:
+            dummy_gp.write_model('test_gp_write', model_format, N_data-1)
+            new_gp = GaussianProcess.from_file(f'test_gp_write.{model_format}')
+            assert np.allclose(prev_ky_mat, new_gp.ky_mat)
+            assert np.allclose(prev_l_mat, new_gp.l_mat)
             assert new_gp.training_data is not test_gp.training_data
 
-            os.remove(f'test_gp_write.{format}')
+            os.remove(f'test_gp_write.{model_format}')
+            dummy_gp = deepcopy(test_gp)
+
+        os.remove(f'test_gp_write_ky_mat.npy')
 
 
 def dumpcompare(obj1, obj2):

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -240,7 +240,6 @@ class TestIO():
     def test_representation_method(self, all_gps, multihyps):
         test_gp = all_gps[multihyps]
         the_str = str(test_gp)
-        print(the_str)
         assert 'GaussianProcess Object' in the_str
         assert 'Kernel: [\'twobody\', \'threebody\', \'manybody\']' in the_str
         assert 'Cutoffs: {\'twobody\': 0.8, \'threebody\': 0.8, \'manybody\': 0.8}' in the_str
@@ -301,6 +300,13 @@ class TestIO():
 
         with raises(ValueError):
             test_gp.write_model('test_gp_write', 'cucumber')
+
+        # Test logic for auto-detecting format in write command
+        for format in ['json', 'pickle']:
+            write_string = 'format_write_test.'+format
+            test_gp.write_model(write_string)
+            assert os.path.exists(write_string)
+            os.remove(write_string)
 
 
     def test_load_reload_huge(self, all_gps):

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -312,19 +312,21 @@ class TestIO():
         test_gp = deepcopy(all_gps[False])
         test_gp.set_L_alpha()
         dummy_gp = deepcopy(test_gp)
-        dummy_gp.training_data = [1]*5001
+
+        N_data = len(dummy_gp.training_data)
 
         prev_ky_mat = deepcopy(dummy_gp.ky_mat)
         prev_l_mat = deepcopy(dummy_gp.l_mat)
 
-        dummy_gp.training_data = [1]*5001
-        test_gp.write_model('test_gp_write', 'json')
-        new_gp = GaussianProcess.from_file('test_gp_write.json')
-        assert np.array_equal(prev_ky_mat, new_gp.ky_mat)
-        assert np.array_equal(prev_l_mat, new_gp.l_mat)
-        assert new_gp.training_data is not test_gp.training_data
+        for format in ['json', 'pickle']:
 
-        os.remove('test_gp_write.json')
+            test_gp.write_model('test_gp_write', format, N_data-1)
+            new_gp = GaussianProcess.from_file(f'test_gp_write.{format}')
+            assert np.array_equal(prev_ky_mat, new_gp.ky_mat)
+            assert np.array_equal(prev_l_mat, new_gp.l_mat)
+            assert new_gp.training_data is not test_gp.training_data
+
+            os.remove(f'test_gp_write.{format}')
 
 
 def dumpcompare(obj1, obj2):


### PR DESCRIPTION
Minor changes: 
- `GaussianProcess.write_model` now allows for flexibility for the user to decide if they want the matrices written separately or not. 
- `write_model` now will not redundantly append .json or .pickle to written models. If the file name is `my_model.json` then it will not write `my_model.json.json`. Also, if you don't specify the format, but if you specify it in the string, it automatically detects it. A small friction I've encountered!
- The remove force data method will now terminate immediately if an empty list is passed in.