### PR TITLE
[WIP]Add backwards compatibility for pickled envs

### DIFF
--- a/flare/env.py
+++ b/flare/env.py
@@ -240,7 +240,6 @@ class AtomicEnvironment:
         cutoffs_mask = getattr(self, 'cutoffs_mask', {'cutoffs': self.cutoffs})
         if not hasattr(self, 'cutoffs_mask'):
             self.cutoffs_mask = cutoffs_mask
-            self.setup_mask(cutoffs_mask)
         dictionary['cutoffs_mask'] = cutoffs_mask
 
         if not include_structure:

--- a/flare/env.py
+++ b/flare/env.py
@@ -5,10 +5,10 @@ import numpy as np
 from copy import deepcopy
 from math import ceil
 from flare.struc import Structure
-from flare.parameters import Parameters
 import flare.kernels.cutoffs as cf
-from flare.utils.env_getarray import get_2_body_arrays, get_3_body_arrays,\
-    get_m2_body_arrays, get_m3_body_arrays
+from flare.utils.env_getarray import get_2_body_arrays, get_3_body_arrays, \
+    get_m2_body_arrays
+
 
 class AtomicEnvironment:
     """Contains information about the local environment of an atom,
@@ -70,7 +70,8 @@ class AtomicEnvironment:
     all_kernel_types = ['twobody', 'threebody', 'manybody']
     ndim = {'twobody': 2, 'threebody': 3, 'manybody': 2, 'cut3b': 2}
 
-    def __init__(self, structure: Structure, atom: int, cutoffs, cutoffs_mask=None):
+    def __init__(self, structure: Structure, atom: int, cutoffs,
+                 cutoffs_mask=None):
 
         self.structure = structure
         self.positions = structure.wrapped_positions
@@ -79,10 +80,10 @@ class AtomicEnvironment:
 
         # backward compatability
         if not isinstance(cutoffs, dict):
-            newcutoffs = {'twobody':cutoffs[0]}
-            if len(cutoffs)>1:
+            newcutoffs = {'twobody': cutoffs[0]}
+            if len(cutoffs) > 1:
                 newcutoffs['threebody'] = cutoffs[1]
-            if len(cutoffs)>2:
+            if len(cutoffs) > 2:
                 newcutoffs['manybody'] = cutoffs[2]
             cutoffs = newcutoffs
 
@@ -98,7 +99,6 @@ class AtomicEnvironment:
 
         self.atom = atom
         self.ctype = structure.coded_species[atom]
-
 
         self.twobody_cutoff = 0
         self.threebody_cutoff = 0
@@ -150,24 +150,26 @@ class AtomicEnvironment:
         for kernel in AtomicEnvironment.all_kernel_types:
             ndim = AtomicEnvironment.ndim[kernel]
             if kernel in self.cutoffs:
-                setattr(self, kernel+'_cutoff', self.cutoffs[kernel])
+                setattr(self, kernel + '_cutoff', self.cutoffs[kernel])
 
-        if (self.twobody_cutoff == 0):
-            self.twobody_cutoff = np.max([self.threebody_cutoff, self.manybody_cutoff])
+        if self.twobody_cutoff == 0:
+            self.twobody_cutoff = np.max(
+                [self.threebody_cutoff, self.manybody_cutoff])
             self.cutoffs['twobody'] = self.twobody_cutoff
 
         self.nspecie = cutoffs_mask.get('nspecie', 1)
         if 'specie_mask' in cutoffs_mask:
-            self.specie_mask = np.array(cutoffs_mask['specie_mask'], dtype=np.int)
+            self.specie_mask = np.array(cutoffs_mask['specie_mask'],
+                                        dtype=np.int)
 
         for kernel in AtomicEnvironment.all_kernel_types:
             ndim = AtomicEnvironment.ndim[kernel]
             if kernel in self.cutoffs:
-                setattr(self, kernel+'_cutoff', self.cutoffs[kernel])
-                setattr(self, 'n'+kernel, 1)
+                setattr(self, kernel + '_cutoff', self.cutoffs[kernel])
+                setattr(self, 'n' + kernel, 1)
                 if kernel != 'threebody':
-                    name_list = [kernel+'_cutoff_list',
-                                 'n'+kernel, kernel+'_mask']
+                    name_list = [kernel + '_cutoff_list',
+                                 'n' + kernel, kernel + '_mask']
                     for name in name_list:
                         if name in cutoffs_mask:
                             setattr(self, name, cutoffs_mask[name])
@@ -175,16 +177,21 @@ class AtomicEnvironment:
                     self.ncut3b = cutoffs_mask.get('ncut3b', 1)
                     self.cut3b_mask = cutoffs_mask.get('cut3b_mask', None)
                     if 'threebody_cutoff_list' in cutoffs_mask:
-                        self.threebody_cutoff_list = np.array(cutoffs_mask['threebody_cutoff_list'], dtype=np.float)
+                        self.threebody_cutoff_list = np.array(
+                            cutoffs_mask['threebody_cutoff_list'],
+                            dtype=np.float)
 
     def compute_env(self):
 
         # get 2-body arrays
-        if (self.ntwobody >= 1):
+        if self.ntwobody >= 1:
             bond_array_2, bond_positions_2, etypes, bond_inds = \
-                get_2_body_arrays(self.positions, self.atom, self.cell, self.twobody_cutoff,
-                                  self.twobody_cutoff_list, self.species, self.sweep_array,
-                                  self.nspecie, self.specie_mask, self.twobody_mask)
+                get_2_body_arrays(self.positions, self.atom, self.cell,
+                                  self.twobody_cutoff,
+                                  self.twobody_cutoff_list, self.species,
+                                  self.sweep_array,
+                                  self.nspecie, self.specie_mask,
+                                  self.twobody_mask)
 
             self.bond_array_2 = bond_array_2
             self.etypes = etypes
@@ -194,9 +201,11 @@ class AtomicEnvironment:
         if self.ncut3b > 0:
             bond_array_3, cross_bond_inds, cross_bond_dists, triplet_counts = \
                 get_3_body_arrays(bond_array_2, bond_positions_2,
-                                  self.species[self.atom], etypes, self.threebody_cutoff,
+                                  self.species[self.atom], etypes,
+                                  self.threebody_cutoff,
                                   self.threebody_cutoff_list,
-                                  self.nspecie, self.specie_mask, self.cut3b_mask)
+                                  self.nspecie, self.specie_mask,
+                                  self.cut3b_mask)
             self.bond_array_3 = bond_array_3
             self.cross_bond_inds = cross_bond_inds
             self.cross_bond_dists = cross_bond_dists
@@ -205,29 +214,37 @@ class AtomicEnvironment:
         # if 3 cutoffs are given, create many-body arrays
         if self.nmanybody > 0:
             self.q_array, self.q_neigh_array, self.q_grads, self.q_neigh_grads, \
-                self.unique_species, self.etypes_mb = \
+            self.unique_species, self.etypes_mb = \
                 get_m2_body_arrays(self.positions, self.atom, self.cell,
-                                  self.manybody_cutoff, self.manybody_cutoff_list,
-                                  self.species, self.sweep_array,
-                                  self.nspecie, self.specie_mask,
-                                  self.manybody_mask, cf.quadratic_cutoff)
+                                   self.manybody_cutoff,
+                                   self.manybody_cutoff_list,
+                                   self.species, self.sweep_array,
+                                   self.nspecie, self.specie_mask,
+                                   self.manybody_mask, cf.quadratic_cutoff)
 
-    def as_dict(self):
+    def as_dict(self, include_structure: bool = False):
         """
         Returns Atomic Environment object as a dictionary for serialization
-        purposes. Does not include the structure to avoid redundant
+        purposes. Optional to not include the structure to avoid redundant
         information.
         :return:
         """
-        # TODO write serialization method for structure
-        # so that the removal of the structure is not messed up
-        # by JSON serialization
+
         dictionary = dict(vars(self))
         dictionary['object'] = 'AtomicEnvironment'
         dictionary['forces'] = self.structure.forces
-        dictionary['cutoffs_mask'] = self.cutoffs_mask
 
-        del dictionary['structure']
+        # Backward compatibility for older models: CUtoffs mask
+        cutoffs_mask = getattr(self, 'cutoffs_mask', {'cutoffs': self.cutoffs})
+        if not hasattr(self, 'cutoffs_mask'):
+            self.cutoffs_mask = cutoffs_mask
+            self.setup_mask(cutoffs_mask)
+        dictionary['cutoffs_mask'] = cutoffs_mask
+
+        if not include_structure:
+            del dictionary['structure']
+        else:
+            dictionary['structure'] = dictionary['structure'].as_dict()
 
         return dictionary
 
@@ -254,13 +271,14 @@ class AtomicEnvironment:
 
         cutoffs_mask = dictionary.get('cutoffs_mask', None)
 
-        return AtomicEnvironment(struc, index, cutoffs, cutoffs_mask=cutoffs_mask)
+        return AtomicEnvironment(struc, index, cutoffs,
+                                 cutoffs_mask=cutoffs_mask)
 
     def __str__(self):
         atom_type = self.ctype
         neighbor_types = self.etypes
         n_neighbors = len(self.bond_array_2)
-        string = 'Atomic Env. of Type {} surrounded by {} atoms '\
+        string = 'Atomic Env. of Type {} surrounded by {} atoms ' \
                  'of Types {}'.format(atom_type, n_neighbors,
                                       sorted(list(set(neighbor_types))))
 

--- a/flare/env.py
+++ b/flare/env.py
@@ -234,7 +234,9 @@ class AtomicEnvironment:
         dictionary['object'] = 'AtomicEnvironment'
         dictionary['forces'] = self.structure.forces
 
-        # Backward compatibility for older models: CUtoffs mask
+        # Backward compatibility for older models: Cutoffs mask.
+        # Can be deleted one day if support is dropped for older (Pre June
+        # 2020) pickled environment objects.
         cutoffs_mask = getattr(self, 'cutoffs_mask', {'cutoffs': self.cutoffs})
         if not hasattr(self, 'cutoffs_mask'):
             self.cutoffs_mask = cutoffs_mask

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -816,7 +816,6 @@ class GaussianProcess:
 
         if update_matrices:
             self.set_L_alpha()
-            self.compute_matrices()
 
         # Put removed data in order of lowest to highest index
         removed_data.reverse()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,19 +1,20 @@
 import pytest
 import numpy as np
+
+from copy import deepcopy
 from flare.struc import Structure
 from flare.env import AtomicEnvironment
 
-
 np.random.seed(0)
 
-cutoff_mask_list = [# (True, np.array([1]), [10]),
-                    (False, {'twobody':1}, [16]),
-                    (False, {'twobody':1, 'threebody':0.05}, [16, 0]),
-                    (False, {'twobody':1, 'threebody':0.8}, [16, 1]),
-                    (False, {'twobody':1, 'threebody':0.9}, [16, 21]),
-                    (True, {'twobody':1, 'threebody':0.8}, [16, 9]),
-                    (True, {'twobody':1, 'threebody':0.05, 'manybody':0.4}, [16, 0]),
-                    (False, {'twobody':1, 'threebody':0.05, 'manybody':0.4}, [16, 0])]
+cutoff_mask_list = [  # (True, np.array([1]), [10]),
+    (False, {'twobody': 1}, [16]),
+    (False, {'twobody': 1, 'threebody': 0.05}, [16, 0]),
+    (False, {'twobody': 1, 'threebody': 0.8}, [16, 1]),
+    (False, {'twobody': 1, 'threebody': 0.9}, [16, 21]),
+    (True, {'twobody': 1, 'threebody': 0.8}, [16, 9]),
+    (True, {'twobody': 1, 'threebody': 0.05, 'manybody': 0.4}, [16, 0]),
+    (False, {'twobody': 1, 'threebody': 0.05, 'manybody': 0.4}, [16, 0])]
 
 
 @pytest.fixture(scope='module')
@@ -35,8 +36,7 @@ def structure() -> Structure:
 
 @pytest.mark.parametrize('mask, cutoff, result', cutoff_mask_list)
 def test_2bspecies_count(structure, mask, cutoff, result):
-
-    if (mask is True):
+    if mask is True:
         mask = generate_mask(cutoff)
     else:
         mask = None
@@ -52,14 +52,13 @@ def test_2bspecies_count(structure, mask, cutoff, result):
     assert (isinstance(env_test.etypes[0], np.int8))
     assert (len(env_test.bond_array_2) == result[0])
 
-    if (len(cutoff) > 1):
+    if len(cutoff) > 1:
         assert (np.sum(env_test.triplet_counts) == result[1])
 
 
 @pytest.mark.parametrize('mask, cutoff, result', cutoff_mask_list)
 def test_env_methods(structure, mask, cutoff, result):
-
-    if (mask is True):
+    if mask is True:
         mask = generate_mask(cutoff)
     else:
         mask = None
@@ -69,8 +68,9 @@ def test_env_methods(structure, mask, cutoff, result):
                                  cutoffs=cutoff,
                                  cutoffs_mask=mask)
 
-    assert str(env_test) == f'Atomic Env. of Type 1 surrounded by {result[0]} atoms' \
-                            ' of Types [1, 2, 3]'
+    assert str(
+        env_test) == f'Atomic Env. of Type 1 surrounded by {result[0]} atoms' \
+                     ' of Types [1, 2, 3]'
 
     the_dict = env_test.as_dict()
     assert isinstance(the_dict, dict)
@@ -81,15 +81,43 @@ def test_env_methods(structure, mask, cutoff, result):
     assert isinstance(remade_env, AtomicEnvironment)
 
     assert np.array_equal(remade_env.bond_array_2, env_test.bond_array_2)
-    if (len(cutoff) > 1):
+    if len(cutoff) > 1:
         assert np.array_equal(remade_env.bond_array_3, env_test.bond_array_3)
-    if (len(cutoff) > 2):
+    if len(cutoff) > 2:
         assert np.array_equal(remade_env.q_array, env_test.q_array)
+
+# Only run on the first four tests, namely, the ones which have
+# False as a parameter.
+@pytest.mark.parametrize('mask, cutoff, result', cutoff_mask_list[:4])
+def test_backwards_compatibility(structure, mask, cutoff, result):
+    """
+    This test can be deleted if backwards compatibility is dropped for the
+    sake of code cleanup. (This test executes in about 5 milliseconds). Tests a
+    particular branch of code within the Environment's as_dict() method for
+    older pickled environments without a cutoffs mask.
+    :return:
+    """
+    if mask is True:
+        mask = generate_mask(cutoff)
+    else:
+        mask = None
+
+    env_test = deepcopy(AtomicEnvironment(structure,
+                                 atom=0,
+                                 cutoffs=cutoff,
+                                 cutoffs_mask=mask))
+    pre_test_dict = env_test.as_dict()
+
+    delattr(env_test, 'cutoffs_mask')
+
+    test_dict = env_test.as_dict()
+
+    assert pre_test_dict['cutoffs_mask'] == test_dict['cutoffs_mask']
 
 
 def generate_mask(cutoff):
     ncutoff = len(cutoff)
-    if (ncutoff == 1):
+    if ncutoff == 1:
         # (1, 1) uses 0.5 cutoff,  (1, 2) (1, 3) (2, 3) use 0.9 cutoff
         mask = {'nspecie': 2, 'specie_mask': np.ones(118, dtype=int)}
         mask['specie_mask'][1] = 0
@@ -98,7 +126,7 @@ def generate_mask(cutoff):
         mask['twobody_mask'] = np.ones(4, dtype=int)
         mask['twobody_mask'][0] = 0
 
-    elif (ncutoff == 2):
+    elif ncutoff == 2:
         # the 3b mask is the same structure as 2b
         nspecie = 3
         specie_mask = np.zeros(118, dtype=int)
@@ -109,13 +137,13 @@ def generate_mask(cutoff):
         # (1, 1) (1, 2) (1, 3) (2, 3) (*, *)
         # correspond to cutoff 0.5, 0.9, 0.8, 0.9, 0.05
         ncut3b = 5
-        tmask = np.ones(nspecie**2, dtype=int)*(ncut3b-1)
+        tmask = np.ones(nspecie ** 2, dtype=int) * (ncut3b - 1)
         count = 0
         for i, j in [(1, 1), (1, 2), (1, 3), (2, 3)]:
             cs1 = specie_mask[i]
             cs2 = specie_mask[j]
-            tmask[cs1*nspecie+cs2] = count
-            tmask[cs2*nspecie+cs1] = count
+            tmask[cs1 * nspecie + cs2] = count
+            tmask[cs2 * nspecie + cs1] = count
             count += 1
 
         mask = {'nspecie': nspecie,
@@ -124,7 +152,7 @@ def generate_mask(cutoff):
                 'ncut3b': ncut3b,
                 'cut3b_mask': tmask}
 
-    elif (ncutoff == 3):
+    elif ncutoff == 3:
         # (1, 1) uses 0.5 cutoff,  (1, 2) (1, 3) (2, 3) use 0.9 cutoff
         mask = {'nspecie': 2, 'specie_mask': np.ones(118, dtype=int)}
         mask['specie_mask'][1] = 0
@@ -166,11 +194,11 @@ def test_auto_sweep():
         np.arange(-sweep_val + 1, sweep_val, 1)
     arbitrary_environment.compute_env()
     n_neighbors_2 = len(arbitrary_environment.etypes)
-    assert(n_neighbors_1 > n_neighbors_2)
+    assert (n_neighbors_1 > n_neighbors_2)
 
     # Increase the sweep value, and check that the count is the same.
     arbitrary_environment.sweep_array = \
         np.arange(-sweep_val - 1, sweep_val + 2, 1)
     arbitrary_environment.compute_env()
     n_neighbors_3 = len(arbitrary_environment.etypes)
-    assert(n_neighbors_1 == n_neighbors_3)
+    assert (n_neighbors_1 == n_neighbors_3)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -114,6 +114,12 @@ def test_backwards_compatibility(structure, mask, cutoff, result):
 
     assert pre_test_dict['cutoffs_mask'] == test_dict['cutoffs_mask']
 
+    new_env = AtomicEnvironment.from_dict(test_dict)
+
+    assert isinstance(new_env, AtomicEnvironment)
+
+    assert str(new_env) == str(env_test)
+
 
 def generate_mask(cutoff):
     ncutoff = len(cutoff)


### PR DESCRIPTION
- env.py should now be backwards compatible with old atomic environment objects without a cutoffs mask attribute
- Clean up PEP8 compliance for `env.py` and `test_env.py`
