### PR TITLE
Steven/bugfix/mgp predict

### DIFF
--- a/flare/env.py
+++ b/flare/env.py
@@ -240,7 +240,6 @@ class AtomicEnvironment:
         cutoffs_mask = getattr(self, 'cutoffs_mask', {'cutoffs': self.cutoffs})
         if not hasattr(self, 'cutoffs_mask'):
             self.cutoffs_mask = cutoffs_mask
-            self.setup_mask(cutoffs_mask)
         dictionary['cutoffs_mask'] = cutoffs_mask
 
         if not include_structure:

--- a/flare/env.py
+++ b/flare/env.py
@@ -234,7 +234,9 @@ class AtomicEnvironment:
         dictionary['object'] = 'AtomicEnvironment'
         dictionary['forces'] = self.structure.forces
 
-        # Backward compatibility for older models: CUtoffs mask
+        # Backward compatibility for older models: Cutoffs mask.
+        # Can be deleted one day if support is dropped for older (Pre June
+        # 2020) pickled environment objects.
         cutoffs_mask = getattr(self, 'cutoffs_mask', {'cutoffs': self.cutoffs})
         if not hasattr(self, 'cutoffs_mask'):
             self.cutoffs_mask = cutoffs_mask

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -816,7 +816,6 @@ class GaussianProcess:
 
         if update_matrices:
             self.set_L_alpha()
-            self.compute_matrices()
 
         # Put removed data in order of lowest to highest index
         removed_data.reverse()

--- a/flare/mgp/cubic_splines_numba.py
+++ b/flare/mgp/cubic_splines_numba.py
@@ -602,13 +602,13 @@ def compute_const():
     ])
     
     global dAd
-    dAd = zeros((4,4))
+    dAd = zeros((4,4), dtype=np.double)
     for i in range(1,4):
         Ad_i = Ad[:, i-1]
         dAd[:,i] = (4-i) * Ad_i
     
     global d2Ad
-    d2Ad = zeros((4,4))
+    d2Ad = zeros((4,4), dtype=np.double)
     for i in range(1,4):
         dAd_i = dAd[:, i-1]
         d2Ad[:,i] = (4-i) * dAd_i
@@ -631,3 +631,4 @@ def filter_data(dinv, data):
     elif len(dinv) == 3:
         return filter_coeffs_3d(dinv, data)
 
+compute_const()

--- a/flare/mgp/cubic_splines_numba.py
+++ b/flare/mgp/cubic_splines_numba.py
@@ -1,10 +1,27 @@
-from numba import jit, njit
-import time
+from numba import njit
 import numpy as np
 from numpy import zeros, array
 
 from math import floor
-from numpy import empty
+
+
+_Ad = array([
+    #      t^3       t^2        t        1
+    [-1.0 / 6.0, 3.0 / 6.0, -3.0 / 6.0, 1.0 / 6.0],
+    [3.0 / 6.0, -6.0 / 6.0, 0.0 / 6.0, 4.0 / 6.0],
+    [-3.0 / 6.0, 3.0 / 6.0, 3.0 / 6.0, 1.0 / 6.0],
+    [1.0 / 6.0, 0.0 / 6.0, 0.0 / 6.0, 0.0 / 6.0]
+])
+
+_dAd = zeros((4, 4), dtype=np.double)
+for i in range(1, 4):
+    Ad_i = _Ad[:, i - 1]
+    _dAd[:, i] = (4 - i) * Ad_i
+
+_d2Ad = zeros((4, 4), dtype=np.double)
+for i in range(1, 4):
+    dAd_i = _dAd[:, i - 1]
+    _d2Ad[:, i] = (4 - i) * dAd_i
 
 
 @njit(cache=True)
@@ -29,20 +46,20 @@ def vec_eval_cubic_spline_1(a, b, orders, coefs, points, out):
         Phi0_2 = 0
         Phi0_3 = 0
         if t0 < 0:
-            Phi0_0 = dAd[0,3]*t0 + Ad[0,3]
-            Phi0_1 = dAd[1,3]*t0 + Ad[1,3]
-            Phi0_2 = dAd[2,3]*t0 + Ad[2,3]
-            Phi0_3 = dAd[3,3]*t0 + Ad[3,3]
+            Phi0_0 = _dAd[0, 3] * t0 + _Ad[0, 3]
+            Phi0_1 = _dAd[1, 3] * t0 + _Ad[1, 3]
+            Phi0_2 = _dAd[2, 3] * t0 + _Ad[2, 3]
+            Phi0_3 = _dAd[3, 3] * t0 + _Ad[3, 3]
         elif t0 > 1:
-            Phi0_0 = (3*Ad[0,0] + 2*Ad[0,1] + Ad[0,2])*(t0-1) + (Ad[0,0]+Ad[0,1]+Ad[0,2]+Ad[0,3])
-            Phi0_1 = (3*Ad[1,0] + 2*Ad[1,1] + Ad[1,2])*(t0-1) + (Ad[1,0]+Ad[1,1]+Ad[1,2]+Ad[1,3])
-            Phi0_2 = (3*Ad[2,0] + 2*Ad[2,1] + Ad[2,2])*(t0-1) + (Ad[2,0]+Ad[2,1]+Ad[2,2]+Ad[2,3])
-            Phi0_3 = (3*Ad[3,0] + 2*Ad[3,1] + Ad[3,2])*(t0-1) + (Ad[3,0]+Ad[3,1]+Ad[3,2]+Ad[3,3])
+            Phi0_0 = (3 * _Ad[0, 0] + 2 * _Ad[0, 1] + _Ad[0, 2]) * (t0 - 1) + (_Ad[0, 0] + _Ad[0, 1] + _Ad[0, 2] + _Ad[0, 3])
+            Phi0_1 = (3 * _Ad[1, 0] + 2 * _Ad[1, 1] + _Ad[1, 2]) * (t0 - 1) + (_Ad[1, 0] + _Ad[1, 1] + _Ad[1, 2] + _Ad[1, 3])
+            Phi0_2 = (3 * _Ad[2, 0] + 2 * _Ad[2, 1] + _Ad[2, 2]) * (t0 - 1) + (_Ad[2, 0] + _Ad[2, 1] + _Ad[2, 2] + _Ad[2, 3])
+            Phi0_3 = (3 * _Ad[3, 0] + 2 * _Ad[3, 1] + _Ad[3, 2]) * (t0 - 1) + (_Ad[3, 0] + _Ad[3, 1] + _Ad[3, 2] + _Ad[3, 3])
         else:
-            Phi0_0 = (Ad[0,0]*tp0_0 + Ad[0,1]*tp0_1 + Ad[0,2]*tp0_2 + Ad[0,3]*tp0_3)
-            Phi0_1 = (Ad[1,0]*tp0_0 + Ad[1,1]*tp0_1 + Ad[1,2]*tp0_2 + Ad[1,3]*tp0_3)
-            Phi0_2 = (Ad[2,0]*tp0_0 + Ad[2,1]*tp0_1 + Ad[2,2]*tp0_2 + Ad[2,3]*tp0_3)
-            Phi0_3 = (Ad[3,0]*tp0_0 + Ad[3,1]*tp0_1 + Ad[3,2]*tp0_2 + Ad[3,3]*tp0_3)
+            Phi0_0 = (_Ad[0, 0] * tp0_0 + _Ad[0, 1] * tp0_1 + _Ad[0, 2] * tp0_2 + _Ad[0, 3] * tp0_3)
+            Phi0_1 = (_Ad[1, 0] * tp0_0 + _Ad[1, 1] * tp0_1 + _Ad[1, 2] * tp0_2 + _Ad[1, 3] * tp0_3)
+            Phi0_2 = (_Ad[2, 0] * tp0_0 + _Ad[2, 1] * tp0_1 + _Ad[2, 2] * tp0_2 + _Ad[2, 3] * tp0_3)
+            Phi0_3 = (_Ad[3, 0] * tp0_0 + _Ad[3, 1] * tp0_1 + _Ad[3, 2] * tp0_2 + _Ad[3, 3] * tp0_3)
 
 
         out[n] = Phi0_0*(coefs[i0+0]) + Phi0_1*(coefs[i0+1]) + Phi0_2*(coefs[i0+2]) + Phi0_3*(coefs[i0+3])
@@ -78,40 +95,40 @@ def vec_eval_cubic_spline_2(a, b, orders, coefs, points, out):
         Phi0_2 = 0
         Phi0_3 = 0
         if t0 < 0:
-            Phi0_0 = dAd[0,3]*t0 + Ad[0,3]
-            Phi0_1 = dAd[1,3]*t0 + Ad[1,3]
-            Phi0_2 = dAd[2,3]*t0 + Ad[2,3]
-            Phi0_3 = dAd[3,3]*t0 + Ad[3,3]
+            Phi0_0 = _dAd[0, 3] * t0 + _Ad[0, 3]
+            Phi0_1 = _dAd[1, 3] * t0 + _Ad[1, 3]
+            Phi0_2 = _dAd[2, 3] * t0 + _Ad[2, 3]
+            Phi0_3 = _dAd[3, 3] * t0 + _Ad[3, 3]
         elif t0 > 1:
-            Phi0_0 = (3*Ad[0,0] + 2*Ad[0,1] + Ad[0,2])*(t0-1) + (Ad[0,0]+Ad[0,1]+Ad[0,2]+Ad[0,3])
-            Phi0_1 = (3*Ad[1,0] + 2*Ad[1,1] + Ad[1,2])*(t0-1) + (Ad[1,0]+Ad[1,1]+Ad[1,2]+Ad[1,3])
-            Phi0_2 = (3*Ad[2,0] + 2*Ad[2,1] + Ad[2,2])*(t0-1) + (Ad[2,0]+Ad[2,1]+Ad[2,2]+Ad[2,3])
-            Phi0_3 = (3*Ad[3,0] + 2*Ad[3,1] + Ad[3,2])*(t0-1) + (Ad[3,0]+Ad[3,1]+Ad[3,2]+Ad[3,3])
+            Phi0_0 = (3 * _Ad[0, 0] + 2 * _Ad[0, 1] + _Ad[0, 2]) * (t0 - 1) + (_Ad[0, 0] + _Ad[0, 1] + _Ad[0, 2] + _Ad[0, 3])
+            Phi0_1 = (3 * _Ad[1, 0] + 2 * _Ad[1, 1] + _Ad[1, 2]) * (t0 - 1) + (_Ad[1, 0] + _Ad[1, 1] + _Ad[1, 2] + _Ad[1, 3])
+            Phi0_2 = (3 * _Ad[2, 0] + 2 * _Ad[2, 1] + _Ad[2, 2]) * (t0 - 1) + (_Ad[2, 0] + _Ad[2, 1] + _Ad[2, 2] + _Ad[2, 3])
+            Phi0_3 = (3 * _Ad[3, 0] + 2 * _Ad[3, 1] + _Ad[3, 2]) * (t0 - 1) + (_Ad[3, 0] + _Ad[3, 1] + _Ad[3, 2] + _Ad[3, 3])
         else:
-            Phi0_0 = (Ad[0,0]*tp0_0 + Ad[0,1]*tp0_1 + Ad[0,2]*tp0_2 + Ad[0,3]*tp0_3)
-            Phi0_1 = (Ad[1,0]*tp0_0 + Ad[1,1]*tp0_1 + Ad[1,2]*tp0_2 + Ad[1,3]*tp0_3)
-            Phi0_2 = (Ad[2,0]*tp0_0 + Ad[2,1]*tp0_1 + Ad[2,2]*tp0_2 + Ad[2,3]*tp0_3)
-            Phi0_3 = (Ad[3,0]*tp0_0 + Ad[3,1]*tp0_1 + Ad[3,2]*tp0_2 + Ad[3,3]*tp0_3)
+            Phi0_0 = (_Ad[0, 0] * tp0_0 + _Ad[0, 1] * tp0_1 + _Ad[0, 2] * tp0_2 + _Ad[0, 3] * tp0_3)
+            Phi0_1 = (_Ad[1, 0] * tp0_0 + _Ad[1, 1] * tp0_1 + _Ad[1, 2] * tp0_2 + _Ad[1, 3] * tp0_3)
+            Phi0_2 = (_Ad[2, 0] * tp0_0 + _Ad[2, 1] * tp0_1 + _Ad[2, 2] * tp0_2 + _Ad[2, 3] * tp0_3)
+            Phi0_3 = (_Ad[3, 0] * tp0_0 + _Ad[3, 1] * tp0_1 + _Ad[3, 2] * tp0_2 + _Ad[3, 3] * tp0_3)
 
         Phi1_0 = 0
         Phi1_1 = 0
         Phi1_2 = 0
         Phi1_3 = 0
         if t1 < 0:
-            Phi1_0 = dAd[0,3]*t1 + Ad[0,3]
-            Phi1_1 = dAd[1,3]*t1 + Ad[1,3]
-            Phi1_2 = dAd[2,3]*t1 + Ad[2,3]
-            Phi1_3 = dAd[3,3]*t1 + Ad[3,3]
+            Phi1_0 = _dAd[0, 3] * t1 + _Ad[0, 3]
+            Phi1_1 = _dAd[1, 3] * t1 + _Ad[1, 3]
+            Phi1_2 = _dAd[2, 3] * t1 + _Ad[2, 3]
+            Phi1_3 = _dAd[3, 3] * t1 + _Ad[3, 3]
         elif t1 > 1:
-            Phi1_0 = (3*Ad[0,0] + 2*Ad[0,1] + Ad[0,2])*(t1-1) + (Ad[0,0]+Ad[0,1]+Ad[0,2]+Ad[0,3])
-            Phi1_1 = (3*Ad[1,0] + 2*Ad[1,1] + Ad[1,2])*(t1-1) + (Ad[1,0]+Ad[1,1]+Ad[1,2]+Ad[1,3])
-            Phi1_2 = (3*Ad[2,0] + 2*Ad[2,1] + Ad[2,2])*(t1-1) + (Ad[2,0]+Ad[2,1]+Ad[2,2]+Ad[2,3])
-            Phi1_3 = (3*Ad[3,0] + 2*Ad[3,1] + Ad[3,2])*(t1-1) + (Ad[3,0]+Ad[3,1]+Ad[3,2]+Ad[3,3])
+            Phi1_0 = (3 * _Ad[0, 0] + 2 * _Ad[0, 1] + _Ad[0, 2]) * (t1 - 1) + (_Ad[0, 0] + _Ad[0, 1] + _Ad[0, 2] + _Ad[0, 3])
+            Phi1_1 = (3 * _Ad[1, 0] + 2 * _Ad[1, 1] + _Ad[1, 2]) * (t1 - 1) + (_Ad[1, 0] + _Ad[1, 1] + _Ad[1, 2] + _Ad[1, 3])
+            Phi1_2 = (3 * _Ad[2, 0] + 2 * _Ad[2, 1] + _Ad[2, 2]) * (t1 - 1) + (_Ad[2, 0] + _Ad[2, 1] + _Ad[2, 2] + _Ad[2, 3])
+            Phi1_3 = (3 * _Ad[3, 0] + 2 * _Ad[3, 1] + _Ad[3, 2]) * (t1 - 1) + (_Ad[3, 0] + _Ad[3, 1] + _Ad[3, 2] + _Ad[3, 3])
         else:
-            Phi1_0 = (Ad[0,0]*tp1_0 + Ad[0,1]*tp1_1 + Ad[0,2]*tp1_2 + Ad[0,3]*tp1_3)
-            Phi1_1 = (Ad[1,0]*tp1_0 + Ad[1,1]*tp1_1 + Ad[1,2]*tp1_2 + Ad[1,3]*tp1_3)
-            Phi1_2 = (Ad[2,0]*tp1_0 + Ad[2,1]*tp1_1 + Ad[2,2]*tp1_2 + Ad[2,3]*tp1_3)
-            Phi1_3 = (Ad[3,0]*tp1_0 + Ad[3,1]*tp1_1 + Ad[3,2]*tp1_2 + Ad[3,3]*tp1_3)
+            Phi1_0 = (_Ad[0, 0] * tp1_0 + _Ad[0, 1] * tp1_1 + _Ad[0, 2] * tp1_2 + _Ad[0, 3] * tp1_3)
+            Phi1_1 = (_Ad[1, 0] * tp1_0 + _Ad[1, 1] * tp1_1 + _Ad[1, 2] * tp1_2 + _Ad[1, 3] * tp1_3)
+            Phi1_2 = (_Ad[2, 0] * tp1_0 + _Ad[2, 1] * tp1_1 + _Ad[2, 2] * tp1_2 + _Ad[2, 3] * tp1_3)
+            Phi1_3 = (_Ad[3, 0] * tp1_0 + _Ad[3, 1] * tp1_1 + _Ad[3, 2] * tp1_2 + _Ad[3, 3] * tp1_3)
 
 
         out[n] = Phi0_0*(Phi1_0*(coefs[i0+0,i1+0]) + Phi1_1*(coefs[i0+0,i1+1]) + Phi1_2*(coefs[i0+0,i1+2]) + Phi1_3*(coefs[i0+0,i1+3])) + Phi0_1*(Phi1_0*(coefs[i0+1,i1+0]) + Phi1_1*(coefs[i0+1,i1+1]) + Phi1_2*(coefs[i0+1,i1+2]) + Phi1_3*(coefs[i0+1,i1+3])) + Phi0_2*(Phi1_0*(coefs[i0+2,i1+0]) + Phi1_1*(coefs[i0+2,i1+1]) + Phi1_2*(coefs[i0+2,i1+2]) + Phi1_3*(coefs[i0+2,i1+3])) + Phi0_3*(Phi1_0*(coefs[i0+3,i1+0]) + Phi1_1*(coefs[i0+3,i1+1]) + Phi1_2*(coefs[i0+3,i1+2]) + Phi1_3*(coefs[i0+3,i1+3]))
@@ -156,60 +173,60 @@ def vec_eval_cubic_spline_3(a, b, orders, coefs, points, out):
         Phi0_2 = 0
         Phi0_3 = 0
         if t0 < 0:
-            Phi0_0 = dAd[0,3]*t0 + Ad[0,3]
-            Phi0_1 = dAd[1,3]*t0 + Ad[1,3]
-            Phi0_2 = dAd[2,3]*t0 + Ad[2,3]
-            Phi0_3 = dAd[3,3]*t0 + Ad[3,3]
+            Phi0_0 = _dAd[0, 3] * t0 + _Ad[0, 3]
+            Phi0_1 = _dAd[1, 3] * t0 + _Ad[1, 3]
+            Phi0_2 = _dAd[2, 3] * t0 + _Ad[2, 3]
+            Phi0_3 = _dAd[3, 3] * t0 + _Ad[3, 3]
         elif t0 > 1:
-            Phi0_0 = (3*Ad[0,0] + 2*Ad[0,1] + Ad[0,2])*(t0-1) + (Ad[0,0]+Ad[0,1]+Ad[0,2]+Ad[0,3])
-            Phi0_1 = (3*Ad[1,0] + 2*Ad[1,1] + Ad[1,2])*(t0-1) + (Ad[1,0]+Ad[1,1]+Ad[1,2]+Ad[1,3])
-            Phi0_2 = (3*Ad[2,0] + 2*Ad[2,1] + Ad[2,2])*(t0-1) + (Ad[2,0]+Ad[2,1]+Ad[2,2]+Ad[2,3])
-            Phi0_3 = (3*Ad[3,0] + 2*Ad[3,1] + Ad[3,2])*(t0-1) + (Ad[3,0]+Ad[3,1]+Ad[3,2]+Ad[3,3])
+            Phi0_0 = (3 * _Ad[0, 0] + 2 * _Ad[0, 1] + _Ad[0, 2]) * (t0 - 1) + (_Ad[0, 0] + _Ad[0, 1] + _Ad[0, 2] + _Ad[0, 3])
+            Phi0_1 = (3 * _Ad[1, 0] + 2 * _Ad[1, 1] + _Ad[1, 2]) * (t0 - 1) + (_Ad[1, 0] + _Ad[1, 1] + _Ad[1, 2] + _Ad[1, 3])
+            Phi0_2 = (3 * _Ad[2, 0] + 2 * _Ad[2, 1] + _Ad[2, 2]) * (t0 - 1) + (_Ad[2, 0] + _Ad[2, 1] + _Ad[2, 2] + _Ad[2, 3])
+            Phi0_3 = (3 * _Ad[3, 0] + 2 * _Ad[3, 1] + _Ad[3, 2]) * (t0 - 1) + (_Ad[3, 0] + _Ad[3, 1] + _Ad[3, 2] + _Ad[3, 3])
         else:
-            Phi0_0 = (Ad[0,0]*tp0_0 + Ad[0,1]*tp0_1 + Ad[0,2]*tp0_2 + Ad[0,3]*tp0_3)
-            Phi0_1 = (Ad[1,0]*tp0_0 + Ad[1,1]*tp0_1 + Ad[1,2]*tp0_2 + Ad[1,3]*tp0_3)
-            Phi0_2 = (Ad[2,0]*tp0_0 + Ad[2,1]*tp0_1 + Ad[2,2]*tp0_2 + Ad[2,3]*tp0_3)
-            Phi0_3 = (Ad[3,0]*tp0_0 + Ad[3,1]*tp0_1 + Ad[3,2]*tp0_2 + Ad[3,3]*tp0_3)
+            Phi0_0 = (_Ad[0, 0] * tp0_0 + _Ad[0, 1] * tp0_1 + _Ad[0, 2] * tp0_2 + _Ad[0, 3] * tp0_3)
+            Phi0_1 = (_Ad[1, 0] * tp0_0 + _Ad[1, 1] * tp0_1 + _Ad[1, 2] * tp0_2 + _Ad[1, 3] * tp0_3)
+            Phi0_2 = (_Ad[2, 0] * tp0_0 + _Ad[2, 1] * tp0_1 + _Ad[2, 2] * tp0_2 + _Ad[2, 3] * tp0_3)
+            Phi0_3 = (_Ad[3, 0] * tp0_0 + _Ad[3, 1] * tp0_1 + _Ad[3, 2] * tp0_2 + _Ad[3, 3] * tp0_3)
 
         Phi1_0 = 0
         Phi1_1 = 0
         Phi1_2 = 0
         Phi1_3 = 0
         if t1 < 0:
-            Phi1_0 = dAd[0,3]*t1 + Ad[0,3]
-            Phi1_1 = dAd[1,3]*t1 + Ad[1,3]
-            Phi1_2 = dAd[2,3]*t1 + Ad[2,3]
-            Phi1_3 = dAd[3,3]*t1 + Ad[3,3]
+            Phi1_0 = _dAd[0, 3] * t1 + _Ad[0, 3]
+            Phi1_1 = _dAd[1, 3] * t1 + _Ad[1, 3]
+            Phi1_2 = _dAd[2, 3] * t1 + _Ad[2, 3]
+            Phi1_3 = _dAd[3, 3] * t1 + _Ad[3, 3]
         elif t1 > 1:
-            Phi1_0 = (3*Ad[0,0] + 2*Ad[0,1] + Ad[0,2])*(t1-1) + (Ad[0,0]+Ad[0,1]+Ad[0,2]+Ad[0,3])
-            Phi1_1 = (3*Ad[1,0] + 2*Ad[1,1] + Ad[1,2])*(t1-1) + (Ad[1,0]+Ad[1,1]+Ad[1,2]+Ad[1,3])
-            Phi1_2 = (3*Ad[2,0] + 2*Ad[2,1] + Ad[2,2])*(t1-1) + (Ad[2,0]+Ad[2,1]+Ad[2,2]+Ad[2,3])
-            Phi1_3 = (3*Ad[3,0] + 2*Ad[3,1] + Ad[3,2])*(t1-1) + (Ad[3,0]+Ad[3,1]+Ad[3,2]+Ad[3,3])
+            Phi1_0 = (3 * _Ad[0, 0] + 2 * _Ad[0, 1] + _Ad[0, 2]) * (t1 - 1) + (_Ad[0, 0] + _Ad[0, 1] + _Ad[0, 2] + _Ad[0, 3])
+            Phi1_1 = (3 * _Ad[1, 0] + 2 * _Ad[1, 1] + _Ad[1, 2]) * (t1 - 1) + (_Ad[1, 0] + _Ad[1, 1] + _Ad[1, 2] + _Ad[1, 3])
+            Phi1_2 = (3 * _Ad[2, 0] + 2 * _Ad[2, 1] + _Ad[2, 2]) * (t1 - 1) + (_Ad[2, 0] + _Ad[2, 1] + _Ad[2, 2] + _Ad[2, 3])
+            Phi1_3 = (3 * _Ad[3, 0] + 2 * _Ad[3, 1] + _Ad[3, 2]) * (t1 - 1) + (_Ad[3, 0] + _Ad[3, 1] + _Ad[3, 2] + _Ad[3, 3])
         else:
-            Phi1_0 = (Ad[0,0]*tp1_0 + Ad[0,1]*tp1_1 + Ad[0,2]*tp1_2 + Ad[0,3]*tp1_3)
-            Phi1_1 = (Ad[1,0]*tp1_0 + Ad[1,1]*tp1_1 + Ad[1,2]*tp1_2 + Ad[1,3]*tp1_3)
-            Phi1_2 = (Ad[2,0]*tp1_0 + Ad[2,1]*tp1_1 + Ad[2,2]*tp1_2 + Ad[2,3]*tp1_3)
-            Phi1_3 = (Ad[3,0]*tp1_0 + Ad[3,1]*tp1_1 + Ad[3,2]*tp1_2 + Ad[3,3]*tp1_3)
+            Phi1_0 = (_Ad[0, 0] * tp1_0 + _Ad[0, 1] * tp1_1 + _Ad[0, 2] * tp1_2 + _Ad[0, 3] * tp1_3)
+            Phi1_1 = (_Ad[1, 0] * tp1_0 + _Ad[1, 1] * tp1_1 + _Ad[1, 2] * tp1_2 + _Ad[1, 3] * tp1_3)
+            Phi1_2 = (_Ad[2, 0] * tp1_0 + _Ad[2, 1] * tp1_1 + _Ad[2, 2] * tp1_2 + _Ad[2, 3] * tp1_3)
+            Phi1_3 = (_Ad[3, 0] * tp1_0 + _Ad[3, 1] * tp1_1 + _Ad[3, 2] * tp1_2 + _Ad[3, 3] * tp1_3)
 
         Phi2_0 = 0
         Phi2_1 = 0
         Phi2_2 = 0
         Phi2_3 = 0
         if t2 < 0:
-            Phi2_0 = dAd[0,3]*t2 + Ad[0,3]
-            Phi2_1 = dAd[1,3]*t2 + Ad[1,3]
-            Phi2_2 = dAd[2,3]*t2 + Ad[2,3]
-            Phi2_3 = dAd[3,3]*t2 + Ad[3,3]
+            Phi2_0 = _dAd[0, 3] * t2 + _Ad[0, 3]
+            Phi2_1 = _dAd[1, 3] * t2 + _Ad[1, 3]
+            Phi2_2 = _dAd[2, 3] * t2 + _Ad[2, 3]
+            Phi2_3 = _dAd[3, 3] * t2 + _Ad[3, 3]
         elif t2 > 1:
-            Phi2_0 = (3*Ad[0,0] + 2*Ad[0,1] + Ad[0,2])*(t2-1) + (Ad[0,0]+Ad[0,1]+Ad[0,2]+Ad[0,3])
-            Phi2_1 = (3*Ad[1,0] + 2*Ad[1,1] + Ad[1,2])*(t2-1) + (Ad[1,0]+Ad[1,1]+Ad[1,2]+Ad[1,3])
-            Phi2_2 = (3*Ad[2,0] + 2*Ad[2,1] + Ad[2,2])*(t2-1) + (Ad[2,0]+Ad[2,1]+Ad[2,2]+Ad[2,3])
-            Phi2_3 = (3*Ad[3,0] + 2*Ad[3,1] + Ad[3,2])*(t2-1) + (Ad[3,0]+Ad[3,1]+Ad[3,2]+Ad[3,3])
+            Phi2_0 = (3 * _Ad[0, 0] + 2 * _Ad[0, 1] + _Ad[0, 2]) * (t2 - 1) + (_Ad[0, 0] + _Ad[0, 1] + _Ad[0, 2] + _Ad[0, 3])
+            Phi2_1 = (3 * _Ad[1, 0] + 2 * _Ad[1, 1] + _Ad[1, 2]) * (t2 - 1) + (_Ad[1, 0] + _Ad[1, 1] + _Ad[1, 2] + _Ad[1, 3])
+            Phi2_2 = (3 * _Ad[2, 0] + 2 * _Ad[2, 1] + _Ad[2, 2]) * (t2 - 1) + (_Ad[2, 0] + _Ad[2, 1] + _Ad[2, 2] + _Ad[2, 3])
+            Phi2_3 = (3 * _Ad[3, 0] + 2 * _Ad[3, 1] + _Ad[3, 2]) * (t2 - 1) + (_Ad[3, 0] + _Ad[3, 1] + _Ad[3, 2] + _Ad[3, 3])
         else:
-            Phi2_0 = (Ad[0,0]*tp2_0 + Ad[0,1]*tp2_1 + Ad[0,2]*tp2_2 + Ad[0,3]*tp2_3)
-            Phi2_1 = (Ad[1,0]*tp2_0 + Ad[1,1]*tp2_1 + Ad[1,2]*tp2_2 + Ad[1,3]*tp2_3)
-            Phi2_2 = (Ad[2,0]*tp2_0 + Ad[2,1]*tp2_1 + Ad[2,2]*tp2_2 + Ad[2,3]*tp2_3)
-            Phi2_3 = (Ad[3,0]*tp2_0 + Ad[3,1]*tp2_1 + Ad[3,2]*tp2_2 + Ad[3,3]*tp2_3)
+            Phi2_0 = (_Ad[0, 0] * tp2_0 + _Ad[0, 1] * tp2_1 + _Ad[0, 2] * tp2_2 + _Ad[0, 3] * tp2_3)
+            Phi2_1 = (_Ad[1, 0] * tp2_0 + _Ad[1, 1] * tp2_1 + _Ad[1, 2] * tp2_2 + _Ad[1, 3] * tp2_3)
+            Phi2_2 = (_Ad[2, 0] * tp2_0 + _Ad[2, 1] * tp2_1 + _Ad[2, 2] * tp2_2 + _Ad[2, 3] * tp2_3)
+            Phi2_3 = (_Ad[3, 0] * tp2_0 + _Ad[3, 1] * tp2_1 + _Ad[3, 2] * tp2_2 + _Ad[3, 3] * tp2_3)
 
 
         out[n] = Phi0_0*(Phi1_0*(Phi2_0*(coefs[i0+0,i1+0,i2+0]) + Phi2_1*(coefs[i0+0,i1+0,i2+1]) + Phi2_2*(coefs[i0+0,i1+0,i2+2]) + Phi2_3*(coefs[i0+0,i1+0,i2+3])) + Phi1_1*(Phi2_0*(coefs[i0+0,i1+1,i2+0]) + Phi2_1*(coefs[i0+0,i1+1,i2+1]) + Phi2_2*(coefs[i0+0,i1+1,i2+2]) + Phi2_3*(coefs[i0+0,i1+1,i2+3])) + Phi1_2*(Phi2_0*(coefs[i0+0,i1+2,i2+0]) + Phi2_1*(coefs[i0+0,i1+2,i2+1]) + Phi2_2*(coefs[i0+0,i1+2,i2+2]) + Phi2_3*(coefs[i0+0,i1+2,i2+3])) + Phi1_3*(Phi2_0*(coefs[i0+0,i1+3,i2+0]) + Phi2_1*(coefs[i0+0,i1+3,i2+1]) + Phi2_2*(coefs[i0+0,i1+3,i2+2]) + Phi2_3*(coefs[i0+0,i1+3,i2+3]))) + Phi0_1*(Phi1_0*(Phi2_0*(coefs[i0+1,i1+0,i2+0]) + Phi2_1*(coefs[i0+1,i1+0,i2+1]) + Phi2_2*(coefs[i0+1,i1+0,i2+2]) + Phi2_3*(coefs[i0+1,i1+0,i2+3])) + Phi1_1*(Phi2_0*(coefs[i0+1,i1+1,i2+0]) + Phi2_1*(coefs[i0+1,i1+1,i2+1]) + Phi2_2*(coefs[i0+1,i1+1,i2+2]) + Phi2_3*(coefs[i0+1,i1+1,i2+3])) + Phi1_2*(Phi2_0*(coefs[i0+1,i1+2,i2+0]) + Phi2_1*(coefs[i0+1,i1+2,i2+1]) + Phi2_2*(coefs[i0+1,i1+2,i2+2]) + Phi2_3*(coefs[i0+1,i1+2,i2+3])) + Phi1_3*(Phi2_0*(coefs[i0+1,i1+3,i2+0]) + Phi2_1*(coefs[i0+1,i1+3,i2+1]) + Phi2_2*(coefs[i0+1,i1+3,i2+2]) + Phi2_3*(coefs[i0+1,i1+3,i2+3]))) + Phi0_2*(Phi1_0*(Phi2_0*(coefs[i0+2,i1+0,i2+0]) + Phi2_1*(coefs[i0+2,i1+0,i2+1]) + Phi2_2*(coefs[i0+2,i1+0,i2+2]) + Phi2_3*(coefs[i0+2,i1+0,i2+3])) + Phi1_1*(Phi2_0*(coefs[i0+2,i1+1,i2+0]) + Phi2_1*(coefs[i0+2,i1+1,i2+1]) + Phi2_2*(coefs[i0+2,i1+1,i2+2]) + Phi2_3*(coefs[i0+2,i1+1,i2+3])) + Phi1_2*(Phi2_0*(coefs[i0+2,i1+2,i2+0]) + Phi2_1*(coefs[i0+2,i1+2,i2+1]) + Phi2_2*(coefs[i0+2,i1+2,i2+2]) + Phi2_3*(coefs[i0+2,i1+2,i2+3])) + Phi1_3*(Phi2_0*(coefs[i0+2,i1+3,i2+0]) + Phi2_1*(coefs[i0+2,i1+3,i2+1]) + Phi2_2*(coefs[i0+2,i1+3,i2+2]) + Phi2_3*(coefs[i0+2,i1+3,i2+3]))) + Phi0_3*(Phi1_0*(Phi2_0*(coefs[i0+3,i1+0,i2+0]) + Phi2_1*(coefs[i0+3,i1+0,i2+1]) + Phi2_2*(coefs[i0+3,i1+0,i2+2]) + Phi2_3*(coefs[i0+3,i1+0,i2+3])) + Phi1_1*(Phi2_0*(coefs[i0+3,i1+1,i2+0]) + Phi2_1*(coefs[i0+3,i1+1,i2+1]) + Phi2_2*(coefs[i0+3,i1+1,i2+2]) + Phi2_3*(coefs[i0+3,i1+1,i2+3])) + Phi1_2*(Phi2_0*(coefs[i0+3,i1+2,i2+0]) + Phi2_1*(coefs[i0+3,i1+2,i2+1]) + Phi2_2*(coefs[i0+3,i1+2,i2+2]) + Phi2_3*(coefs[i0+3,i1+2,i2+3])) + Phi1_3*(Phi2_0*(coefs[i0+3,i1+3,i2+0]) + Phi2_1*(coefs[i0+3,i1+3,i2+1]) + Phi2_2*(coefs[i0+3,i1+3,i2+2]) + Phi2_3*(coefs[i0+3,i1+3,i2+3])))
@@ -239,24 +256,24 @@ def vec_eval_cubic_splines_G_1(a, b, orders, coefs, points, vals, dvals):
         Phi0_2 = 0
         Phi0_3 = 0
         if t0 < 0:
-            Phi0_0 = dAd[0,3]*t0 + Ad[0,3]
-            Phi0_1 = dAd[1,3]*t0 + Ad[1,3]
-            Phi0_2 = dAd[2,3]*t0 + Ad[2,3]
-            Phi0_3 = dAd[3,3]*t0 + Ad[3,3]
+            Phi0_0 = _dAd[0, 3] * t0 + _Ad[0, 3]
+            Phi0_1 = _dAd[1, 3] * t0 + _Ad[1, 3]
+            Phi0_2 = _dAd[2, 3] * t0 + _Ad[2, 3]
+            Phi0_3 = _dAd[3, 3] * t0 + _Ad[3, 3]
         elif t0 > 1:
-            Phi0_0 = (3*Ad[0,0] + 2*Ad[0,1] + Ad[0,2])*(t0-1) + (Ad[0,0]+Ad[0,1]+Ad[0,2]+Ad[0,3])
-            Phi0_1 = (3*Ad[1,0] + 2*Ad[1,1] + Ad[1,2])*(t0-1) + (Ad[1,0]+Ad[1,1]+Ad[1,2]+Ad[1,3])
-            Phi0_2 = (3*Ad[2,0] + 2*Ad[2,1] + Ad[2,2])*(t0-1) + (Ad[2,0]+Ad[2,1]+Ad[2,2]+Ad[2,3])
-            Phi0_3 = (3*Ad[3,0] + 2*Ad[3,1] + Ad[3,2])*(t0-1) + (Ad[3,0]+Ad[3,1]+Ad[3,2]+Ad[3,3])
+            Phi0_0 = (3 * _Ad[0, 0] + 2 * _Ad[0, 1] + _Ad[0, 2]) * (t0 - 1) + (_Ad[0, 0] + _Ad[0, 1] + _Ad[0, 2] + _Ad[0, 3])
+            Phi0_1 = (3 * _Ad[1, 0] + 2 * _Ad[1, 1] + _Ad[1, 2]) * (t0 - 1) + (_Ad[1, 0] + _Ad[1, 1] + _Ad[1, 2] + _Ad[1, 3])
+            Phi0_2 = (3 * _Ad[2, 0] + 2 * _Ad[2, 1] + _Ad[2, 2]) * (t0 - 1) + (_Ad[2, 0] + _Ad[2, 1] + _Ad[2, 2] + _Ad[2, 3])
+            Phi0_3 = (3 * _Ad[3, 0] + 2 * _Ad[3, 1] + _Ad[3, 2]) * (t0 - 1) + (_Ad[3, 0] + _Ad[3, 1] + _Ad[3, 2] + _Ad[3, 3])
         else:
-            Phi0_0 = (Ad[0,0]*tp0_0 + Ad[0,1]*tp0_1 + Ad[0,2]*tp0_2 + Ad[0,3]*tp0_3)
-            Phi0_1 = (Ad[1,0]*tp0_0 + Ad[1,1]*tp0_1 + Ad[1,2]*tp0_2 + Ad[1,3]*tp0_3)
-            Phi0_2 = (Ad[2,0]*tp0_0 + Ad[2,1]*tp0_1 + Ad[2,2]*tp0_2 + Ad[2,3]*tp0_3)
-            Phi0_3 = (Ad[3,0]*tp0_0 + Ad[3,1]*tp0_1 + Ad[3,2]*tp0_2 + Ad[3,3]*tp0_3)
-        dPhi0_0 = (dAd[0,0]*tp0_0 + dAd[0,1]*tp0_1 + dAd[0,2]*tp0_2 + dAd[0,3]*tp0_3)*dinv0
-        dPhi0_1 = (dAd[1,0]*tp0_0 + dAd[1,1]*tp0_1 + dAd[1,2]*tp0_2 + dAd[1,3]*tp0_3)*dinv0
-        dPhi0_2 = (dAd[2,0]*tp0_0 + dAd[2,1]*tp0_1 + dAd[2,2]*tp0_2 + dAd[2,3]*tp0_3)*dinv0
-        dPhi0_3 = (dAd[3,0]*tp0_0 + dAd[3,1]*tp0_1 + dAd[3,2]*tp0_2 + dAd[3,3]*tp0_3)*dinv0
+            Phi0_0 = (_Ad[0, 0] * tp0_0 + _Ad[0, 1] * tp0_1 + _Ad[0, 2] * tp0_2 + _Ad[0, 3] * tp0_3)
+            Phi0_1 = (_Ad[1, 0] * tp0_0 + _Ad[1, 1] * tp0_1 + _Ad[1, 2] * tp0_2 + _Ad[1, 3] * tp0_3)
+            Phi0_2 = (_Ad[2, 0] * tp0_0 + _Ad[2, 1] * tp0_1 + _Ad[2, 2] * tp0_2 + _Ad[2, 3] * tp0_3)
+            Phi0_3 = (_Ad[3, 0] * tp0_0 + _Ad[3, 1] * tp0_1 + _Ad[3, 2] * tp0_2 + _Ad[3, 3] * tp0_3)
+        dPhi0_0 = (_dAd[0, 0] * tp0_0 + _dAd[0, 1] * tp0_1 + _dAd[0, 2] * tp0_2 + _dAd[0, 3] * tp0_3) * dinv0
+        dPhi0_1 = (_dAd[1, 0] * tp0_0 + _dAd[1, 1] * tp0_1 + _dAd[1, 2] * tp0_2 + _dAd[1, 3] * tp0_3) * dinv0
+        dPhi0_2 = (_dAd[2, 0] * tp0_0 + _dAd[2, 1] * tp0_1 + _dAd[2, 2] * tp0_2 + _dAd[2, 3] * tp0_3) * dinv0
+        dPhi0_3 = (_dAd[3, 0] * tp0_0 + _dAd[3, 1] * tp0_1 + _dAd[3, 2] * tp0_2 + _dAd[3, 3] * tp0_3) * dinv0
 
         vals[n, 0] = Phi0_0*(coefs[i0+0]) + Phi0_1*(coefs[i0+1]) + Phi0_2*(coefs[i0+2]) + Phi0_3*(coefs[i0+3])
         dvals[n, 0, 0] = dPhi0_0*(coefs[i0+0]) + dPhi0_1*(coefs[i0+1]) + dPhi0_2*(coefs[i0+2]) + dPhi0_3*(coefs[i0+3])
@@ -306,70 +323,70 @@ def vec_eval_cubic_splines_G_3(a, b, orders, coefs, points, vals, dvals):
         Phi0_2 = 0
         Phi0_3 = 0
         if t0 < 0:
-            Phi0_0 = dAd[0,3]*t0 + Ad[0,3]
-            Phi0_1 = dAd[1,3]*t0 + Ad[1,3]
-            Phi0_2 = dAd[2,3]*t0 + Ad[2,3]
-            Phi0_3 = dAd[3,3]*t0 + Ad[3,3]
+            Phi0_0 = _dAd[0, 3] * t0 + _Ad[0, 3]
+            Phi0_1 = _dAd[1, 3] * t0 + _Ad[1, 3]
+            Phi0_2 = _dAd[2, 3] * t0 + _Ad[2, 3]
+            Phi0_3 = _dAd[3, 3] * t0 + _Ad[3, 3]
         elif t0 > 1:
-            Phi0_0 = (3*Ad[0,0] + 2*Ad[0,1] + Ad[0,2])*(t0-1) + (Ad[0,0]+Ad[0,1]+Ad[0,2]+Ad[0,3])
-            Phi0_1 = (3*Ad[1,0] + 2*Ad[1,1] + Ad[1,2])*(t0-1) + (Ad[1,0]+Ad[1,1]+Ad[1,2]+Ad[1,3])
-            Phi0_2 = (3*Ad[2,0] + 2*Ad[2,1] + Ad[2,2])*(t0-1) + (Ad[2,0]+Ad[2,1]+Ad[2,2]+Ad[2,3])
-            Phi0_3 = (3*Ad[3,0] + 2*Ad[3,1] + Ad[3,2])*(t0-1) + (Ad[3,0]+Ad[3,1]+Ad[3,2]+Ad[3,3])
+            Phi0_0 = (3 * _Ad[0, 0] + 2 * _Ad[0, 1] + _Ad[0, 2]) * (t0 - 1) + (_Ad[0, 0] + _Ad[0, 1] + _Ad[0, 2] + _Ad[0, 3])
+            Phi0_1 = (3 * _Ad[1, 0] + 2 * _Ad[1, 1] + _Ad[1, 2]) * (t0 - 1) + (_Ad[1, 0] + _Ad[1, 1] + _Ad[1, 2] + _Ad[1, 3])
+            Phi0_2 = (3 * _Ad[2, 0] + 2 * _Ad[2, 1] + _Ad[2, 2]) * (t0 - 1) + (_Ad[2, 0] + _Ad[2, 1] + _Ad[2, 2] + _Ad[2, 3])
+            Phi0_3 = (3 * _Ad[3, 0] + 2 * _Ad[3, 1] + _Ad[3, 2]) * (t0 - 1) + (_Ad[3, 0] + _Ad[3, 1] + _Ad[3, 2] + _Ad[3, 3])
         else:
-            Phi0_0 = (Ad[0,0]*tp0_0 + Ad[0,1]*tp0_1 + Ad[0,2]*tp0_2 + Ad[0,3]*tp0_3)
-            Phi0_1 = (Ad[1,0]*tp0_0 + Ad[1,1]*tp0_1 + Ad[1,2]*tp0_2 + Ad[1,3]*tp0_3)
-            Phi0_2 = (Ad[2,0]*tp0_0 + Ad[2,1]*tp0_1 + Ad[2,2]*tp0_2 + Ad[2,3]*tp0_3)
-            Phi0_3 = (Ad[3,0]*tp0_0 + Ad[3,1]*tp0_1 + Ad[3,2]*tp0_2 + Ad[3,3]*tp0_3)
+            Phi0_0 = (_Ad[0, 0] * tp0_0 + _Ad[0, 1] * tp0_1 + _Ad[0, 2] * tp0_2 + _Ad[0, 3] * tp0_3)
+            Phi0_1 = (_Ad[1, 0] * tp0_0 + _Ad[1, 1] * tp0_1 + _Ad[1, 2] * tp0_2 + _Ad[1, 3] * tp0_3)
+            Phi0_2 = (_Ad[2, 0] * tp0_0 + _Ad[2, 1] * tp0_1 + _Ad[2, 2] * tp0_2 + _Ad[2, 3] * tp0_3)
+            Phi0_3 = (_Ad[3, 0] * tp0_0 + _Ad[3, 1] * tp0_1 + _Ad[3, 2] * tp0_2 + _Ad[3, 3] * tp0_3)
         Phi1_0 = 0
         Phi1_1 = 0
         Phi1_2 = 0
         Phi1_3 = 0
         if t1 < 0:
-            Phi1_0 = dAd[0,3]*t1 + Ad[0,3]
-            Phi1_1 = dAd[1,3]*t1 + Ad[1,3]
-            Phi1_2 = dAd[2,3]*t1 + Ad[2,3]
-            Phi1_3 = dAd[3,3]*t1 + Ad[3,3]
+            Phi1_0 = _dAd[0, 3] * t1 + _Ad[0, 3]
+            Phi1_1 = _dAd[1, 3] * t1 + _Ad[1, 3]
+            Phi1_2 = _dAd[2, 3] * t1 + _Ad[2, 3]
+            Phi1_3 = _dAd[3, 3] * t1 + _Ad[3, 3]
         elif t1 > 1:
-            Phi1_0 = (3*Ad[0,0] + 2*Ad[0,1] + Ad[0,2])*(t1-1) + (Ad[0,0]+Ad[0,1]+Ad[0,2]+Ad[0,3])
-            Phi1_1 = (3*Ad[1,0] + 2*Ad[1,1] + Ad[1,2])*(t1-1) + (Ad[1,0]+Ad[1,1]+Ad[1,2]+Ad[1,3])
-            Phi1_2 = (3*Ad[2,0] + 2*Ad[2,1] + Ad[2,2])*(t1-1) + (Ad[2,0]+Ad[2,1]+Ad[2,2]+Ad[2,3])
-            Phi1_3 = (3*Ad[3,0] + 2*Ad[3,1] + Ad[3,2])*(t1-1) + (Ad[3,0]+Ad[3,1]+Ad[3,2]+Ad[3,3])
+            Phi1_0 = (3 * _Ad[0, 0] + 2 * _Ad[0, 1] + _Ad[0, 2]) * (t1 - 1) + (_Ad[0, 0] + _Ad[0, 1] + _Ad[0, 2] + _Ad[0, 3])
+            Phi1_1 = (3 * _Ad[1, 0] + 2 * _Ad[1, 1] + _Ad[1, 2]) * (t1 - 1) + (_Ad[1, 0] + _Ad[1, 1] + _Ad[1, 2] + _Ad[1, 3])
+            Phi1_2 = (3 * _Ad[2, 0] + 2 * _Ad[2, 1] + _Ad[2, 2]) * (t1 - 1) + (_Ad[2, 0] + _Ad[2, 1] + _Ad[2, 2] + _Ad[2, 3])
+            Phi1_3 = (3 * _Ad[3, 0] + 2 * _Ad[3, 1] + _Ad[3, 2]) * (t1 - 1) + (_Ad[3, 0] + _Ad[3, 1] + _Ad[3, 2] + _Ad[3, 3])
         else:
-            Phi1_0 = (Ad[0,0]*tp1_0 + Ad[0,1]*tp1_1 + Ad[0,2]*tp1_2 + Ad[0,3]*tp1_3)
-            Phi1_1 = (Ad[1,0]*tp1_0 + Ad[1,1]*tp1_1 + Ad[1,2]*tp1_2 + Ad[1,3]*tp1_3)
-            Phi1_2 = (Ad[2,0]*tp1_0 + Ad[2,1]*tp1_1 + Ad[2,2]*tp1_2 + Ad[2,3]*tp1_3)
-            Phi1_3 = (Ad[3,0]*tp1_0 + Ad[3,1]*tp1_1 + Ad[3,2]*tp1_2 + Ad[3,3]*tp1_3)
+            Phi1_0 = (_Ad[0, 0] * tp1_0 + _Ad[0, 1] * tp1_1 + _Ad[0, 2] * tp1_2 + _Ad[0, 3] * tp1_3)
+            Phi1_1 = (_Ad[1, 0] * tp1_0 + _Ad[1, 1] * tp1_1 + _Ad[1, 2] * tp1_2 + _Ad[1, 3] * tp1_3)
+            Phi1_2 = (_Ad[2, 0] * tp1_0 + _Ad[2, 1] * tp1_1 + _Ad[2, 2] * tp1_2 + _Ad[2, 3] * tp1_3)
+            Phi1_3 = (_Ad[3, 0] * tp1_0 + _Ad[3, 1] * tp1_1 + _Ad[3, 2] * tp1_2 + _Ad[3, 3] * tp1_3)
         Phi2_0 = 0
         Phi2_1 = 0
         Phi2_2 = 0
         Phi2_3 = 0
         if t2 < 0:
-            Phi2_0 = dAd[0,3]*t2 + Ad[0,3]
-            Phi2_1 = dAd[1,3]*t2 + Ad[1,3]
-            Phi2_2 = dAd[2,3]*t2 + Ad[2,3]
-            Phi2_3 = dAd[3,3]*t2 + Ad[3,3]
+            Phi2_0 = _dAd[0, 3] * t2 + _Ad[0, 3]
+            Phi2_1 = _dAd[1, 3] * t2 + _Ad[1, 3]
+            Phi2_2 = _dAd[2, 3] * t2 + _Ad[2, 3]
+            Phi2_3 = _dAd[3, 3] * t2 + _Ad[3, 3]
         elif t2 > 1:
-            Phi2_0 = (3*Ad[0,0] + 2*Ad[0,1] + Ad[0,2])*(t2-1) + (Ad[0,0]+Ad[0,1]+Ad[0,2]+Ad[0,3])
-            Phi2_1 = (3*Ad[1,0] + 2*Ad[1,1] + Ad[1,2])*(t2-1) + (Ad[1,0]+Ad[1,1]+Ad[1,2]+Ad[1,3])
-            Phi2_2 = (3*Ad[2,0] + 2*Ad[2,1] + Ad[2,2])*(t2-1) + (Ad[2,0]+Ad[2,1]+Ad[2,2]+Ad[2,3])
-            Phi2_3 = (3*Ad[3,0] + 2*Ad[3,1] + Ad[3,2])*(t2-1) + (Ad[3,0]+Ad[3,1]+Ad[3,2]+Ad[3,3])
+            Phi2_0 = (3 * _Ad[0, 0] + 2 * _Ad[0, 1] + _Ad[0, 2]) * (t2 - 1) + (_Ad[0, 0] + _Ad[0, 1] + _Ad[0, 2] + _Ad[0, 3])
+            Phi2_1 = (3 * _Ad[1, 0] + 2 * _Ad[1, 1] + _Ad[1, 2]) * (t2 - 1) + (_Ad[1, 0] + _Ad[1, 1] + _Ad[1, 2] + _Ad[1, 3])
+            Phi2_2 = (3 * _Ad[2, 0] + 2 * _Ad[2, 1] + _Ad[2, 2]) * (t2 - 1) + (_Ad[2, 0] + _Ad[2, 1] + _Ad[2, 2] + _Ad[2, 3])
+            Phi2_3 = (3 * _Ad[3, 0] + 2 * _Ad[3, 1] + _Ad[3, 2]) * (t2 - 1) + (_Ad[3, 0] + _Ad[3, 1] + _Ad[3, 2] + _Ad[3, 3])
         else:
-            Phi2_0 = (Ad[0,0]*tp2_0 + Ad[0,1]*tp2_1 + Ad[0,2]*tp2_2 + Ad[0,3]*tp2_3)
-            Phi2_1 = (Ad[1,0]*tp2_0 + Ad[1,1]*tp2_1 + Ad[1,2]*tp2_2 + Ad[1,3]*tp2_3)
-            Phi2_2 = (Ad[2,0]*tp2_0 + Ad[2,1]*tp2_1 + Ad[2,2]*tp2_2 + Ad[2,3]*tp2_3)
-            Phi2_3 = (Ad[3,0]*tp2_0 + Ad[3,1]*tp2_1 + Ad[3,2]*tp2_2 + Ad[3,3]*tp2_3)
-        dPhi0_0 = (dAd[0,0]*tp0_0 + dAd[0,1]*tp0_1 + dAd[0,2]*tp0_2 + dAd[0,3]*tp0_3)*dinv0
-        dPhi0_1 = (dAd[1,0]*tp0_0 + dAd[1,1]*tp0_1 + dAd[1,2]*tp0_2 + dAd[1,3]*tp0_3)*dinv0
-        dPhi0_2 = (dAd[2,0]*tp0_0 + dAd[2,1]*tp0_1 + dAd[2,2]*tp0_2 + dAd[2,3]*tp0_3)*dinv0
-        dPhi0_3 = (dAd[3,0]*tp0_0 + dAd[3,1]*tp0_1 + dAd[3,2]*tp0_2 + dAd[3,3]*tp0_3)*dinv0
-        dPhi1_0 = (dAd[0,0]*tp1_0 + dAd[0,1]*tp1_1 + dAd[0,2]*tp1_2 + dAd[0,3]*tp1_3)*dinv1
-        dPhi1_1 = (dAd[1,0]*tp1_0 + dAd[1,1]*tp1_1 + dAd[1,2]*tp1_2 + dAd[1,3]*tp1_3)*dinv1
-        dPhi1_2 = (dAd[2,0]*tp1_0 + dAd[2,1]*tp1_1 + dAd[2,2]*tp1_2 + dAd[2,3]*tp1_3)*dinv1
-        dPhi1_3 = (dAd[3,0]*tp1_0 + dAd[3,1]*tp1_1 + dAd[3,2]*tp1_2 + dAd[3,3]*tp1_3)*dinv1
-        dPhi2_0 = (dAd[0,0]*tp2_0 + dAd[0,1]*tp2_1 + dAd[0,2]*tp2_2 + dAd[0,3]*tp2_3)*dinv2
-        dPhi2_1 = (dAd[1,0]*tp2_0 + dAd[1,1]*tp2_1 + dAd[1,2]*tp2_2 + dAd[1,3]*tp2_3)*dinv2
-        dPhi2_2 = (dAd[2,0]*tp2_0 + dAd[2,1]*tp2_1 + dAd[2,2]*tp2_2 + dAd[2,3]*tp2_3)*dinv2
-        dPhi2_3 = (dAd[3,0]*tp2_0 + dAd[3,1]*tp2_1 + dAd[3,2]*tp2_2 + dAd[3,3]*tp2_3)*dinv2
+            Phi2_0 = (_Ad[0, 0] * tp2_0 + _Ad[0, 1] * tp2_1 + _Ad[0, 2] * tp2_2 + _Ad[0, 3] * tp2_3)
+            Phi2_1 = (_Ad[1, 0] * tp2_0 + _Ad[1, 1] * tp2_1 + _Ad[1, 2] * tp2_2 + _Ad[1, 3] * tp2_3)
+            Phi2_2 = (_Ad[2, 0] * tp2_0 + _Ad[2, 1] * tp2_1 + _Ad[2, 2] * tp2_2 + _Ad[2, 3] * tp2_3)
+            Phi2_3 = (_Ad[3, 0] * tp2_0 + _Ad[3, 1] * tp2_1 + _Ad[3, 2] * tp2_2 + _Ad[3, 3] * tp2_3)
+        dPhi0_0 = (_dAd[0, 0] * tp0_0 + _dAd[0, 1] * tp0_1 + _dAd[0, 2] * tp0_2 + _dAd[0, 3] * tp0_3) * dinv0
+        dPhi0_1 = (_dAd[1, 0] * tp0_0 + _dAd[1, 1] * tp0_1 + _dAd[1, 2] * tp0_2 + _dAd[1, 3] * tp0_3) * dinv0
+        dPhi0_2 = (_dAd[2, 0] * tp0_0 + _dAd[2, 1] * tp0_1 + _dAd[2, 2] * tp0_2 + _dAd[2, 3] * tp0_3) * dinv0
+        dPhi0_3 = (_dAd[3, 0] * tp0_0 + _dAd[3, 1] * tp0_1 + _dAd[3, 2] * tp0_2 + _dAd[3, 3] * tp0_3) * dinv0
+        dPhi1_0 = (_dAd[0, 0] * tp1_0 + _dAd[0, 1] * tp1_1 + _dAd[0, 2] * tp1_2 + _dAd[0, 3] * tp1_3) * dinv1
+        dPhi1_1 = (_dAd[1, 0] * tp1_0 + _dAd[1, 1] * tp1_1 + _dAd[1, 2] * tp1_2 + _dAd[1, 3] * tp1_3) * dinv1
+        dPhi1_2 = (_dAd[2, 0] * tp1_0 + _dAd[2, 1] * tp1_1 + _dAd[2, 2] * tp1_2 + _dAd[2, 3] * tp1_3) * dinv1
+        dPhi1_3 = (_dAd[3, 0] * tp1_0 + _dAd[3, 1] * tp1_1 + _dAd[3, 2] * tp1_2 + _dAd[3, 3] * tp1_3) * dinv1
+        dPhi2_0 = (_dAd[0, 0] * tp2_0 + _dAd[0, 1] * tp2_1 + _dAd[0, 2] * tp2_2 + _dAd[0, 3] * tp2_3) * dinv2
+        dPhi2_1 = (_dAd[1, 0] * tp2_0 + _dAd[1, 1] * tp2_1 + _dAd[1, 2] * tp2_2 + _dAd[1, 3] * tp2_3) * dinv2
+        dPhi2_2 = (_dAd[2, 0] * tp2_0 + _dAd[2, 1] * tp2_1 + _dAd[2, 2] * tp2_2 + _dAd[2, 3] * tp2_3) * dinv2
+        dPhi2_3 = (_dAd[3, 0] * tp2_0 + _dAd[3, 1] * tp2_1 + _dAd[3, 2] * tp2_2 + _dAd[3, 3] * tp2_3) * dinv2
 
         for k in range(n_vals):
             vals[n,k] = Phi0_0*(Phi1_0*(Phi2_0*(coefs[i0+0,i1+0,i2+0,k]) + Phi2_1*(coefs[i0+0,i1+0,i2+1,k]) + Phi2_2*(coefs[i0+0,i1+0,i2+2,k]) + Phi2_3*(coefs[i0+0,i1+0,i2+3,k])) + \
@@ -591,31 +608,7 @@ def filter_coeffs_3d(dinv, data):
 
 
 
-def compute_const():
-    global Ad
-    Ad = array([
-    #      t^3       t^2        t        1
-       [-1.0/6.0,  3.0/6.0, -3.0/6.0, 1.0/6.0],
-       [ 3.0/6.0, -6.0/6.0,  0.0/6.0, 4.0/6.0],
-       [-3.0/6.0,  3.0/6.0,  3.0/6.0, 1.0/6.0],
-       [ 1.0/6.0,  0.0/6.0,  0.0/6.0, 0.0/6.0]
-    ])
-    
-    global dAd
-    dAd = zeros((4,4), dtype=np.double)
-    for i in range(1,4):
-        Ad_i = Ad[:, i-1]
-        dAd[:,i] = (4-i) * Ad_i
-    
-    global d2Ad
-    d2Ad = zeros((4,4), dtype=np.double)
-    for i in range(1,4):
-        dAd_i = dAd[:, i-1]
-        d2Ad[:,i] = (4-i) * dAd_i
-
-
 def filter_coeffs(smin, smax, orders, data):
-    compute_const()
     smin = np.array(smin, dtype=float)
     smax = np.array(smax, dtype=float)
     dinv = (smax - smin) / orders
@@ -630,5 +623,3 @@ def filter_data(dinv, data):
         return filter_coeffs_2d(dinv, data)
     elif len(dinv) == 3:
         return filter_coeffs_3d(dinv, data)
-
-compute_const()

--- a/flare/mgp/cubic_splines_numba.py
+++ b/flare/mgp/cubic_splines_numba.py
@@ -13,15 +13,26 @@ _Ad = array([
     [1.0 / 6.0, 0.0 / 6.0, 0.0 / 6.0, 0.0 / 6.0]
 ])
 
-_dAd = zeros((4, 4), dtype=np.double)
-for i in range(1, 4):
-    Ad_i = _Ad[:, i - 1]
-    _dAd[:, i] = (4 - i) * Ad_i
+_dAd = array([[ 0.,  -0.5,  1.,  -0.5], 
+              [ 0.,   1.5, -2.,   0. ],
+              [ 0.,  -1.5,  1.,   0.5],
+              [ 0.,   0.5,  0.,   0. ]])
 
-_d2Ad = zeros((4, 4), dtype=np.double)
-for i in range(1, 4):
-    dAd_i = _dAd[:, i - 1]
-    _d2Ad[:, i] = (4 - i) * dAd_i
+_d2Ad = array([[ 0.,  0., -1.,  1.],
+               [ 0.,  0.,  3., -2.],
+               [ 0.,  0., -3.,  1.],
+               [ 0.,  0.,  1.,  0.]])
+
+# The dAd and d2Ad are computed from the code below
+# _dAd = zeros((4, 4), dtype=np.double)
+# for i in range(1, 4):
+#     Ad_i = _Ad[:, i - 1]
+#     _dAd[:, i] = (4 - i) * Ad_i
+# 
+# _d2Ad = zeros((4, 4), dtype=np.double)
+# for i in range(1, 4):
+#     dAd_i = _dAd[:, i - 1]
+#     _d2Ad[:, i] = (4 - i) * dAd_i
 
 
 @njit(cache=True)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,19 +1,20 @@
 import pytest
 import numpy as np
+
+from copy import deepcopy
 from flare.struc import Structure
 from flare.env import AtomicEnvironment
 
-
 np.random.seed(0)
 
-cutoff_mask_list = [# (True, np.array([1]), [10]),
-                    (False, {'twobody':1}, [16]),
-                    (False, {'twobody':1, 'threebody':0.05}, [16, 0]),
-                    (False, {'twobody':1, 'threebody':0.8}, [16, 1]),
-                    (False, {'twobody':1, 'threebody':0.9}, [16, 21]),
-                    (True, {'twobody':1, 'threebody':0.8}, [16, 9]),
-                    (True, {'twobody':1, 'threebody':0.05, 'manybody':0.4}, [16, 0]),
-                    (False, {'twobody':1, 'threebody':0.05, 'manybody':0.4}, [16, 0])]
+cutoff_mask_list = [  # (True, np.array([1]), [10]),
+    (False, {'twobody': 1}, [16]),
+    (False, {'twobody': 1, 'threebody': 0.05}, [16, 0]),
+    (False, {'twobody': 1, 'threebody': 0.8}, [16, 1]),
+    (False, {'twobody': 1, 'threebody': 0.9}, [16, 21]),
+    (True, {'twobody': 1, 'threebody': 0.8}, [16, 9]),
+    (True, {'twobody': 1, 'threebody': 0.05, 'manybody': 0.4}, [16, 0]),
+    (False, {'twobody': 1, 'threebody': 0.05, 'manybody': 0.4}, [16, 0])]
 
 
 @pytest.fixture(scope='module')
@@ -35,8 +36,7 @@ def structure() -> Structure:
 
 @pytest.mark.parametrize('mask, cutoff, result', cutoff_mask_list)
 def test_2bspecies_count(structure, mask, cutoff, result):
-
-    if (mask is True):
+    if mask is True:
         mask = generate_mask(cutoff)
     else:
         mask = None
@@ -52,14 +52,13 @@ def test_2bspecies_count(structure, mask, cutoff, result):
     assert (isinstance(env_test.etypes[0], np.int8))
     assert (len(env_test.bond_array_2) == result[0])
 
-    if (len(cutoff) > 1):
+    if len(cutoff) > 1:
         assert (np.sum(env_test.triplet_counts) == result[1])
 
 
 @pytest.mark.parametrize('mask, cutoff, result', cutoff_mask_list)
 def test_env_methods(structure, mask, cutoff, result):
-
-    if (mask is True):
+    if mask is True:
         mask = generate_mask(cutoff)
     else:
         mask = None
@@ -69,8 +68,9 @@ def test_env_methods(structure, mask, cutoff, result):
                                  cutoffs=cutoff,
                                  cutoffs_mask=mask)
 
-    assert str(env_test) == f'Atomic Env. of Type 1 surrounded by {result[0]} atoms' \
-                            ' of Types [1, 2, 3]'
+    assert str(
+        env_test) == f'Atomic Env. of Type 1 surrounded by {result[0]} atoms' \
+                     ' of Types [1, 2, 3]'
 
     the_dict = env_test.as_dict()
     assert isinstance(the_dict, dict)
@@ -81,15 +81,43 @@ def test_env_methods(structure, mask, cutoff, result):
     assert isinstance(remade_env, AtomicEnvironment)
 
     assert np.array_equal(remade_env.bond_array_2, env_test.bond_array_2)
-    if (len(cutoff) > 1):
+    if len(cutoff) > 1:
         assert np.array_equal(remade_env.bond_array_3, env_test.bond_array_3)
-    if (len(cutoff) > 2):
+    if len(cutoff) > 2:
         assert np.array_equal(remade_env.q_array, env_test.q_array)
+
+# Only run on the first four tests, namely, the ones which have
+# False as a parameter.
+@pytest.mark.parametrize('mask, cutoff, result', cutoff_mask_list[:4])
+def test_backwards_compatibility(structure, mask, cutoff, result):
+    """
+    This test can be deleted if backwards compatibility is dropped for the
+    sake of code cleanup. (This test executes in about 5 milliseconds). Tests a
+    particular branch of code within the Environment's as_dict() method for
+    older pickled environments without a cutoffs mask.
+    :return:
+    """
+    if mask is True:
+        mask = generate_mask(cutoff)
+    else:
+        mask = None
+
+    env_test = deepcopy(AtomicEnvironment(structure,
+                                 atom=0,
+                                 cutoffs=cutoff,
+                                 cutoffs_mask=mask))
+    pre_test_dict = env_test.as_dict()
+
+    delattr(env_test, 'cutoffs_mask')
+
+    test_dict = env_test.as_dict()
+
+    assert pre_test_dict['cutoffs_mask'] == test_dict['cutoffs_mask']
 
 
 def generate_mask(cutoff):
     ncutoff = len(cutoff)
-    if (ncutoff == 1):
+    if ncutoff == 1:
         # (1, 1) uses 0.5 cutoff,  (1, 2) (1, 3) (2, 3) use 0.9 cutoff
         mask = {'nspecie': 2, 'specie_mask': np.ones(118, dtype=int)}
         mask['specie_mask'][1] = 0
@@ -98,7 +126,7 @@ def generate_mask(cutoff):
         mask['twobody_mask'] = np.ones(4, dtype=int)
         mask['twobody_mask'][0] = 0
 
-    elif (ncutoff == 2):
+    elif ncutoff == 2:
         # the 3b mask is the same structure as 2b
         nspecie = 3
         specie_mask = np.zeros(118, dtype=int)
@@ -109,13 +137,13 @@ def generate_mask(cutoff):
         # (1, 1) (1, 2) (1, 3) (2, 3) (*, *)
         # correspond to cutoff 0.5, 0.9, 0.8, 0.9, 0.05
         ncut3b = 5
-        tmask = np.ones(nspecie**2, dtype=int)*(ncut3b-1)
+        tmask = np.ones(nspecie ** 2, dtype=int) * (ncut3b - 1)
         count = 0
         for i, j in [(1, 1), (1, 2), (1, 3), (2, 3)]:
             cs1 = specie_mask[i]
             cs2 = specie_mask[j]
-            tmask[cs1*nspecie+cs2] = count
-            tmask[cs2*nspecie+cs1] = count
+            tmask[cs1 * nspecie + cs2] = count
+            tmask[cs2 * nspecie + cs1] = count
             count += 1
 
         mask = {'nspecie': nspecie,
@@ -124,7 +152,7 @@ def generate_mask(cutoff):
                 'ncut3b': ncut3b,
                 'cut3b_mask': tmask}
 
-    elif (ncutoff == 3):
+    elif ncutoff == 3:
         # (1, 1) uses 0.5 cutoff,  (1, 2) (1, 3) (2, 3) use 0.9 cutoff
         mask = {'nspecie': 2, 'specie_mask': np.ones(118, dtype=int)}
         mask['specie_mask'][1] = 0
@@ -166,11 +194,11 @@ def test_auto_sweep():
         np.arange(-sweep_val + 1, sweep_val, 1)
     arbitrary_environment.compute_env()
     n_neighbors_2 = len(arbitrary_environment.etypes)
-    assert(n_neighbors_1 > n_neighbors_2)
+    assert (n_neighbors_1 > n_neighbors_2)
 
     # Increase the sweep value, and check that the count is the same.
     arbitrary_environment.sweep_array = \
         np.arange(-sweep_val - 1, sweep_val + 2, 1)
     arbitrary_environment.compute_env()
     n_neighbors_3 = len(arbitrary_environment.etypes)
-    assert(n_neighbors_1 == n_neighbors_3)
+    assert (n_neighbors_1 == n_neighbors_3)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -114,6 +114,12 @@ def test_backwards_compatibility(structure, mask, cutoff, result):
 
     assert pre_test_dict['cutoffs_mask'] == test_dict['cutoffs_mask']
 
+    new_env = AtomicEnvironment.from_dict(test_dict)
+
+    assert isinstance(new_env, AtomicEnvironment)
+
+    assert str(new_env) == str(env_test)
+
 
 def generate_mask(cutoff):
     ncutoff = len(cutoff)


### PR DESCRIPTION
If an MGP is unpickled and used, routines called within the https://github.com/mir-group/flare/blob/development/flare/mgp/cubic_splines_numba.py cubic splines numba file will attempt to use a variable `dAd` which is only defined when `filter_coeffs` is called, which seems to only occur during mapping. This adds a call to the calculate_coeffs function when the cubic_splines_numba file is imported, loading it into global memory.