### PR TITLE
merge xyz looping into kernel function

### DIFF
--- a/flare/ase/calculator.py
+++ b/flare/ase/calculator.py
@@ -1,8 +1,8 @@
-''':class:`FLARE_Calculator` is a calculator compatible with `ASE`. 
-You can build up `ASE Atoms` for your atomic structure, and use `get_forces`, 
-`get_potential_energy` as general `ASE Calculators`, and use it in 
-`ASE Molecular Dynamics` and our `ASE OTF` training module. For the usage 
-users can refer to `ASE Calculator module <https://wiki.fysik.dtu.dk/ase/ase/calculators/calculators.html>`_ 
+''':class:`FLARE_Calculator` is a calculator compatible with `ASE`.
+You can build up `ASE Atoms` for your atomic structure, and use `get_forces`,
+`get_potential_energy` as general `ASE Calculators`, and use it in
+`ASE Molecular Dynamics` and our `ASE OTF` training module. For the usage
+users can refer to `ASE Calculator module <https://wiki.fysik.dtu.dk/ase/ase/calculators/calculators.html>`_
 and `ASE Calculator tutorial <https://wiki.fysik.dtu.dk/ase/ase/atoms.html#adding-a-calculator>`_.'''
 
 import warnings
@@ -11,16 +11,15 @@ import multiprocessing as mp
 from flare.env import AtomicEnvironment
 from flare.struc import Structure
 from flare.mgp import MappedGaussianProcess
-from flare.predict import predict_on_structure_par_en, predict_on_structure_en
 from ase.calculators.calculator import Calculator
 
 class FLARE_Calculator(Calculator):
     """
     Build FLARE as an ASE Calculator, which is compatible with ASE Atoms and
-    Molecular Dynamics. 
+    Molecular Dynamics.
     Args:
         gp_model (GaussianProcess): FLARE's Gaussian process object
-        mgp_model (MappedGaussianProcess): FLARE's Mapped Gaussian Process object. 
+        mgp_model (MappedGaussianProcess): FLARE's Mapped Gaussian Process object.
             `None` by default. MGP will only be used if `use_mapping` is set to True
         par (Bool): set to `True` if parallelize the prediction. `False` by default.
         use_mapping (Bool): set to `True` if use MGP for prediction. `False` by default.
@@ -84,10 +83,10 @@ class FLARE_Calculator(Calculator):
 
         if self.par:
             forces, stds, local_energies = \
-                    predict_on_structure_par_en(struc_curr, self.gp_model)
+                    predict_on_structure_par(struc_curr, self.gp_model, energy=True)
         else:
             forces, stds, local_energies = \
-                    predict_on_structure_en(struc_curr, self.gp_model)
+                    predict_on_structure(struc_curr, self.gp_model, energy=True)
 
         self.results['forces'] = forces
         self.results['stds'] = stds

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -299,7 +299,7 @@ class GaussianProcess:
         if train:
             self.train(**kwargs)
 
-    def train(self, logger=None, custom_bounds=None,
+    def train(self, logger_name=None, custom_bounds=None,
               grad_tol: float = 1e-4,
               x_tol: float = 1e-5,
               line_steps: int = 20,
@@ -309,7 +309,7 @@ class GaussianProcess:
         (related to the covariance matrix of the training set).
 
         Args:
-            logger (logging.logger): logger object specifying where to write the
+            logger_name (str): name of logger object specifying where to write the
                 progress of the optimization.
             custom_bounds (np.ndarray): Custom bounds on the hyperparameters.
             grad_tol (float): Tolerance of the hyperparameter gradient that
@@ -323,10 +323,11 @@ class GaussianProcess:
         verbose = "info"
         if print_progress:
             verbose = "debug"
-        if logger is None:
-            logger = set_logger("gp_algebra", stream=True,
-                                fileout_name="log.gp_algebra",
-                                verbose=verbose)
+        if logger_name is None:
+            set_logger("gp_algebra", stream=False,
+                       fileout_name="log.gp_algebra",
+                       verbose=verbose)
+            logger_name = "gp_algebra"
 
         disp = print_progress
 
@@ -337,7 +338,7 @@ class GaussianProcess:
 
         x_0 = self.hyps
 
-        args = (self.name, self.kernel_grad, logger,
+        args = (self.name, self.kernel_grad, logger_name,
                 self.cutoffs, self.hyps_mask,
                 self.n_cpus, self.n_sample)
 
@@ -825,12 +826,12 @@ class GaussianProcess:
                     split_matrix_size_cutoff: int = 5000):
         """
         Write model in a variety of formats to a file for later re-use.
-        JSON files are open to visual inspection and are easier to use 
+        JSON files are open to visual inspection and are easier to use
         across different versions of FLARE or GP implementations. However,
         they are larger and loading them in takes longer (by setting up a
         new GP from the specifications). Pickled files can be faster to
         read & write, and they take up less memory.
-        
+
         Args:
             name (str): Output name.
             format (str): Output format.

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -68,11 +68,13 @@ class GaussianProcess:
                  per_atom_par: bool = True, n_cpus: int = 1,
                  n_sample: int = 100, output: Output = None,
                  name="default_gp",
-                 energy_noise: float = 0.01, **kwargs,):
+                 energy_noise: float = 0.01, verbose = "INFO",
+                 **kwargs,):
         """Initialize GP parameters and training data."""
 
         # load arguments into attributes
         self.name = name
+        self.verbose = verbose
 
         self.output = output
         self.opt_algorithm = opt_algorithm
@@ -100,7 +102,7 @@ class GaussianProcess:
         if self.output is None:
             self.logger_name = self.name+"GaussianProcess"
             set_logger(self.logger_name, stream=True,
-                       fileout_name=None, verbose="info")
+                       fileout_name=None, verbose=verbose)
         else:
             self.logger_name = self.output.basename+'log'
 
@@ -318,9 +320,9 @@ class GaussianProcess:
                 hyperparameter optimization.
         """
 
-        verbose = "warning"
+        verbose = "info"
         if print_progress:
-            verbose = "info"
+            verbose = "debug"
         if logger is None:
             logger = set_logger("gp_algebra", stream=True,
                                 fileout_name="log.gp_algebra",
@@ -405,20 +407,16 @@ class GaussianProcess:
         elif (size3 != self.alpha.shape[0]):
             self.set_L_alpha()
 
-    def predict(self, x_t: AtomicEnvironment, d: int) -> [float, float]:
+    def predict(self, x_t: AtomicEnvironment) -> [float, float]:
         """
         Predict a force component of the central atom of a local environment.
 
         Args:
             x_t (AtomicEnvironment): Input local environment.
-            d (int): Force component to be predicted (1 is x, 2 is y, and
-                3 is z).
 
         Return:
             (float, float): Mean and epistemic variance of the prediction.
         """
-
-        assert (d in [1, 2, 3]), "d should be 1, 2, or 3"
 
         # Kernel vector allows for evaluation of atomic environments.
         if self.parallel and not self.per_atom_par:
@@ -430,7 +428,7 @@ class GaussianProcess:
 
         k_v = \
             get_kernel_vector(self.name, self.kernel, self.energy_force_kernel,
-                              x_t, d, self.hyps, cutoffs=self.cutoffs,
+                              x_t, self.hyps, cutoffs=self.cutoffs,
                               hyps_mask=self.hyps_mask, n_cpus=n_cpus,
                               n_sample=self.n_sample)
 
@@ -438,16 +436,16 @@ class GaussianProcess:
         self.check_L_alpha()
 
         # get predictive mean
-        pred_mean = np.matmul(k_v, self.alpha)
+        pred_mean = np.matmul(self.alpha, k_v)
 
         # get predictive variance without cholesky (possibly faster)
         # pass args to kernel based on if mult. hyperparameters in use
         args = from_mask_to_args(self.hyps, self.cutoffs, self.hyps_mask)
 
-        self_kern = self.kernel(x_t, x_t, d, d, *args)
-        pred_var = self_kern - np.matmul(np.matmul(k_v, self.ky_mat_inv), k_v)
+        self_kern = self.kernel(x_t, x_t, *args)
+        pred_var = self_kern - np.matmul(np.matmul(k_v.T, self.ky_mat_inv), k_v)
 
-        return pred_mean, pred_var
+        return pred_mean, np.diagonal(pred_var)
 
     def predict_local_energy(self, x_t: AtomicEnvironment) -> float:
         """Predict the local energy of a local environment.

--- a/flare/gp_from_aimd.py
+++ b/flare/gp_from_aimd.py
@@ -46,9 +46,7 @@ from flare.env import AtomicEnvironment
 from flare.gp import GaussianProcess
 from flare.mgp.mgp import MappedGaussianProcess
 from flare.output import Output
-from flare.predict import predict_on_atom, predict_on_atom_en, \
-    predict_on_structure_par, predict_on_structure_par_en, \
-    predict_on_structure_mgp
+from flare.predict import predict_on_structure_par, predict_on_structure_mgp
 from flare.struc import Structure
 from flare.utils.element_coder import element_to_Z, Z_to_element, NumpyEncoder
 from flare.utils.learner import subset_of_frame_by_element, \
@@ -165,14 +163,11 @@ class TrajectoryTrainer:
 
         # Set prediction function based on if forces or energies are
         # desired, and parallelization accordingly
-        if not self.mgp:
-            if calculate_energy:
-                self.pred_func = predict_on_structure_par_en
-            else:
-                self.pred_func = predict_on_structure_par
-
-        elif self.mgp:
+        self.calculate_energy = calculate_energy
+        if self.mgp:
             self.pred_func = predict_on_structure_mgp
+        else:
+            self.pred_func = predict_on_structure_par
 
         # Parameters for negotiating with the training frames
 
@@ -284,6 +279,13 @@ class TrajectoryTrainer:
                 # Get a randomized set of atoms of species i from the frame
                 # So that it is not always the lowest-indexed atoms chosen
                 atoms_of_specie = frame.indices_of_specie(species_i)
+
+                # remove fixed/zero-forces atoms
+                new_list = []
+                for atom in atoms_of_specie:
+                    if all(frame.forces[atom, :]):
+                        new_list += [atom]
+                atoms_of_specie = new_list
                 np.random.shuffle(atoms_of_specie)
                 n_at = len(atoms_of_specie)
                 # Determine how many to add based on user defined cutoffs
@@ -366,7 +368,7 @@ class TrajectoryTrainer:
                 pred_forces, pred_stds, local_energies = self.pred_func(
                     structure=cur_frame, gp=self.gp, n_cpus=self.n_cpus,
                     write_to_structure=False, selective_atoms=predict_atoms,
-                    skipped_atom_value=np.nan)
+                    skipped_atom_value=np.nan, energy=self.calculate_energy)
             else:
                 pred_forces, pred_stds = self.pred_func(structure=cur_frame,
                                                         gp=self.gp,
@@ -530,7 +532,7 @@ class TrajectoryTrainer:
         logger = logging.getLogger(self.logger_name)
         logger.debug('Train GP')
 
-        logger_train = logging.getLogger(self.output.basename+'hyps')
+        logger_train = self.output.basename+'hyps'
 
         # TODO: Improve flexibility in GP training to make this next step
         # unnecessary, so maxiter can be passed as an argument
@@ -541,10 +543,10 @@ class TrajectoryTrainer:
         elif max_iter is not None:
             temp_maxiter = self.gp.maxiter
             self.gp.maxiter = max_iter
-            self.gp.train(logger=logger_train)
+            self.gp.train(logger_name=logger_train)
             self.gp.maxiter = temp_maxiter
         else:
-            self.gp.train(logger=logger_train)
+            self.gp.train(logger_name=logger_train)
 
         self.output.write_hyps(self.gp.hyp_labels, self.gp.hyps,
                                self.start_time,

--- a/flare/kernels/__init__.py
+++ b/flare/kernels/__init__.py
@@ -1,1 +1,1 @@
-__all__ = [ 'kernels', 'mc_simple', 'mc_sephyps']
+__all__ = ['kernels', 'mc_simple', 'mc_sephyps']

--- a/flare/kernels/cutoffs.py
+++ b/flare/kernels/cutoffs.py
@@ -21,6 +21,7 @@ def hard_cutoff(r_cut: float, ri: float, ci):
     """
     return 1, 0
 
+
 @njit
 def quadratic_cutoff_bound(r_cut: float, ri: float, ci):
     """A quadratic cutoff that goes to zero smoothly at the cutoff boundary.

--- a/flare/kernels/cutoffs.py
+++ b/flare/kernels/cutoffs.py
@@ -4,10 +4,11 @@ kernel to zero near the boundary of the cutoff sphere.
 """
 from math import cos, sin, pi
 from numba import njit
+import numpy as np
 
 
 @njit
-def hard_cutoff(r_cut: float, ri: float, ci: float):
+def hard_cutoff(r_cut: float, ri: float, ci):
     """A hard cutoff that assigns a value of 1 to all interatomic distances.
 
     Args:
@@ -21,7 +22,7 @@ def hard_cutoff(r_cut: float, ri: float, ci: float):
     return 1, 0
 
 @njit
-def quadratic_cutoff_bound(r_cut: float, ri: float, ci: float):
+def quadratic_cutoff_bound(r_cut: float, ri: float, ci):
     """A quadratic cutoff that goes to zero smoothly at the cutoff boundary.
 
     Args:
@@ -33,19 +34,18 @@ def quadratic_cutoff_bound(r_cut: float, ri: float, ci: float):
         (float, float): Cutoff value and its derivative.
     """
 
-    if (r_cut > ri):
-        rdiff = r_cut - ri
-        fi = rdiff * rdiff
-        fdi = 2 * rdiff * ci
-    else:
-        fi = 0
-        fdi = 0
+    rdiff = r_cut - ri
+    fi = rdiff * rdiff
+    fdi = 2 * rdiff * ci
+    if (r_cut < ri):
+        fi *= 0.0
+        fdi *= 0.0
 
     return fi, fdi
 
 
 @njit
-def quadratic_cutoff(r_cut: float, ri: float, ci: float):
+def quadratic_cutoff(r_cut: float, ri: float, ci):
     """A quadratic cutoff that goes to zero smoothly at the cutoff boundary.
 
     Args:

--- a/flare/kernels/kernels.py
+++ b/flare/kernels/kernels.py
@@ -1,5 +1,5 @@
 import numpy as np
-from math import exp
+from numpy import exp
 from numba import njit
 import flare.kernels.cutoffs as cf
 

--- a/flare/kernels/kernels.py
+++ b/flare/kernels/kernels.py
@@ -149,9 +149,8 @@ def three_body_en_helper(ci1, ci2, r11, r22, r33, fi, fj, fdi, ls1, ls2, sig2):
 #                        many body helper functions
 # -----------------------------------------------------------------------------
 
+
 @njit
-
-
 def k_sq_exp_double_dev(q1, q2, sig, ls):
     """Second Gradient of generic squared exponential kernel on two many body functions
 
@@ -174,9 +173,8 @@ def k_sq_exp_double_dev(q1, q2, sig, ls):
 
     return ret
 
+
 @njit
-
-
 def k_sq_exp_dev(q1, q2, sig, ls):
     """First Gradient of generic squared exponential kernel on two many body functions
 
@@ -242,6 +240,7 @@ def q_value(distances, r_cut, cutoff_func, q_func=coordination_number):
         q += q_
 
     return q
+
 
 @njit
 def q_value_mc(distances, r_cut, ref_species, species, cutoff_func, q_func=coordination_number):
@@ -310,6 +309,7 @@ def mb_grad_helper_ls_(qdiffsq, sig, ls):
     ret = - prefact * (qdiffsq ** 2 / ls2 - 5 * qdiffsq + 2 * ls2)
 
     return ret
+
 
 @njit
 def mb_grad_helper_ls(q1, q2, qi, qj, sig, ls):

--- a/flare/kernels/mc_3b_sepcut.py
+++ b/flare/kernels/mc_3b_sepcut.py
@@ -36,10 +36,7 @@ def three_body_mc_sepcut_jit(bond_array_1, c1, etypes1,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = np.zeros((3, 3), dtype=np.float64)
-        ci1[0, :] += bond_array_1[m, 1]
-        ci1[1, :] += bond_array_1[m, 2]
-        ci1[2, :] += bond_array_1[m, 3]
+        ci1 = bond_array_1[m, 1:]
         ei1 = etypes1[m]
 
         # determine cutoff1 based on the end points
@@ -53,10 +50,7 @@ def three_body_mc_sepcut_jit(bond_array_1, c1, etypes1,
 
             ind1 = cross_bond_inds_1[m, m + n + 1]
             ri2 = bond_array_1[ind1, 0]
-            ci2 = np.zeros((3, 3), dtype=np.float64)
-            ci2[0, :] += bond_array_1[ind1, 1]
-            ci2[1, :] += bond_array_1[ind1, 2]
-            ci2[2, :] += bond_array_1[ind1, 3]
+            ci2 = bond_array_1[ind1, 1:]
             ei2 = etypes1[ind1]
 
             # skip if species does not match
@@ -92,10 +86,7 @@ def three_body_mc_sepcut_jit(bond_array_1, c1, etypes1,
                         tr_spec1.remove(ej1)
 
                         rj1 = bond_array_2[p, 0]
-                        cj1 = np.zeros((3, 3), dtype=np.float64)
-                        cj1[:, 0] += bond_array_2[p, 1]
-                        cj1[:, 1] += bond_array_2[p, 2]
-                        cj1[:, 2] += bond_array_2[p, 3]
+                        cj1 = bond_array_2[p, 1:]
                         bej1 = spec_mask[ej1]
                         btype_ej1 = cut3b_mask[bej1 + bcjn]
                         cut_ej1 = r_cut[btype_ej1]
@@ -108,10 +99,7 @@ def three_body_mc_sepcut_jit(bond_array_1, c1, etypes1,
                             ej2 = etypes2[ind2]
                             if ej2 == tr_spec1[0]:
                                 rj2 = bond_array_2[ind2, 0]
-                                cj2 = np.zeros((3, 3), dtype=np.float64)
-                                cj2[:, 0] += bond_array_2[ind2, 1]
-                                cj2[:, 1] += bond_array_2[ind2, 2]
-                                cj2[:, 2] += bond_array_2[ind2, 3]
+                                cj2 = bond_array_2[ind2, 1:]
 
                                 bej2 = spec_mask[ej2]
                                 btype_ej2 = cut3b_mask[bej2 + bcjn]
@@ -137,49 +125,52 @@ def three_body_mc_sepcut_jit(bond_array_1, c1, etypes1,
                                 r32 = ri3 - rj2
                                 r33 = ri3 - rj3
 
-                                if (c1 == c2):
-                                    if (ei1 == ej1) and (ei2 == ej2):
-                                        kern += \
-                                            three_body_helper_1(ci1, ci2, cj1, cj2, r11,
-                                                                r22, r33, fi, fj, fdi, fdj,
-                                                                tls1, tls2, tls3,
-                                                                tsig2)
-                                    if (ei1 == ej2) and (ei2 == ej1):
-                                        kern += \
-                                            three_body_helper_1(ci1, ci2, cj2, cj1, r12,
-                                                                r21, r33, fi, fj, fdi, fdj,
-                                                                tls1, tls2, tls3,
-                                                                tsig2)
-                                if (c1 == ej1):
-                                    if (ei1 == ej2) and (ei2 == c2):
-                                        kern += \
-                                            three_body_helper_2(ci2, ci1, cj2, cj1, r21,
-                                                                r13, r32, fi, fj, fdi,
-                                                                fdj,
-                                                                tls1, tls2, tls3,
-                                                                tsig2)
-                                    if (ei1 == c2) and (ei2 == ej2):
-                                        kern += \
-                                            three_body_helper_2(ci1, ci2, cj2, cj1, r11,
-                                                                r23, r32, fi, fj, fdi,
-                                                                fdj,
-                                                                tls1, tls2, tls3,
-                                                                tsig2)
-                                if (c1 == ej2):
-                                    if (ei1 == ej1) and (ei2 == c2):
-                                        kern += \
-                                            three_body_helper_2(ci2, ci1, cj1, cj2, r22,
-                                                                r13, r31, fi, fj, fdi,
-                                                                fdj,
-                                                                tls1, tls2, tls3,
-                                                                tsig2)
-                                    if (ei1 == c2) and (ei2 == ej1):
-                                        kern += \
-                                            three_body_helper_2(ci1, ci2, cj1, cj2, r12,
-                                                                r23, r31, fi, fj, fdi,
-                                                                fdj,
-                                                                tls1, tls2, tls3,
-                                                                tsig2)
+                                for d1 in range(3):
+                                    for d2 in range(3):
+
+                                         if (c1 == c2):
+                                             if (ei1 == ej1) and (ei2 == ej2):
+                                                 kern[d1, d2] += \
+                                                     three_body_helper_1(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r11,
+                                                                         r22, r33, fi, fj, fdi[d1], fdj[d2],
+                                                                         tls1, tls2, tls3,
+                                                                         tsig2)
+                                             if (ei1 == ej2) and (ei2 == ej1):
+                                                 kern[d1, d2] += \
+                                                     three_body_helper_1(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r12,
+                                                                         r21, r33, fi, fj, fdi[d1], fdj[d2],
+                                                                         tls1, tls2, tls3,
+                                                                         tsig2)
+                                         if (c1 == ej1):
+                                             if (ei1 == ej2) and (ei2 == c2):
+                                                 kern[d1, d2] += \
+                                                     three_body_helper_2(ci2[d1], ci1[d1], cj2[d2], cj1[d2], r21,
+                                                                         r13, r32, fi, fj, fdi[d1],
+                                                                         fdj[d2],
+                                                                         tls1, tls2, tls3,
+                                                                         tsig2)
+                                             if (ei1 == c2) and (ei2 == ej2):
+                                                 kern[d1, d2] += \
+                                                     three_body_helper_2(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r11,
+                                                                         r23, r32, fi, fj, fdi[d1],
+                                                                         fdj[d2],
+                                                                         tls1, tls2, tls3,
+                                                                         tsig2)
+                                         if (c1 == ej2):
+                                             if (ei1 == ej1) and (ei2 == c2):
+                                                 kern[d1, d2] += \
+                                                     three_body_helper_2(ci2[d1], ci1[d1], cj1[d2], cj2[d2], r22,
+                                                                         r13, r31, fi, fj, fdi[d1],
+                                                                         fdj[d2],
+                                                                         tls1, tls2, tls3,
+                                                                         tsig2)
+                                             if (ei1 == c2) and (ei2 == ej1):
+                                                 kern[d1, d2] += \
+                                                     three_body_helper_2(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r12,
+                                                                         r23, r31, fi, fj, fdi[d1],
+                                                                         fdj[d2],
+                                                                         tls1, tls2, tls3,
+                                                                         tsig2)
 
     return kern
 
@@ -207,10 +198,7 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = np.zeros((3, 3), dtype=np.float64)
-        ci1[0, :] += bond_array_1[m, 1]
-        ci1[1, :] += bond_array_1[m, 2]
-        ci1[2, :] += bond_array_1[m, 3]
+        ci1 = bond_array_1[m, 1:]
         ei1 = etypes1[m]
 
         bei1 = spec_mask[ei1]
@@ -222,10 +210,7 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
             ind1 = cross_bond_inds_1[m, m + n + 1]
             ri3 = cross_bond_dists_1[m, m + n + 1]
             ri2 = bond_array_1[ind1, 0]
-            ci2 = np.zeros((3, 3), dtype=np.float64)
-            ci2[0, :] += bond_array_1[ind1, 1]
-            ci2[1, :] += bond_array_1[ind1, 2]
-            ci2[2, :] += bond_array_1[ind1, 3]
+            ci2 = bond_array_1[ind1, 1:]
             ei2 = etypes1[ind1]
 
             # skip if species does not match
@@ -264,10 +249,7 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                         tr_spec1.remove(ej1)
 
                         rj1 = bond_array_2[p, 0]
-                        cj1 = np.zeros((3, 3), dtype=np.float64)
-                        cj1[:, 0] += bond_array_2[p, 1]
-                        cj1[:, 1] += bond_array_2[p, 2]
-                        cj1[:, 2] += bond_array_2[p, 3]
+                        cj1 = bond_array_2[p, 1:]
                         bej1 = spec_mask[ej1]
                         bej1n = spec_mask[ej1]*nspec
 
@@ -281,10 +263,7 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                             if ej2 == tr_spec1[0]:
                                 rj3 = cross_bond_dists_2[p, p + q + 1]
                                 rj2 = bond_array_2[ind2, 0]
-                                cj2 = np.zeros((3, 3), dtype=np.float64)
-                                cj2[:, 0] += bond_array_2[ind2, 1]
-                                cj2[:, 1] += bond_array_2[ind2, 2]
-                                cj2[:, 2] += bond_array_2[ind2, 3]
+                                cj2 = bond_array_2[ind2, 1:]
 
                                 bej2 = spec_mask[ej2]
                                 bond_q = cut3b_mask[bc2+bej2*nspec]
@@ -306,81 +285,83 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                                 r32 = ri3 - rj2
                                 r33 = ri3 - rj3
 
-                                if (c1 == c2):
-                                    if (ei1 == ej1) and (ei2 == ej2):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_1(ci1, ci2, cj1, cj2,
-                                                                     r11, r22, r33, fi, fj,
-                                                                     fdi, fdj, tls1, tls2,
-                                                                     tls3, tls4, tls5,
-                                                                     tls6,
-                                                                     tsig2, tsig3)
-                                        kern += kern_term
-                                        sig_derv[ttypei] += sig_term
-                                        ls_derv[ttypei] += ls_term
+                                for d1 in range(3):
+                                    for d2 in range(3):
+                                        if (c1 == c2):
+                                            if (ei1 == ej1) and (ei2 == ej2):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_1(ci1[d1], ci2[d1], cj1[d2], cj2[d2],
+                                                                             r11, r22, r33, fi, fj,
+                                                                             fdi[d1], fdj[d2], tls1, tls2,
+                                                                             tls3, tls4, tls5,
+                                                                             tls6,
+                                                                             tsig2, tsig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[ttypei][d1, d2] += sig_term
+                                                ls_derv[ttypei][d1, d2] += ls_term
 
-                                    if (ei1 == ej2) and (ei2 == ej1):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_1(ci1, ci2, cj2, cj1,
-                                                                     r12, r21, r33, fi, fj,
-                                                                     fdi, fdj, tls1, tls2,
-                                                                     tls3, tls4, tls5,
-                                                                     tls6,
-                                                                     tsig2, tsig3)
-                                        kern += kern_term
-                                        sig_derv[ttypei] += sig_term
-                                        ls_derv[ttypei] += ls_term
+                                            if (ei1 == ej2) and (ei2 == ej1):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_1(ci1[d1], ci2[d1], cj2[d2], cj1[d2],
+                                                                             r12, r21, r33, fi, fj,
+                                                                             fdi[d1], fdj[d2], tls1, tls2,
+                                                                             tls3, tls4, tls5,
+                                                                             tls6,
+                                                                             tsig2, tsig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[ttypei][d1, d2] += sig_term
+                                                ls_derv[ttypei][d1, d2] += ls_term
 
-                                if (c1 == ej1):
-                                    if (ei1 == ej2) and (ei2 == c2):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_2(ci2, ci1, cj2, cj1,
-                                                                     r21, r13, r32, fi, fj,
-                                                                     fdi, fdj, tls1, tls2,
-                                                                     tls3, tls4, tls5,
-                                                                     tls6,
-                                                                     tsig2, tsig3)
-                                        kern += kern_term
-                                        sig_derv[ttypei] += sig_term
-                                        ls_derv[ttypei] += ls_term
+                                        if (c1 == ej1):
+                                            if (ei1 == ej2) and (ei2 == c2):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_2(ci2[d1], ci1[d1], cj2[d2], cj1[d2],
+                                                                             r21, r13, r32, fi, fj,
+                                                                             fdi[d1], fdj[d2], tls1, tls2,
+                                                                             tls3, tls4, tls5,
+                                                                             tls6,
+                                                                             tsig2, tsig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[ttypei][d1, d2] += sig_term
+                                                ls_derv[ttypei][d1, d2] += ls_term
 
-                                    if (ei1 == c2) and (ei2 == ej2):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_2(ci1, ci2, cj2, cj1,
-                                                                     r11, r23, r32, fi, fj,
-                                                                     fdi, fdj, tls1, tls2,
-                                                                     tls3, tls4, tls5,
-                                                                     tls6,
-                                                                     tsig2, tsig3)
-                                        kern += kern_term
-                                        sig_derv[ttypei] += sig_term
-                                        ls_derv[ttypei] += ls_term
+                                            if (ei1 == c2) and (ei2 == ej2):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_2(ci1[d1], ci2[d1], cj2[d2], cj1[d2],
+                                                                             r11, r23, r32, fi, fj,
+                                                                             fdi[d1], fdj[d2], tls1, tls2,
+                                                                             tls3, tls4, tls5,
+                                                                             tls6,
+                                                                             tsig2, tsig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[ttypei][d1, d2] += sig_term
+                                                ls_derv[ttypei][d1, d2] += ls_term
 
-                                if (c1 == ej2):
-                                    if (ei1 == ej1) and (ei2 == c2):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_2(ci2, ci1, cj1, cj2,
-                                                                     r22, r13, r31, fi, fj,
-                                                                     fdi, fdj, tls1, tls2,
-                                                                     tls3, tls4, tls5,
-                                                                     tls6,
-                                                                     tsig2, tsig3)
-                                        kern += kern_term
-                                        sig_derv[ttypei] += sig_term
-                                        ls_derv[ttypei] += ls_term
+                                        if (c1 == ej2):
+                                            if (ei1 == ej1) and (ei2 == c2):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_2(ci2[d1], ci1[d1], cj1[d2], cj2[d2],
+                                                                             r22, r13, r31, fi, fj,
+                                                                             fdi[d1], fdj[d2], tls1, tls2,
+                                                                             tls3, tls4, tls5,
+                                                                             tls6,
+                                                                             tsig2, tsig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[ttypei][d1, d2] += sig_term
+                                                ls_derv[ttypei][d1, d2] += ls_term
 
-                                    if (ei1 == c2) and (ei2 == ej1):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_2(ci1, ci2, cj1, cj2,
-                                                                     r12, r23, r31, fi, fj,
-                                                                     fdi, fdj, tls1, tls2,
-                                                                     tls3, tls4, tls5,
-                                                                     tls6,
-                                                                     tsig2, tsig3)
+                                            if (ei1 == c2) and (ei2 == ej1):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_2(ci1[d1], ci2[d1], cj1[d2], cj2[d2],
+                                                                             r12, r23, r31, fi, fj,
+                                                                             fdi[d1], fdj[d2], tls1, tls2,
+                                                                             tls3, tls4, tls5,
+                                                                             tls6,
+                                                                             tsig2, tsig3)
 
-                                        kern += kern_term
-                                        sig_derv[ttypei] += sig_term
-                                        ls_derv[ttypei] += ls_term
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[ttypei][d1, d2] += sig_term
+                                                ls_derv[ttypei][d1, d2] += ls_term
 
     return kern, np.vstack((sig_derv, ls_derv))
 
@@ -408,10 +389,7 @@ def three_body_mc_force_en_sepcut_jit(bond_array_1, c1, etypes1,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = np.zeros(3, dtype=np.float64)
-        ci1[0] += bond_array_1[m, 1]
-        ci1[1] += bond_array_1[m, 2]
-        ci1[2] += bond_array_1[m, 3]
+        ci1 = bond_array_1[m, 1:]
         ei1 = etypes1[m]
 
         bei1 = spec_mask[ei1]
@@ -432,10 +410,7 @@ def three_body_mc_force_en_sepcut_jit(bond_array_1, c1, etypes1,
                 tr_spec.remove(c2)
 
                 ri2 = bond_array_1[ind1, 0]
-                ci2 = np.zeros(3, dtype=np.float64)
-                ci2[0] += bond_array_1[ind1, 1]
-                ci2[1] += bond_array_1[ind1, 2]
-                ci2[2] += bond_array_1[ind1, 3]
+                ci2 = bond_array_1[ind1, 1:]
                 bei2 = spec_mask[ei2]
 
                 ttypei = triplet_mask[bc1nn + bei1n + bei2]
@@ -499,39 +474,40 @@ def three_body_mc_force_en_sepcut_jit(bond_array_1, c1, etypes1,
                                     r32 = ri3 - rj2
                                     r33 = ri3 - rj3
 
-                                    if (c1 == c2):
-                                        if (ei1 == ej1) and (ei2 == ej2):
-                                            kern += three_body_en_helper(ci1, ci2, r11, r22,
-                                                                         r33, fi, fj, fdi,
-                                                                         tls1,
-                                                                         tls2, tsig2)
-                                        if (ei1 == ej2) and (ei2 == ej1):
-                                            kern += three_body_en_helper(ci1, ci2, r12, r21,
-                                                                         r33, fi, fj, fdi,
-                                                                         tls1,
-                                                                         tls2, tsig2)
-                                    if (c1 == ej1):
-                                        if (ei1 == ej2) and (ei2 == c2):
-                                            kern += three_body_en_helper(ci1, ci2, r13, r21,
-                                                                         r32, fi, fj, fdi,
-                                                                         tls1,
-                                                                         tls2, tsig2)
-                                        if (ei1 == c2) and (ei2 == ej2):
-                                            kern += three_body_en_helper(ci1, ci2, r11, r23,
-                                                                         r32, fi, fj, fdi,
-                                                                         tls1,
-                                                                         tls2, tsig2)
-                                    if (c1 == ej2):
-                                        if (ei1 == ej1) and (ei2 == c2):
-                                            kern += three_body_en_helper(ci1, ci2, r13, r22,
-                                                                         r31, fi, fj, fdi,
-                                                                         tls1,
-                                                                         tls2, tsig2)
-                                        if (ei1 == c2) and (ei2 == ej1):
-                                            kern += three_body_en_helper(ci1, ci2, r12, r23,
-                                                                         r31, fi, fj, fdi,
-                                                                         tls1,
-                                                                         tls2, tsig2)
+                                    for d1 in range(3):
+                                        if (c1 == c2):
+                                            if (ei1 == ej1) and (ei2 == ej2):
+                                                kern[d1] += three_body_en_helper(
+                                                        ci1[d1], ci2[d1], r11, r22,
+                                                        r33, fi, fj, fdi[d1],
+                                                        tls1, tls2, tsig2)
+                                            if (ei1 == ej2) and (ei2 == ej1):
+                                                kern[d1] += three_body_en_helper(
+                                                        ci1[d1], ci2[d1], r12, r21,
+                                                        r33, fi, fj, fdi[d1],
+                                                        tls1, tls2, tsig2)
+                                        if (c1 == ej1):
+                                            if (ei1 == ej2) and (ei2 == c2):
+                                                kern[d1] += three_body_en_helper(
+                                                        ci1[d1], ci2[d1], r13, r21,
+                                                        r32, fi, fj, fdi[d1],
+                                                        tls1, tls2, tsig2)
+                                            if (ei1 == c2) and (ei2 == ej2):
+                                                kern[d1] += three_body_en_helper(
+                                                        ci1[d1], ci2[d1], r11, r23,
+                                                        r32, fi, fj, fdi[d1],
+                                                        tls1, tls2, tsig2)
+                                        if (c1 == ej2):
+                                            if (ei1 == ej1) and (ei2 == c2):
+                                                kern[d1] += three_body_en_helper(
+                                                        ci1[d1], ci2[d1], r13, r22,
+                                                        r31, fi, fj, fdi[d1],
+                                                        tls1, tls2, tsig2)
+                                            if (ei1 == c2) and (ei2 == ej1):
+                                                kern[d1] += three_body_en_helper(
+                                                        ci1[d1], ci2[d1], r12, r23,
+                                                        r31, fi, fj, fdi[d1],
+                                                        tls1, tls2, tsig2)
 
     return kern
 

--- a/flare/kernels/mc_3b_sepcut.py
+++ b/flare/kernels/mc_3b_sepcut.py
@@ -18,10 +18,10 @@ def three_body_mc_sepcut_jit(bond_array_1, c1, etypes1,
                              cross_bond_inds_1, cross_bond_inds_2,
                              cross_bond_dists_1, cross_bond_dists_2,
                              triplets_1, triplets_2,
-                             d1, d2, sig, ls, r_cut, cutoff_func,
+                             sig, ls, r_cut, cutoff_func,
                              nspec, spec_mask, triplet_mask, cut3b_mask):
 
-    kern = 0
+    kern = np.zeros((3, 3), dtype=np.float64)
 
     # pre-compute constants that appear in the inner loop
     sig2 = sig * sig
@@ -36,7 +36,10 @@ def three_body_mc_sepcut_jit(bond_array_1, c1, etypes1,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = bond_array_1[m, d1]
+        ci1 = np.zeros((3, 3), dtype=np.float64)
+        ci1[0, :] += bond_array_1[m, 1]
+        ci1[1, :] += bond_array_1[m, 2]
+        ci1[2, :] += bond_array_1[m, 3]
         ei1 = etypes1[m]
 
         # determine cutoff1 based on the end points
@@ -50,7 +53,10 @@ def three_body_mc_sepcut_jit(bond_array_1, c1, etypes1,
 
             ind1 = cross_bond_inds_1[m, m + n + 1]
             ri2 = bond_array_1[ind1, 0]
-            ci2 = bond_array_1[ind1, d1]
+            ci2 = np.zeros((3, 3), dtype=np.float64)
+            ci2[0, :] += bond_array_1[ind1, 1]
+            ci2[1, :] += bond_array_1[ind1, 2]
+            ci2[2, :] += bond_array_1[ind1, 3]
             ei2 = etypes1[ind1]
 
             # skip if species does not match
@@ -86,7 +92,10 @@ def three_body_mc_sepcut_jit(bond_array_1, c1, etypes1,
                         tr_spec1.remove(ej1)
 
                         rj1 = bond_array_2[p, 0]
-                        cj1 = bond_array_2[p, d2]
+                        cj1 = np.zeros((3, 3), dtype=np.float64)
+                        cj1[:, 0] += bond_array_2[p, 1]
+                        cj1[:, 1] += bond_array_2[p, 2]
+                        cj1[:, 2] += bond_array_2[p, 3]
                         bej1 = spec_mask[ej1]
                         btype_ej1 = cut3b_mask[bej1 + bcjn]
                         cut_ej1 = r_cut[btype_ej1]
@@ -99,7 +108,10 @@ def three_body_mc_sepcut_jit(bond_array_1, c1, etypes1,
                             ej2 = etypes2[ind2]
                             if ej2 == tr_spec1[0]:
                                 rj2 = bond_array_2[ind2, 0]
-                                cj2 = bond_array_2[ind2, d2]
+                                cj2 = np.zeros((3, 3), dtype=np.float64)
+                                cj2[:, 0] += bond_array_2[ind2, 1]
+                                cj2[:, 1] += bond_array_2[ind2, 2]
+                                cj2[:, 2] += bond_array_2[ind2, 3]
 
                                 bej2 = spec_mask[ej2]
                                 btype_ej2 = cut3b_mask[bej2 + bcjn]
@@ -178,13 +190,13 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                                   cross_bond_inds_1, cross_bond_inds_2,
                                   cross_bond_dists_1, cross_bond_dists_2,
                                   triplets_1, triplets_2,
-                                  d1, d2, sig, ls, r_cut, cutoff_func,
+                                  sig, ls, r_cut, cutoff_func,
                                   nspec, spec_mask, ntriplet, triplet_mask, cut3b_mask):
     """Kernel gradient for 3-body force comparisons."""
 
-    kern = 0.0
-    sig_derv = np.zeros(ntriplet, dtype=np.float64)
-    ls_derv = np.zeros(ntriplet, dtype=np.float64)
+    kern = np.zeros((3, 3), dtype=np.float64)
+    sig_derv = np.zeros((ntriplet, 3, 3), dtype=np.float64)
+    ls_derv = np.zeros((ntriplet, 3, 3), dtype=np.float64)
 
     # pre-compute constants that appear in the inner loop
     sig2, sig3, ls1, ls2, ls3, ls4, ls5, ls6 = grad_constants(sig, ls)
@@ -195,7 +207,10 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = bond_array_1[m, d1]
+        ci1 = np.zeros((3, 3), dtype=np.float64)
+        ci1[0, :] += bond_array_1[m, 1]
+        ci1[1, :] += bond_array_1[m, 2]
+        ci1[2, :] += bond_array_1[m, 3]
         ei1 = etypes1[m]
 
         bei1 = spec_mask[ei1]
@@ -207,7 +222,10 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
             ind1 = cross_bond_inds_1[m, m + n + 1]
             ri3 = cross_bond_dists_1[m, m + n + 1]
             ri2 = bond_array_1[ind1, 0]
-            ci2 = bond_array_1[ind1, d1]
+            ci2 = np.zeros((3, 3), dtype=np.float64)
+            ci2[0, :] += bond_array_1[ind1, 1]
+            ci2[1, :] += bond_array_1[ind1, 2]
+            ci2[2, :] += bond_array_1[ind1, 3]
             ei2 = etypes1[ind1]
 
             # skip if species does not match
@@ -246,7 +264,10 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                         tr_spec1.remove(ej1)
 
                         rj1 = bond_array_2[p, 0]
-                        cj1 = bond_array_2[p, d2]
+                        cj1 = np.zeros((3, 3), dtype=np.float64)
+                        cj1[:, 0] += bond_array_2[p, 1]
+                        cj1[:, 1] += bond_array_2[p, 2]
+                        cj1[:, 2] += bond_array_2[p, 3]
                         bej1 = spec_mask[ej1]
                         bej1n = spec_mask[ej1]*nspec
 
@@ -260,7 +281,10 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                             if ej2 == tr_spec1[0]:
                                 rj3 = cross_bond_dists_2[p, p + q + 1]
                                 rj2 = bond_array_2[ind2, 0]
-                                cj2 = bond_array_2[ind2, d2]
+                                cj2 = np.zeros((3, 3), dtype=np.float64)
+                                cj2[:, 0] += bond_array_2[ind2, 1]
+                                cj2[:, 1] += bond_array_2[ind2, 2]
+                                cj2[:, 2] += bond_array_2[ind2, 3]
 
                                 bej2 = spec_mask[ej2]
                                 bond_q = cut3b_mask[bc2+bej2*nspec]
@@ -358,12 +382,7 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                                         sig_derv[ttypei] += sig_term
                                         ls_derv[ttypei] += ls_term
 
-    kern_grad = np.hstack((sig_derv, ls_derv))
-    # np.zeros(2*ntriplet, dtype=np.float64)
-    # kern_grad[:ntriplet] = sig_derv
-    # kern_grad[ntriplet:] = ls_derv
-
-    return kern, kern_grad
+    return kern, np.vstack((sig_derv, ls_derv))
 
 
 @njit
@@ -372,11 +391,11 @@ def three_body_mc_force_en_sepcut_jit(bond_array_1, c1, etypes1,
                                       cross_bond_inds_1, cross_bond_inds_2,
                                       cross_bond_dists_1, cross_bond_dists_2,
                                       triplets_1, triplets_2,
-                                      d1, sig, ls, r_cut, cutoff_func,
+                                      sig, ls, r_cut, cutoff_func,
                                       nspec, spec_mask, triplet_mask, cut3b_mask):
     """Kernel for 3-body force/energy comparisons."""
 
-    kern = 0
+    kern = np.zeros(3, dtype=np.float64)
 
     # pre-compute constants that appear in the inner loop
     sig2 = sig * sig
@@ -389,7 +408,10 @@ def three_body_mc_force_en_sepcut_jit(bond_array_1, c1, etypes1,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = bond_array_1[m, d1]
+        ci1 = np.zeros(3, dtype=np.float64)
+        ci1[0] += bond_array_1[m, 1]
+        ci1[1] += bond_array_1[m, 2]
+        ci1[2] += bond_array_1[m, 3]
         ei1 = etypes1[m]
 
         bei1 = spec_mask[ei1]
@@ -410,7 +432,10 @@ def three_body_mc_force_en_sepcut_jit(bond_array_1, c1, etypes1,
                 tr_spec.remove(c2)
 
                 ri2 = bond_array_1[ind1, 0]
-                ci2 = bond_array_1[ind1, d1]
+                ci2 = np.zeros(3, dtype=np.float64)
+                ci2[0] += bond_array_1[ind1, 1]
+                ci2[1] += bond_array_1[ind1, 2]
+                ci2[2] += bond_array_1[ind1, 3]
                 bei2 = spec_mask[ei2]
 
                 ttypei = triplet_mask[bc1nn + bei1n + bei2]

--- a/flare/kernels/mc_3b_sepcut.py
+++ b/flare/kernels/mc_3b_sepcut.py
@@ -12,6 +12,7 @@ from flare.kernels.kernels import force_helper, grad_constants, grad_helper, \
     force_energy_helper, three_body_en_helper, three_body_helper_1, \
     three_body_helper_2, three_body_grad_helper_1, three_body_grad_helper_2
 
+
 @njit
 def three_body_mc_sepcut_jit(bond_array_1, c1, etypes1,
                              bond_array_2, c2, etypes2,
@@ -128,49 +129,49 @@ def three_body_mc_sepcut_jit(bond_array_1, c1, etypes1,
                                 for d1 in range(3):
                                     for d2 in range(3):
 
-                                         if (c1 == c2):
-                                             if (ei1 == ej1) and (ei2 == ej2):
-                                                 kern[d1, d2] += \
-                                                     three_body_helper_1(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r11,
-                                                                         r22, r33, fi, fj, fdi[d1], fdj[d2],
-                                                                         tls1, tls2, tls3,
-                                                                         tsig2)
-                                             if (ei1 == ej2) and (ei2 == ej1):
-                                                 kern[d1, d2] += \
-                                                     three_body_helper_1(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r12,
-                                                                         r21, r33, fi, fj, fdi[d1], fdj[d2],
-                                                                         tls1, tls2, tls3,
-                                                                         tsig2)
-                                         if (c1 == ej1):
-                                             if (ei1 == ej2) and (ei2 == c2):
-                                                 kern[d1, d2] += \
-                                                     three_body_helper_2(ci2[d1], ci1[d1], cj2[d2], cj1[d2], r21,
-                                                                         r13, r32, fi, fj, fdi[d1],
-                                                                         fdj[d2],
-                                                                         tls1, tls2, tls3,
-                                                                         tsig2)
-                                             if (ei1 == c2) and (ei2 == ej2):
-                                                 kern[d1, d2] += \
-                                                     three_body_helper_2(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r11,
-                                                                         r23, r32, fi, fj, fdi[d1],
-                                                                         fdj[d2],
-                                                                         tls1, tls2, tls3,
-                                                                         tsig2)
-                                         if (c1 == ej2):
-                                             if (ei1 == ej1) and (ei2 == c2):
-                                                 kern[d1, d2] += \
-                                                     three_body_helper_2(ci2[d1], ci1[d1], cj1[d2], cj2[d2], r22,
-                                                                         r13, r31, fi, fj, fdi[d1],
-                                                                         fdj[d2],
-                                                                         tls1, tls2, tls3,
-                                                                         tsig2)
-                                             if (ei1 == c2) and (ei2 == ej1):
-                                                 kern[d1, d2] += \
-                                                     three_body_helper_2(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r12,
-                                                                         r23, r31, fi, fj, fdi[d1],
-                                                                         fdj[d2],
-                                                                         tls1, tls2, tls3,
-                                                                         tsig2)
+                                        if (c1 == c2):
+                                            if (ei1 == ej1) and (ei2 == ej2):
+                                                kern[d1, d2] += \
+                                                    three_body_helper_1(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r11,
+                                                                        r22, r33, fi, fj, fdi[d1], fdj[d2],
+                                                                        tls1, tls2, tls3,
+                                                                        tsig2)
+                                            if (ei1 == ej2) and (ei2 == ej1):
+                                                kern[d1, d2] += \
+                                                    three_body_helper_1(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r12,
+                                                                        r21, r33, fi, fj, fdi[d1], fdj[d2],
+                                                                        tls1, tls2, tls3,
+                                                                        tsig2)
+                                        if (c1 == ej1):
+                                            if (ei1 == ej2) and (ei2 == c2):
+                                                kern[d1, d2] += \
+                                                    three_body_helper_2(ci2[d1], ci1[d1], cj2[d2], cj1[d2], r21,
+                                                                        r13, r32, fi, fj, fdi[d1],
+                                                                        fdj[d2],
+                                                                        tls1, tls2, tls3,
+                                                                        tsig2)
+                                            if (ei1 == c2) and (ei2 == ej2):
+                                                kern[d1, d2] += \
+                                                    three_body_helper_2(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r11,
+                                                                        r23, r32, fi, fj, fdi[d1],
+                                                                        fdj[d2],
+                                                                        tls1, tls2, tls3,
+                                                                        tsig2)
+                                        if (c1 == ej2):
+                                            if (ei1 == ej1) and (ei2 == c2):
+                                                kern[d1, d2] += \
+                                                    three_body_helper_2(ci2[d1], ci1[d1], cj1[d2], cj2[d2], r22,
+                                                                        r13, r31, fi, fj, fdi[d1],
+                                                                        fdj[d2],
+                                                                        tls1, tls2, tls3,
+                                                                        tsig2)
+                                            if (ei1 == c2) and (ei2 == ej1):
+                                                kern[d1, d2] += \
+                                                    three_body_helper_2(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r12,
+                                                                        r23, r31, fi, fj, fdi[d1],
+                                                                        fdj[d2],
+                                                                        tls1, tls2, tls3,
+                                                                        tsig2)
 
     return kern
 
@@ -267,7 +268,8 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
 
                                 bej2 = spec_mask[ej2]
                                 bond_q = cut3b_mask[bc2+bej2*nspec]
-                                fj2, fdj2 = cutoff_func(r_cut[bond_q], rj2, cj2)
+                                fj2, fdj2 = cutoff_func(
+                                    r_cut[bond_q], rj2, cj2)
 
                                 bond_pq = cut3b_mask[bej1n + bej2]
                                 fj3, _ = cutoff_func(r_cut[bond_pq], rj3, 0)
@@ -297,8 +299,10 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                                                                              tls6,
                                                                              tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
-                                                sig_derv[ttypei][d1, d2] += sig_term
-                                                ls_derv[ttypei][d1, d2] += ls_term
+                                                sig_derv[ttypei][d1,
+                                                                 d2] += sig_term
+                                                ls_derv[ttypei][d1,
+                                                                d2] += ls_term
 
                                             if (ei1 == ej2) and (ei2 == ej1):
                                                 kern_term, sig_term, ls_term = \
@@ -309,8 +313,10 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                                                                              tls6,
                                                                              tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
-                                                sig_derv[ttypei][d1, d2] += sig_term
-                                                ls_derv[ttypei][d1, d2] += ls_term
+                                                sig_derv[ttypei][d1,
+                                                                 d2] += sig_term
+                                                ls_derv[ttypei][d1,
+                                                                d2] += ls_term
 
                                         if (c1 == ej1):
                                             if (ei1 == ej2) and (ei2 == c2):
@@ -322,8 +328,10 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                                                                              tls6,
                                                                              tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
-                                                sig_derv[ttypei][d1, d2] += sig_term
-                                                ls_derv[ttypei][d1, d2] += ls_term
+                                                sig_derv[ttypei][d1,
+                                                                 d2] += sig_term
+                                                ls_derv[ttypei][d1,
+                                                                d2] += ls_term
 
                                             if (ei1 == c2) and (ei2 == ej2):
                                                 kern_term, sig_term, ls_term = \
@@ -334,8 +342,10 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                                                                              tls6,
                                                                              tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
-                                                sig_derv[ttypei][d1, d2] += sig_term
-                                                ls_derv[ttypei][d1, d2] += ls_term
+                                                sig_derv[ttypei][d1,
+                                                                 d2] += sig_term
+                                                ls_derv[ttypei][d1,
+                                                                d2] += ls_term
 
                                         if (c1 == ej2):
                                             if (ei1 == ej1) and (ei2 == c2):
@@ -347,8 +357,10 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                                                                              tls6,
                                                                              tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
-                                                sig_derv[ttypei][d1, d2] += sig_term
-                                                ls_derv[ttypei][d1, d2] += ls_term
+                                                sig_derv[ttypei][d1,
+                                                                 d2] += sig_term
+                                                ls_derv[ttypei][d1,
+                                                                d2] += ls_term
 
                                             if (ei1 == c2) and (ei2 == ej1):
                                                 kern_term, sig_term, ls_term = \
@@ -360,8 +372,10 @@ def three_body_mc_grad_sepcut_jit(bond_array_1, c1, etypes1,
                                                                              tsig2, tsig3)
 
                                                 kern[d1, d2] += kern_term
-                                                sig_derv[ttypei][d1, d2] += sig_term
-                                                ls_derv[ttypei][d1, d2] += ls_term
+                                                sig_derv[ttypei][d1,
+                                                                 d2] += sig_term
+                                                ls_derv[ttypei][d1,
+                                                                d2] += ls_term
 
     return kern, np.vstack((sig_derv, ls_derv))
 
@@ -460,7 +474,8 @@ def three_body_mc_force_en_sepcut_jit(bond_array_1, c1, etypes1,
                                     fj2, _ = cutoff_func(r_cut[bond_q], rj2, 0)
 
                                     bond_pq = cut3b_mask[bej2+bej1n]
-                                    fj3, _ = cutoff_func(r_cut[bond_pq], rj3, 0)
+                                    fj3, _ = cutoff_func(
+                                        r_cut[bond_pq], rj3, 0)
 
                                     fj = fj1 * fj2 * fj3
 
@@ -478,36 +493,36 @@ def three_body_mc_force_en_sepcut_jit(bond_array_1, c1, etypes1,
                                         if (c1 == c2):
                                             if (ei1 == ej1) and (ei2 == ej2):
                                                 kern[d1] += three_body_en_helper(
-                                                        ci1[d1], ci2[d1], r11, r22,
-                                                        r33, fi, fj, fdi[d1],
-                                                        tls1, tls2, tsig2)
+                                                    ci1[d1], ci2[d1], r11, r22,
+                                                    r33, fi, fj, fdi[d1],
+                                                    tls1, tls2, tsig2)
                                             if (ei1 == ej2) and (ei2 == ej1):
                                                 kern[d1] += three_body_en_helper(
-                                                        ci1[d1], ci2[d1], r12, r21,
-                                                        r33, fi, fj, fdi[d1],
-                                                        tls1, tls2, tsig2)
+                                                    ci1[d1], ci2[d1], r12, r21,
+                                                    r33, fi, fj, fdi[d1],
+                                                    tls1, tls2, tsig2)
                                         if (c1 == ej1):
                                             if (ei1 == ej2) and (ei2 == c2):
                                                 kern[d1] += three_body_en_helper(
-                                                        ci1[d1], ci2[d1], r13, r21,
-                                                        r32, fi, fj, fdi[d1],
-                                                        tls1, tls2, tsig2)
+                                                    ci1[d1], ci2[d1], r13, r21,
+                                                    r32, fi, fj, fdi[d1],
+                                                    tls1, tls2, tsig2)
                                             if (ei1 == c2) and (ei2 == ej2):
                                                 kern[d1] += three_body_en_helper(
-                                                        ci1[d1], ci2[d1], r11, r23,
-                                                        r32, fi, fj, fdi[d1],
-                                                        tls1, tls2, tsig2)
+                                                    ci1[d1], ci2[d1], r11, r23,
+                                                    r32, fi, fj, fdi[d1],
+                                                    tls1, tls2, tsig2)
                                         if (c1 == ej2):
                                             if (ei1 == ej1) and (ei2 == c2):
                                                 kern[d1] += three_body_en_helper(
-                                                        ci1[d1], ci2[d1], r13, r22,
-                                                        r31, fi, fj, fdi[d1],
-                                                        tls1, tls2, tsig2)
+                                                    ci1[d1], ci2[d1], r13, r22,
+                                                    r31, fi, fj, fdi[d1],
+                                                    tls1, tls2, tsig2)
                                             if (ei1 == c2) and (ei2 == ej1):
                                                 kern[d1] += three_body_en_helper(
-                                                        ci1[d1], ci2[d1], r12, r23,
-                                                        r31, fi, fj, fdi[d1],
-                                                        tls1, tls2, tsig2)
+                                                    ci1[d1], ci2[d1], r12, r23,
+                                                    r31, fi, fj, fdi[d1],
+                                                    tls1, tls2, tsig2)
 
     return kern
 
@@ -608,23 +623,29 @@ def three_body_mc_en_sepcut_jit(bond_array_1, c1, etypes1,
                                 if (c1 == c2):
                                     if (ei1 == ej1) and (ei2 == ej2):
                                         C1 = r11 * r11 + r22 * r22 + r33 * r33
-                                        kern += tsig2 * exp(-C1 * tls2) * fi * fj
+                                        kern += tsig2 * \
+                                            exp(-C1 * tls2) * fi * fj
                                     if (ei1 == ej2) and (ei2 == ej1):
                                         C3 = r12 * r12 + r21 * r21 + r33 * r33
-                                        kern += tsig2 * exp(-C3 * tls2) * fi * fj
+                                        kern += tsig2 * \
+                                            exp(-C3 * tls2) * fi * fj
                                 if (c1 == ej1):
                                     if (ei1 == ej2) and (ei2 == c2):
                                         C5 = r13 * r13 + r21 * r21 + r32 * r32
-                                        kern += tsig2 * exp(-C5 * tls2) * fi * fj
+                                        kern += tsig2 * \
+                                            exp(-C5 * tls2) * fi * fj
                                     if (ei1 == c2) and (ei2 == ej2):
                                         C2 = r11 * r11 + r23 * r23 + r32 * r32
-                                        kern += tsig2 * exp(-C2 * tls2) * fi * fj
+                                        kern += tsig2 * \
+                                            exp(-C2 * tls2) * fi * fj
                                 if (c1 == ej2):
                                     if (ei1 == ej1) and (ei2 == c2):
                                         C6 = r13 * r13 + r22 * r22 + r31 * r31
-                                        kern += tsig2 * exp(-C6 * tls2) * fi * fj
+                                        kern += tsig2 * \
+                                            exp(-C6 * tls2) * fi * fj
                                     if (ei1 == c2) and (ei2 == ej1):
                                         C4 = r12 * r12 + r23 * r23 + r31 * r31
-                                        kern += tsig2 * exp(-C4 * tls2) * fi * fj
+                                        kern += tsig2 * \
+                                            exp(-C4 * tls2) * fi * fj
 
     return kern

--- a/flare/kernels/mc_mb_sepcut.py
+++ b/flare/kernels/mc_mb_sepcut.py
@@ -63,8 +63,8 @@ def many_body_mc_sepcut_jit(q_array_1, q_array_2,
         mbtype2 = mb_mask[bc2n + bs]
 
         # Calculate many-body descriptor values for central atoms 1 and 2
-        s1 = np.where(species1==s)[0][0]
-        s2 = np.where(species2==s)[0][0]
+        s1 = np.where(species1 == s)[0][0]
+        s2 = np.where(species2 == s)[0][0]
         q1 = q_array_1[s1]
         q2 = q_array_2[s2]
 
@@ -118,12 +118,14 @@ def many_body_mc_sepcut_jit(q_array_1, q_array_2,
                 qjs = q_neigh_array_2[j, s2]
 
                 if c1 == etypes2[j]:
-                    k1js = k_sq_exp_double_dev(q1, qjs, sig[mbtype1], ls[mbtype1])
+                    k1js = k_sq_exp_double_dev(
+                        q1, qjs, sig[mbtype1], ls[mbtype1])
 
                 be = spec_mask[etypes1[i]]
                 mbtype = mb_mask[be+bsn]
                 if etypes1[i] == etypes2[j]:
-                    kij = k_sq_exp_double_dev(qis, qjs, sig[mbtype], ls[mbtype])
+                    kij = k_sq_exp_double_dev(
+                        qis, qjs, sig[mbtype], ls[mbtype])
                 else:
                     kij = 0
 
@@ -133,14 +135,15 @@ def many_body_mc_sepcut_jit(q_array_1, q_array_2,
                 kern += qi1_grads * qj2_grads * kij
     return kern
 
+
 @njit
 def many_body_mc_grad_sepcut_jit(q_array_1, q_array_2,
-                            q_neigh_array_1, q_neigh_array_2,
-                            q_neigh_grads_1, q_neigh_grads_2,
-                            c1, c2, etypes1, etypes2,
-                            species1, species2,
-                            sig, ls,
-                            nspec, spec_mask, nmb, mb_mask):
+                                 q_neigh_array_1, q_neigh_array_2,
+                                 q_neigh_grads_1, q_neigh_grads_2,
+                                 c1, c2, etypes1, etypes2,
+                                 species1, species2,
+                                 sig, ls,
+                                 nspec, spec_mask, nmb, mb_mask):
     """gradient of many-body multi-element kernel between two force components
     w.r.t. the hyperparameters, accelerated with Numba.
 
@@ -178,8 +181,8 @@ def many_body_mc_grad_sepcut_jit(q_array_1, q_array_2,
         mbtype2 = mb_mask[bc2n + bs]
 
         # Calculate many-body descriptor values for central atoms 1 and 2
-        s1 = np.where(species1==s)[0][0]
-        s2 = np.where(species2==s)[0][0]
+        s1 = np.where(species1 == s)[0][0]
+        s2 = np.where(species2 == s)[0][0]
         q1 = q_array_1[s1]
         q2 = q_array_2[s2]
 
@@ -214,7 +217,8 @@ def many_body_mc_grad_sepcut_jit(q_array_1, q_array_2,
             if c2 == etypes1[i]:
                 ki2s = k_sq_exp_double_dev(qis, q2, sig[mbtype2], ls[mbtype2])
                 qi2diffsq = (qis - q2) * (qis - q2)
-                dki2s = mb_grad_helper_ls_(qi2diffsq, sig[mbtype2], ls[mbtype2])
+                dki2s = mb_grad_helper_ls_(
+                    qi2diffsq, sig[mbtype2], ls[mbtype2])
 
             # Compute k1js, qj2_grads and qjs
             for j in range(q_neigh_array_2.shape[0]):
@@ -236,9 +240,11 @@ def many_body_mc_grad_sepcut_jit(q_array_1, q_array_2,
                 qjs = q_neigh_array_2[j, s2]
 
                 if c1 == etypes2[j]:
-                    k1js = k_sq_exp_double_dev(q1, qjs, sig[mbtype1], ls[mbtype1])
+                    k1js = k_sq_exp_double_dev(
+                        q1, qjs, sig[mbtype1], ls[mbtype1])
                     q1jdiffsq = (q1 - qjs) * (q1 - qjs)
-                    dk1js = mb_grad_helper_ls_(q1jdiffsq, sig[mbtype1], ls[mbtype1])
+                    dk1js = mb_grad_helper_ls_(
+                        q1jdiffsq, sig[mbtype1], ls[mbtype1])
 
                 be = spec_mask[etypes2[j]]
                 mbtype = mb_mask[bsn + be]
@@ -255,7 +261,7 @@ def many_body_mc_grad_sepcut_jit(q_array_1, q_array_2,
                 # c1 s and c2 s and if c1==c2 --> c1 s
                 if k12 != 0:
                     kern_term_c1s = q1i_grads * q2j_grads * k12
-                    if sig[mbtype1] !=0:
+                    if sig[mbtype1] != 0:
                         sig_derv[mbtype1] += kern_term_c1s * 2. / sig[mbtype1]
                     kern += kern_term_c1s
                     ls_derv[mbtype1] += q1i_grads * q2j_grads * dk12
@@ -263,7 +269,7 @@ def many_body_mc_grad_sepcut_jit(q_array_1, q_array_2,
                 # s e1 and c2 s and c2==e1 --> c2 s
                 if ki2s != 0:
                     kern_term_c2s = qi1_grads * q2j_grads * ki2s
-                    if sig[mbtype2] !=0:
+                    if sig[mbtype2] != 0:
                         sig_derv[mbtype2] += kern_term_c2s * 2. / sig[mbtype2]
                     kern += kern_term_c2s
                     ls_derv[mbtype2] += qi1_grads * q2j_grads * dki2s
@@ -271,7 +277,7 @@ def many_body_mc_grad_sepcut_jit(q_array_1, q_array_2,
                 # c1 s and s e2 and  c1==e2 --> c1 s
                 if k1js != 0:
                     kern_term_c1s = q1i_grads * qj2_grads * k1js
-                    if sig[mbtype1] !=0:
+                    if sig[mbtype1] != 0:
                         sig_derv[mbtype1] += kern_term_c1s * 2. / sig[mbtype1]
                     kern += kern_term_c1s
                     ls_derv[mbtype1] += q1i_grads * qj2_grads * dk1js
@@ -279,10 +285,10 @@ def many_body_mc_grad_sepcut_jit(q_array_1, q_array_2,
                 # s e1 and s e2 and e1 == e2 -> s e
                 if kij != 0:
                     kern_term_se = qi1_grads * qj2_grads * kij
-                    if sig[mbtype] !=0:
+                    if sig[mbtype] != 0:
                         sig_derv[mbtype] += kern_term_se * 2. / sig[mbtype]
                     kern += kern_term_se
-                    ls_derv[mbtype]  += qi1_grads * qj2_grads * dkij
+                    ls_derv[mbtype] += qi1_grads * qj2_grads * dkij
 
     return kern, np.vstack((sig_derv, ls_derv))
 
@@ -327,8 +333,8 @@ def many_body_mc_force_en_sepcut_jit(q_array_1, q_array_2,
         mbtype1 = mb_mask[bc1n + bs]
         mbtype2 = mb_mask[bc2n + bs]
 
-        s1 = np.where(species1==s)[0][0]
-        s2 = np.where(species2==s)[0][0]
+        s1 = np.where(species1 == s)[0][0]
+        s2 = np.where(species2 == s)[0][0]
         q1 = q_array_1[s1]
         q2 = q_array_2[s2]
 
@@ -402,8 +408,8 @@ def many_body_mc_en_sepcut_jit(q_array_1, q_array_2, c1, c2,
             tls2 = ls2[mbtype]
             tsig2 = sig2[mbtype]
 
-            q1 = q_array_1[np.where(species1==s)[0][0]]
-            q2 = q_array_2[np.where(species2==s)[0][0]]
+            q1 = q_array_1[np.where(species1 == s)[0][0]]
+            q2 = q_array_2[np.where(species2 == s)[0][0]]
 
             q1q2diff = q1 - q2
 

--- a/flare/kernels/mc_sephyps.py
+++ b/flare/kernels/mc_sephyps.py
@@ -1107,46 +1107,54 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                                         if (c1 == c2):
                                             if (ei1 == ej1) and (ei2 == ej2):
                                                 kern[d1, d2] += \
-                                                    three_body_helper_1(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r11,
-                                                                        r22, r33, fi, fj, fdi[d1], fdj[d2],
-                                                                        tls1, tls2, tls3,
-                                                                        tsig2)
+                                                    three_body_helper_1(
+                                                    ci1[d1], ci2[d1],
+                                                    cj1[d2], cj2[d2],
+                                                    r11, r22, r33, fi, fj,
+                                                    fdi[d1], fdj[d2],
+                                                    tls1, tls2, tls3, tsig2)
                                             if (ei1 == ej2) and (ei2 == ej1):
                                                 kern[d1, d2] += \
-                                                    three_body_helper_1(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r12,
-                                                                        r21, r33, fi, fj, fdi[d1], fdj[d2],
-                                                                        tls1, tls2, tls3,
-                                                                        tsig2)
+                                                    three_body_helper_1(
+                                                    ci1[d1], ci2[d1],
+                                                    cj2[d2], cj1[d2],
+                                                    r12, r21, r33, fi, fj,
+                                                    fdi[d1], fdj[d2],
+                                                    tls1, tls2, tls3, tsig2)
                                         if (c1 == ej1):
                                             if (ei1 == ej2) and (ei2 == c2):
                                                 kern[d1, d2] += \
-                                                    three_body_helper_2(ci2[d1], ci1[d1], cj2[d2], cj1[d2], r21,
-                                                                        r13, r32, fi, fj, fdi[d1],
-                                                                        fdj[d2],
-                                                                        tls1, tls2, tls3,
-                                                                        tsig2)
+                                                    three_body_helper_2(
+                                                    ci2[d1], ci1[d1],
+                                                    cj2[d2], cj1[d2],
+                                                    r21, r13, r32, fi, fj,
+                                                    fdi[d1], fdj[d2],
+                                                    tls1, tls2, tls3, tsig2)
                                             if (ei1 == c2) and (ei2 == ej2):
                                                 kern[d1, d2] += \
-                                                    three_body_helper_2(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r11,
-                                                                        r23, r32, fi, fj, fdi[d1],
-                                                                        fdj[d2],
-                                                                        tls1, tls2, tls3,
-                                                                        tsig2)
+                                                    three_body_helper_2(
+                                                    ci1[d1], ci2[d1],
+                                                    cj2[d2], cj1[d2],
+                                                    r11, r23, r32, fi, fj,
+                                                    fdi[d1], fdj[d2],
+                                                    tls1, tls2, tls3, tsig2)
                                         if (c1 == ej2):
                                             if (ei1 == ej1) and (ei2 == c2):
                                                 kern[d1, d2] += \
-                                                    three_body_helper_2(ci2[d1], ci1[d1], cj1[d2], cj2[d2], r22,
-                                                                        r13, r31, fi, fj, fdi[d1],
-                                                                        fdj[d2],
-                                                                        tls1, tls2, tls3,
-                                                                        tsig2)
+                                                    three_body_helper_2(
+                                                    ci2[d1], ci1[d1],
+                                                    cj1[d2], cj2[d2],
+                                                    r22, r13, r31, fi, fj,
+                                                    fdi[d1], fdj[d2],
+                                                    tls1, tls2, tls3, tsig2)
                                             if (ei1 == c2) and (ei2 == ej1):
                                                 kern[d1, d2] += \
-                                                    three_body_helper_2(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r12,
-                                                                        r23, r31, fi, fj, fdi[d1],
-                                                                        fdj[d2],
-                                                                        tls1, tls2, tls3,
-                                                                        tsig2)
+                                                    three_body_helper_2(
+                                                    ci1[d1], ci2[d1],
+                                                    cj1[d2], cj2[d2],
+                                                    r12, r23, r31, fi, fj,
+                                                    fdi[d1], fdj[d2],
+                                                    tls1, tls2, tls3, tsig2)
 
     return kern
 
@@ -1252,12 +1260,14 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                                         if (c1 == c2):
                                             if (ei1 == ej1) and (ei2 == ej2):
                                                 kern_term, sig_term, ls_term = \
-                                                    three_body_grad_helper_1(ci1[d1], ci2[d1], cj1[d2], cj2[d2],
-                                                                             r11, r22, r33, fi, fj,
-                                                                             fdi[d1], fdj[d2], tls1, tls2,
-                                                                             tls3, tls4, tls5,
-                                                                             tls6,
-                                                                             tsig2, tsig3)
+                                                    three_body_grad_helper_1(
+                                                        ci1[d1], ci2[d1],
+                                                        cj1[d2], cj2[d2],
+                                                        r11, r22, r33, fi, fj,
+                                                        fdi[d1], fdj[d2],
+                                                        tls1, tls2, tls3,
+                                                        tls4, tls5, tls6,
+                                                        tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
                                                 sig_derv[ttypei, d1,
                                                          d2] += sig_term
@@ -1266,12 +1276,14 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
 
                                             if (ei1 == ej2) and (ei2 == ej1):
                                                 kern_term, sig_term, ls_term = \
-                                                    three_body_grad_helper_1(ci1[d1], ci2[d1], cj2[d2], cj1[d2],
-                                                                             r12, r21, r33, fi, fj,
-                                                                             fdi[d1], fdj[d2], tls1, tls2,
-                                                                             tls3, tls4, tls5,
-                                                                             tls6,
-                                                                             tsig2, tsig3)
+                                                    three_body_grad_helper_1(
+                                                        ci1[d1], ci2[d1],
+                                                        cj2[d2], cj1[d2],
+                                                        r12, r21, r33, fi, fj,
+                                                        fdi[d1], fdj[d2],
+                                                        tls1, tls2,
+                                                        tls3, tls4, tls5, tls6,
+                                                        tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
                                                 sig_derv[ttypei, d1,
                                                          d2] += sig_term
@@ -1281,12 +1293,14 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                                         if (c1 == ej1):
                                             if (ei1 == ej2) and (ei2 == c2):
                                                 kern_term, sig_term, ls_term = \
-                                                    three_body_grad_helper_2(ci2[d1], ci1[d1], cj2[d2], cj1[d2],
-                                                                             r21, r13, r32, fi, fj,
-                                                                             fdi[d1], fdj[d2], tls1, tls2,
-                                                                             tls3, tls4, tls5,
-                                                                             tls6,
-                                                                             tsig2, tsig3)
+                                                    three_body_grad_helper_2(
+                                                            ci2[d1], ci1[d1],
+                                                            cj2[d2], cj1[d2],
+                                                            r21, r13, r32, fi, fj,
+                                                            fdi[d1], fdj[d2],
+                                                            tls1, tls2, tls3,
+                                                            tls4, tls5, tls6,
+                                                            tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
                                                 sig_derv[ttypei, d1,
                                                          d2] += sig_term

--- a/flare/kernels/mc_sephyps.py
+++ b/flare/kernels/mc_sephyps.py
@@ -1106,27 +1106,27 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                                     for d2 in range(3):
                                         if (c1 == c2):
                                             if (ei1 == ej1) and (ei2 == ej2):
-                                                kern[d1,d2] += \
+                                                kern[d1, d2] += \
                                                     three_body_helper_1(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r11,
                                                                         r22, r33, fi, fj, fdi[d1], fdj[d2],
                                                                         tls1, tls2, tls3,
                                                                         tsig2)
                                             if (ei1 == ej2) and (ei2 == ej1):
-                                                kern[d1,d2] += \
+                                                kern[d1, d2] += \
                                                     three_body_helper_1(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r12,
                                                                         r21, r33, fi, fj, fdi[d1], fdj[d2],
                                                                         tls1, tls2, tls3,
                                                                         tsig2)
                                         if (c1 == ej1):
                                             if (ei1 == ej2) and (ei2 == c2):
-                                                kern[d1,d2] += \
+                                                kern[d1, d2] += \
                                                     three_body_helper_2(ci2[d1], ci1[d1], cj2[d2], cj1[d2], r21,
                                                                         r13, r32, fi, fj, fdi[d1],
                                                                         fdj[d2],
                                                                         tls1, tls2, tls3,
                                                                         tsig2)
                                             if (ei1 == c2) and (ei2 == ej2):
-                                                kern[d1,d2] += \
+                                                kern[d1, d2] += \
                                                     three_body_helper_2(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r11,
                                                                         r23, r32, fi, fj, fdi[d1],
                                                                         fdj[d2],
@@ -1134,14 +1134,14 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                                                                         tsig2)
                                         if (c1 == ej2):
                                             if (ei1 == ej1) and (ei2 == c2):
-                                                kern[d1,d2] += \
+                                                kern[d1, d2] += \
                                                     three_body_helper_2(ci2[d1], ci1[d1], cj1[d2], cj2[d2], r22,
                                                                         r13, r31, fi, fj, fdi[d1],
                                                                         fdj[d2],
                                                                         tls1, tls2, tls3,
                                                                         tsig2)
                                             if (ei1 == c2) and (ei2 == ej1):
-                                                kern[d1,d2] += \
+                                                kern[d1, d2] += \
                                                     three_body_helper_2(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r12,
                                                                         r23, r31, fi, fj, fdi[d1],
                                                                         fdj[d2],
@@ -1259,8 +1259,10 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                                                                              tls6,
                                                                              tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
-                                                sig_derv[ttypei, d1, d2] += sig_term
-                                                ls_derv[ttypei, d1, d2] += ls_term
+                                                sig_derv[ttypei, d1,
+                                                         d2] += sig_term
+                                                ls_derv[ttypei, d1,
+                                                        d2] += ls_term
 
                                             if (ei1 == ej2) and (ei2 == ej1):
                                                 kern_term, sig_term, ls_term = \
@@ -1271,8 +1273,10 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                                                                              tls6,
                                                                              tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
-                                                sig_derv[ttypei, d1, d2] += sig_term
-                                                ls_derv[ttypei, d1, d2] += ls_term
+                                                sig_derv[ttypei, d1,
+                                                         d2] += sig_term
+                                                ls_derv[ttypei, d1,
+                                                        d2] += ls_term
 
                                         if (c1 == ej1):
                                             if (ei1 == ej2) and (ei2 == c2):
@@ -1284,8 +1288,10 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                                                                              tls6,
                                                                              tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
-                                                sig_derv[ttypei, d1, d2] += sig_term
-                                                ls_derv[ttypei, d1, d2] += ls_term
+                                                sig_derv[ttypei, d1,
+                                                         d2] += sig_term
+                                                ls_derv[ttypei, d1,
+                                                        d2] += ls_term
 
                                             if (ei1 == c2) and (ei2 == ej2):
                                                 kern_term, sig_term, ls_term = \
@@ -1296,8 +1302,10 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                                                                              tls6,
                                                                              tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
-                                                sig_derv[ttypei, d1, d2] += sig_term
-                                                ls_derv[ttypei, d1, d2] += ls_term
+                                                sig_derv[ttypei, d1,
+                                                         d2] += sig_term
+                                                ls_derv[ttypei, d1,
+                                                        d2] += ls_term
 
                                         if (c1 == ej2):
                                             if (ei1 == ej1) and (ei2 == c2):
@@ -1309,8 +1317,10 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                                                                              tls6,
                                                                              tsig2, tsig3)
                                                 kern[d1, d2] += kern_term
-                                                sig_derv[ttypei, d1, d2] += sig_term
-                                                ls_derv[ttypei, d1, d2] += ls_term
+                                                sig_derv[ttypei, d1,
+                                                         d2] += sig_term
+                                                ls_derv[ttypei, d1,
+                                                        d2] += ls_term
 
                                             if (ei1 == c2) and (ei2 == ej1):
                                                 kern_term, sig_term, ls_term = \
@@ -1322,8 +1332,10 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                                                                              tsig2, tsig3)
 
                                                 kern[d1, d2] += kern_term
-                                                sig_derv[ttypei, d1, d2] += sig_term
-                                                ls_derv[ttypei, d1, d2] += ls_term
+                                                sig_derv[ttypei, d1,
+                                                         d2] += sig_term
+                                                ls_derv[ttypei, d1,
+                                                        d2] += ls_term
 
     return kern, np.vstack((sig_derv, ls_derv))
 
@@ -1420,32 +1432,32 @@ def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                                     if (c1 == c2):
                                         if (ei1 == ej1) and (ei2 == ej2):
                                             kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r11, r22,
-                                                                         r33, fi, fj, fdi[d1],
-                                                                         tls1, tls2, tsig2)
+                                                                             r33, fi, fj, fdi[d1],
+                                                                             tls1, tls2, tsig2)
                                         if (ei1 == ej2) and (ei2 == ej1):
                                             kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r12, r21,
-                                                                         r33, fi, fj, fdi[d1],
-                                                                         tls1, tls2, tsig2)
+                                                                             r33, fi, fj, fdi[d1],
+                                                                             tls1, tls2, tsig2)
                                     if (c1 == ej1):
                                         if (ei1 == ej2) and (ei2 == c2):
                                             kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r13, r21,
-                                                                         r32, fi, fj, fdi[d1],
-                                                                         tls1, tls2, tsig2)
+                                                                             r32, fi, fj, fdi[d1],
+                                                                             tls1, tls2, tsig2)
                                         if (ei1 == c2) and (ei2 == ej2):
                                             kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r11, r23,
-                                                                         r32, fi, fj, fdi[d1],
-                                                                         tls1, tls2, tsig2)
+                                                                             r32, fi, fj, fdi[d1],
+                                                                             tls1, tls2, tsig2)
                                     if (c1 == ej2):
                                         if (ei1 == ej1) and (ei2 == c2):
                                             kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r13, r22,
-                                                                         r31, fi, fj, fdi[d1],
-                                                                         tls1,
-                                                                         tls2, tsig2)
+                                                                             r31, fi, fj, fdi[d1],
+                                                                             tls1,
+                                                                             tls2, tsig2)
                                         if (ei1 == c2) and (ei2 == ej1):
                                             kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r12, r23,
-                                                                         r31, fi, fj, fdi[d1],
-                                                                         tls1,
-                                                                         tls2, tsig2)
+                                                                             r31, fi, fj, fdi[d1],
+                                                                             tls1,
+                                                                             tls2, tsig2)
 
     return kern
 
@@ -1678,7 +1690,6 @@ def two_body_mc_grad_jit(bond_array_1, c1, etypes1,
 
                     r11 = ri - rj
 
-
                     D = r11 * r11
                     for d1 in range(3):
                         B = r11 * ci[d1]
@@ -1745,8 +1756,8 @@ def two_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                     for d1 in range(3):
                         B = r11 * ci[d1]
                         kern[d1] += force_energy_helper(B, D, fi, fj, fdi[d1],
-                                                    tls1, tls2,
-                                                    tsig2)
+                                                        tls1, tls2,
+                                                        tsig2)
 
     return kern
 
@@ -1790,6 +1801,7 @@ def two_body_mc_en_jit(bond_array_1, c1, etypes1,
                     kern += fi * fj * tsig2 * exp(-r11 * r11 * tls1)
 
     return kern
+
 
 def many_body_mc(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                  nspec, spec_mask,

--- a/flare/kernels/mc_sephyps.py
+++ b/flare/kernels/mc_sephyps.py
@@ -128,7 +128,7 @@ from flare.kernels.mc_mb_sepcut import \
 # -----------------------------------------------------------------------------
 
 
-def two_three_many_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
+def two_three_many_body_mc(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                            nspec, spec_mask,
                            nbond, bond_mask, ntriplet, triplet_mask,
                            ncut3b, cut3b_mask,
@@ -140,8 +140,6 @@ def two_three_many_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b (float, np.ndarray): cutoff(s) for two-body interaction
         cutoff_3b (float, np.ndarray): cutoff(s) for three-body interaction
         cutoff_mb (float, np.ndarray): cutoff(s) for coordination-based manybody interaction
@@ -169,7 +167,7 @@ def two_three_many_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
 
     two_term = two_body_mc_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                                env2.bond_array_2, env2.ctype, env2.etypes,
-                               d1, d2, sig2, ls2, cutoff_2b, cutoff_func,
+                               sig2, ls2, cutoff_2b, cutoff_func,
                                nspec, spec_mask, bond_mask)
 
     if (ncut3b == 0):
@@ -183,7 +181,7 @@ def two_three_many_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
               env1.cross_bond_inds, env2.cross_bond_inds,
               env1.cross_bond_dists, env2.cross_bond_dists,
               env1.triplet_counts, env2.triplet_counts,
-              d1, d2, sig3, ls3, cutoff_3b, cutoff_func,
+              sig3, ls3, cutoff_3b, cutoff_func,
               nspec, spec_mask, triplet_mask, cut3b_mask)
 
     mbmcj = many_body_mc_sepcut_jit
@@ -193,13 +191,13 @@ def two_three_many_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
                       env1.ctype, env2.ctype,
                       env1.etypes_mb, env2.etypes_mb,
                       env1.unique_species, env2.unique_species,
-                      d1, d2, sigm, lsm,
+                      sigm, lsm,
                       nspec, spec_mask, mb_mask)
 
     return two_term + three_term + many_term
 
 
-def two_three_many_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
+def two_three_many_body_mc_grad(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                                 nspec, spec_mask,
                                 nbond, bond_mask, ntriplet, triplet_mask,
                                 ncut3b, cut3b_mask,
@@ -212,8 +210,6 @@ def two_three_many_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b (float, np.ndarray): cutoff(s) for two-body interaction
         cutoff_3b (float, np.ndarray): cutoff(s) for three-body interaction
         cutoff_mb (float, np.ndarray): cutoff(s) for coordination-based manybody interaction
@@ -244,7 +240,7 @@ def two_three_many_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff
     kern2, grad2 = \
         two_body_mc_grad_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                              env2.bond_array_2, env2.ctype, env2.etypes,
-                             d1, d2, sig2, ls2, cutoff_2b, cutoff_func,
+                             sig2, ls2, cutoff_2b, cutoff_func,
                              nspec, spec_mask,
                              nbond, bond_mask)
 
@@ -259,7 +255,7 @@ def two_three_many_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff
               env1.cross_bond_inds, env2.cross_bond_inds,
               env1.cross_bond_dists, env2.cross_bond_dists,
               env1.triplet_counts, env2.triplet_counts,
-              d1, d2, sig3, ls3, cutoff_3b,
+              sig3, ls3, cutoff_3b,
               cutoff_func,
               nspec, spec_mask,
               ntriplet, triplet_mask, cut3b_mask)
@@ -271,13 +267,13 @@ def two_three_many_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff
                              env1.ctype, env2.ctype,
                              env1.etypes_mb, env2.etypes_mb,
                              env1.unique_species, env2.unique_species,
-                             d1, d2, sigm, lsm,
+                             sigm, lsm,
                              nspec, spec_mask, nmb, mb_mask)
 
-    return kern2 + kern3 + kern_many, np.hstack([grad2, grad3, gradm])
+    return kern2 + kern3 + kern_many, np.vstack((grad2, grad3, gradm))
 
 
-def two_three_many_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
+def two_three_many_mc_force_en(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                                nspec, spec_mask,
                                nbond, bond_mask, ntriplet, triplet_mask,
                                ncut3b, cut3b_mask,
@@ -290,8 +286,6 @@ def two_three_many_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b (float, np.ndarray): cutoff(s) for two-body interaction
         cutoff_3b (float, np.ndarray): cutoff(s) for three-body interaction
         cutoff_mb (float, np.ndarray): cutoff(s) for coordination-based manybody interaction
@@ -320,7 +314,7 @@ def two_three_many_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
     two_term = \
         two_body_mc_force_en_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                                  env2.bond_array_2, env2.ctype, env2.etypes,
-                                 d1, sig2, ls2, cutoff_2b, cutoff_func,
+                                 sig2, ls2, cutoff_2b, cutoff_func,
                                  nspec, spec_mask,
                                  bond_mask) / 2
 
@@ -336,7 +330,7 @@ def two_three_many_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
               env1.cross_bond_dists,
               env2.cross_bond_dists,
               env1.triplet_counts, env2.triplet_counts,
-              d1, sig3, ls3, cutoff_3b, cutoff_func,
+              sig3, ls3, cutoff_3b, cutoff_func,
               nspec, spec_mask, triplet_mask,
               cut3b_mask) / 3
 
@@ -345,7 +339,7 @@ def two_three_many_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
                       env1.q_neigh_array, env1.q_neigh_grads,
                       env1.ctype, env2.ctype, env1.etypes_mb,
                       env1.unique_species, env2.unique_species,
-                      d1, sigm, lsm,
+                      sigm, lsm,
                       nspec, spec_mask, mb_mask)
 
     return two_term + three_term + many_term
@@ -363,8 +357,6 @@ def two_three_many_mc_en(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b (float, np.ndarray): cutoff(s) for two-body interaction
         cutoff_3b (float, np.ndarray): cutoff(s) for three-body interaction
         cutoff_mb (float, np.ndarray): cutoff(s) for coordination-based manybody interaction
@@ -427,7 +419,7 @@ def two_three_many_mc_en(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
 # -----------------------------------------------------------------------------
 
 
-def two_plus_three_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
+def two_plus_three_body_mc(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                            nspec, spec_mask,
                            nbond, bond_mask, ntriplet, triplet_mask,
                            ncut3b, cut3b_mask,
@@ -439,8 +431,6 @@ def two_plus_three_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b (float, np.ndarray): cutoff(s) for two-body interaction
         cutoff_3b (float, np.ndarray): cutoff(s) for three-body interaction
         cutoff_mb (float, np.ndarray): cutoff(s) for coordination-based manybody interaction
@@ -464,7 +454,7 @@ def two_plus_three_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
 
     two_term = two_body_mc_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                                env2.bond_array_2, env2.ctype, env2.etypes,
-                               d1, d2, sig2, ls2, cutoff_2b, cutoff_func,
+                               sig2, ls2, cutoff_2b, cutoff_func,
                                nspec, spec_mask, bond_mask)
 
     if (ncut3b <= 1):
@@ -478,13 +468,13 @@ def two_plus_three_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
               env1.cross_bond_inds, env2.cross_bond_inds,
               env1.cross_bond_dists, env2.cross_bond_dists,
               env1.triplet_counts, env2.triplet_counts,
-              d1, d2, sig3, ls3, cutoff_3b, cutoff_func,
+              sig3, ls3, cutoff_3b, cutoff_func,
               nspec, spec_mask, triplet_mask, cut3b_mask)
 
     return two_term + three_term
 
 
-def two_plus_three_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
+def two_plus_three_body_mc_grad(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                                 nspec, spec_mask,
                                 nbond, bond_mask, ntriplet, triplet_mask,
                                 ncut3b, cut3b_mask,
@@ -497,8 +487,6 @@ def two_plus_three_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b (float, np.ndarray): cutoff(s) for two-body interaction
         cutoff_3b (float, np.ndarray): cutoff(s) for three-body interaction
         nspec (int): number of different species groups
@@ -524,7 +512,7 @@ def two_plus_three_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff
     kern2, grad2 = \
         two_body_mc_grad_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                              env2.bond_array_2, env2.ctype, env2.etypes,
-                             d1, d2, sig2, ls2, cutoff_2b, cutoff_func,
+                             sig2, ls2, cutoff_2b, cutoff_func,
                              nspec, spec_mask,
                              nbond, bond_mask)
 
@@ -539,17 +527,17 @@ def two_plus_three_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff
               env1.cross_bond_inds, env2.cross_bond_inds,
               env1.cross_bond_dists, env2.cross_bond_dists,
               env1.triplet_counts, env2.triplet_counts,
-              d1, d2, sig3, ls3, cutoff_3b,
+              sig3, ls3, cutoff_3b,
               cutoff_func,
               nspec, spec_mask,
               ntriplet, triplet_mask, cut3b_mask)
 
-    g = np.hstack([grad2, grad3])
+    g = np.vstack((grad2, grad3))
 
     return kern2 + kern3, g
 
 
-def two_plus_three_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
+def two_plus_three_mc_force_en(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                                nspec, spec_mask, nbond, bond_mask,
                                ntriplet, triplet_mask, ncut3b, cut3b_mask,
                                nmb, mb_mask,
@@ -560,8 +548,6 @@ def two_plus_three_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b (float, np.ndarray): cutoff(s) for two-body interaction
         cutoff_3b (float, np.ndarray): cutoff(s) for three-body interaction
         cutoff_mb (float, np.ndarray): cutoff(s) for coordination-based manybody interaction
@@ -586,7 +572,7 @@ def two_plus_three_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
     two_term = \
         two_body_mc_force_en_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                                  env2.bond_array_2, env2.ctype, env2.etypes,
-                                 d1, sig2, ls2, cutoff_2b, cutoff_func,
+                                 sig2, ls2, cutoff_2b, cutoff_func,
                                  nspec, spec_mask,
                                  bond_mask) / 2
 
@@ -602,7 +588,7 @@ def two_plus_three_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
               env1.cross_bond_dists,
               env2.cross_bond_dists,
               env1.triplet_counts, env2.triplet_counts,
-              d1, sig3, ls3, cutoff_3b, cutoff_func,
+              sig3, ls3, cutoff_3b, cutoff_func,
               nspec, spec_mask,
               triplet_mask, cut3b_mask) / 3
 
@@ -620,8 +606,6 @@ def two_plus_three_mc_en(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b (float, np.ndarray): cutoff(s) for two-body interaction
         cutoff_3b (float, np.ndarray): cutoff(s) for three-body interaction
         cutoff_mb (float, np.ndarray): cutoff(s) for coordination-based manybody interaction
@@ -673,7 +657,7 @@ def two_plus_three_mc_en(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
 # -----------------------------------------------------------------------------
 
 
-def three_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
+def three_body_mc(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                   nspec, spec_mask, nbond, bond_mask,
                   ntriplet, triplet_mask, ncut3b, cut3b_mask,
                   nmb, mb_mask,
@@ -684,8 +668,6 @@ def three_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b: dummy
         cutoff_3b (float, np.ndarray): cutoff(s) for three-body interaction
         nspec (int): number of different species groups
@@ -716,12 +698,12 @@ def three_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
                  env1.cross_bond_inds, env2.cross_bond_inds,
                  env1.cross_bond_dists, env2.cross_bond_dists,
                  env1.triplet_counts, env2.triplet_counts,
-                 d1, d2, sig3, ls3, cutoff_3b, cutoff_func,
+                 sig3, ls3, cutoff_3b, cutoff_func,
                  nspec, spec_mask,
                  triplet_mask, cut3b_mask)
 
 
-def three_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
+def three_body_mc_grad(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                        nspec, spec_mask, nbond, bond_mask,
                        ntriplet, triplet_mask, ncut3b, cut3b_mask,
                        nmb, mb_mask,
@@ -733,8 +715,6 @@ def three_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b: dummy
         cutoff_3b (float, np.ndarray): cutoff(s) for three-body interaction
         nspec (int): number of different species groups
@@ -768,11 +748,11 @@ def three_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
         env1.cross_bond_inds, env2.cross_bond_inds,
         env1.cross_bond_dists, env2.cross_bond_dists,
         env1.triplet_counts, env2.triplet_counts,
-        d1, d2, sig3, ls3, cutoff_3b, cutoff_func,
+        sig3, ls3, cutoff_3b, cutoff_func,
         nspec, spec_mask, ntriplet, triplet_mask, cut3b_mask)
 
 
-def three_body_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
+def three_body_mc_force_en(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                            nspec, spec_mask, nbond, bond_mask, ntriplet, triplet_mask,
                            ncut3b, cut3b_mask, nmb, mb_mask,
                            sig2, ls2, sig3, ls3, sigm, lsm,
@@ -782,8 +762,6 @@ def three_body_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b: dummy
         cutoff_3b (float, np.ndarray): cutoff(s) for three-body interaction
         nspec (int): number of different species groups
@@ -819,7 +797,7 @@ def three_body_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
                  env2.cross_bond_dists,
                  env1.triplet_counts,
                  env2.triplet_counts,
-                 d1, sig3, ls3, cutoff_3b,
+                 sig3, ls3, cutoff_3b,
                  cutoff_func,
                  nspec,
                  spec_mask,
@@ -836,8 +814,6 @@ def three_body_mc_en(env1, env2, cutoff_2b, cutoff_3b,  cutoff_mb,  nspec, spec_
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b: dummy
         cutoff_3b (float, np.ndarray): cutoff(s) for three-body interaction
         nspec (int): number of different species groups
@@ -879,7 +855,7 @@ def three_body_mc_en(env1, env2, cutoff_2b, cutoff_3b,  cutoff_mb,  nspec, spec_
 
 
 def two_body_mc(
-        env1, env2, d1, d2, cutoff_2b, cutoff_3b,  cutoff_mb,  nspec, spec_mask,
+        env1, env2, cutoff_2b, cutoff_3b,  cutoff_mb,  nspec, spec_mask,
         nbond, bond_mask, ntriplet, triplet_mask, ncut3b, cut3b_mask,
         nmb, mb_mask, sig2, ls2, sig3, ls3, sigm, lsm,
         cutoff_func=cf.quadratic_cutoff):
@@ -888,8 +864,6 @@ def two_body_mc(
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b (float, np.ndarray): cutoff(s) for two-body interaction
         cutoff_3b: dummy
         nspec (int): number of different species groups
@@ -912,12 +886,12 @@ def two_body_mc(
 
     return two_body_mc_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                            env2.bond_array_2, env2.ctype, env2.etypes,
-                           d1, d2, sig2, ls2, cutoff_2b, cutoff_func,
+                           sig2, ls2, cutoff_2b, cutoff_func,
                            nspec, spec_mask, bond_mask)
 
 
 def two_body_mc_grad(
-        env1, env2, d1, d2, cutoff_2b, cutoff_3b,  cutoff_mb,  nspec, spec_mask,
+        env1, env2, cutoff_2b, cutoff_3b,  cutoff_mb,  nspec, spec_mask,
         nbond, bond_mask, ntriplet, triplet_mask,
         ncut3b, cut3b_mask, nmb, mb_mask,
         sig2, ls2, sig3, ls3, sigm, lsm,
@@ -928,8 +902,6 @@ def two_body_mc_grad(
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b (float, np.ndarray): cutoff(s) for two-body interaction
         cutoff_3b: dummy
         nspec (int): number of different species groups
@@ -955,11 +927,11 @@ def two_body_mc_grad(
     return two_body_mc_grad_jit(
         env1.bond_array_2, env1.ctype, env1.etypes,
         env2.bond_array_2, env2.ctype, env2.etypes,
-        d1, d2, sig2, ls2, cutoff_2b, cutoff_func,
+        sig2, ls2, cutoff_2b, cutoff_func,
         nspec, spec_mask, nbond, bond_mask)
 
 
-def two_body_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
+def two_body_mc_force_en(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                          nspec, spec_mask, nbond, bond_mask, ntriplet, triplet_mask,
                          ncut3b, cut3b_mask, nmb, mb_mask,
                          sig2, ls2, sig3, ls3, sigm, lsm,
@@ -969,8 +941,6 @@ def two_body_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b (float, np.ndarray): cutoff(s) for two-body interaction
         cutoff_3b: dummy
         nspec (int): number of different species groups
@@ -994,7 +964,7 @@ def two_body_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
     return two_body_mc_force_en_jit(
         env1.bond_array_2, env1.ctype, env1.etypes,
         env2.bond_array_2, env2.ctype, env2.etypes,
-        d1, sig2, ls2, cutoff_2b, cutoff_func,
+        sig2, ls2, cutoff_2b, cutoff_func,
         nspec, spec_mask, bond_mask) / 2
 
 
@@ -1009,8 +979,6 @@ def two_body_mc_en(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         cutoff_2b (float, np.ndarray): cutoff(s) for two-body interaction
         cutoff_3b: dummy
         nspec (int): number of different species groups
@@ -1047,9 +1015,10 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                       cross_bond_inds_1, cross_bond_inds_2,
                       cross_bond_dists_1, cross_bond_dists_2,
                       triplets_1, triplets_2,
-                      d1, d2, sig, ls, r_cut, cutoff_func,
+                      sig, ls, r_cut, cutoff_func,
                       nspec, spec_mask, triplet_mask, cut3b_mask):
-    kern = 0
+
+    kern = np.zeros((3, 3), dtype=np.float64)
 
     # pre-compute constants that appear in the inner loop
     sig2 = sig * sig
@@ -1062,7 +1031,7 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = bond_array_1[m, d1]
+        ci1 = bond_array_1[m, 1:4]
         ei1 = etypes1[m]
 
         bei1 = spec_mask[ei1]
@@ -1080,7 +1049,7 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                 tr_spec.remove(c2)
 
                 ri2 = bond_array_1[ind1, 0]
-                ci2 = bond_array_1[ind1, d1]
+                ci2 = bond_array_1[ind1, 1:4]
                 fi2, fdi2 = cutoff_func(r_cut, ri2, ci2)
 
                 bei2 = spec_mask[ei2]
@@ -1104,7 +1073,7 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                     if ej1 in tr_spec1:
                         tr_spec1.remove(ej1)
                         rj1 = bond_array_2[p, 0]
-                        cj1 = bond_array_2[p, d2]
+                        cj1 = bond_array_2[p, 1:4]
                         fj1, fdj1 = cutoff_func(r_cut, rj1, cj1)
 
                         for q in range(triplets_2[p]):
@@ -1113,7 +1082,7 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                             if ej2 == tr_spec1[0]:
                                 ind2 = cross_bond_inds_2[p, p + 1 + q]
                                 rj2 = bond_array_2[ind2, 0]
-                                cj2 = bond_array_2[ind2, d2]
+                                cj2 = bond_array_2[ind2, 1:4]
                                 fj2, fdj2 = cutoff_func(r_cut, rj2, cj2)
                                 ej2 = etypes2[ind2]
 
@@ -1133,49 +1102,51 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                                 r32 = ri3 - rj2
                                 r33 = ri3 - rj3
 
-                                if (c1 == c2):
-                                    if (ei1 == ej1) and (ei2 == ej2):
-                                        kern += \
-                                            three_body_helper_1(ci1, ci2, cj1, cj2, r11,
-                                                                r22, r33, fi, fj, fdi, fdj,
-                                                                tls1, tls2, tls3,
-                                                                tsig2)
-                                    if (ei1 == ej2) and (ei2 == ej1):
-                                        kern += \
-                                            three_body_helper_1(ci1, ci2, cj2, cj1, r12,
-                                                                r21, r33, fi, fj, fdi, fdj,
-                                                                tls1, tls2, tls3,
-                                                                tsig2)
-                                if (c1 == ej1):
-                                    if (ei1 == ej2) and (ei2 == c2):
-                                        kern += \
-                                            three_body_helper_2(ci2, ci1, cj2, cj1, r21,
-                                                                r13, r32, fi, fj, fdi,
-                                                                fdj,
-                                                                tls1, tls2, tls3,
-                                                                tsig2)
-                                    if (ei1 == c2) and (ei2 == ej2):
-                                        kern += \
-                                            three_body_helper_2(ci1, ci2, cj2, cj1, r11,
-                                                                r23, r32, fi, fj, fdi,
-                                                                fdj,
-                                                                tls1, tls2, tls3,
-                                                                tsig2)
-                                if (c1 == ej2):
-                                    if (ei1 == ej1) and (ei2 == c2):
-                                        kern += \
-                                            three_body_helper_2(ci2, ci1, cj1, cj2, r22,
-                                                                r13, r31, fi, fj, fdi,
-                                                                fdj,
-                                                                tls1, tls2, tls3,
-                                                                tsig2)
-                                    if (ei1 == c2) and (ei2 == ej1):
-                                        kern += \
-                                            three_body_helper_2(ci1, ci2, cj1, cj2, r12,
-                                                                r23, r31, fi, fj, fdi,
-                                                                fdj,
-                                                                tls1, tls2, tls3,
-                                                                tsig2)
+                                for d1 in range(3):
+                                    for d2 in range(3):
+                                        if (c1 == c2):
+                                            if (ei1 == ej1) and (ei2 == ej2):
+                                                kern[d1,d2] += \
+                                                    three_body_helper_1(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r11,
+                                                                        r22, r33, fi, fj, fdi[d1], fdj[d2],
+                                                                        tls1, tls2, tls3,
+                                                                        tsig2)
+                                            if (ei1 == ej2) and (ei2 == ej1):
+                                                kern[d1,d2] += \
+                                                    three_body_helper_1(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r12,
+                                                                        r21, r33, fi, fj, fdi[d1], fdj[d2],
+                                                                        tls1, tls2, tls3,
+                                                                        tsig2)
+                                        if (c1 == ej1):
+                                            if (ei1 == ej2) and (ei2 == c2):
+                                                kern[d1,d2] += \
+                                                    three_body_helper_2(ci2[d1], ci1[d1], cj2[d2], cj1[d2], r21,
+                                                                        r13, r32, fi, fj, fdi[d1],
+                                                                        fdj[d2],
+                                                                        tls1, tls2, tls3,
+                                                                        tsig2)
+                                            if (ei1 == c2) and (ei2 == ej2):
+                                                kern[d1,d2] += \
+                                                    three_body_helper_2(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r11,
+                                                                        r23, r32, fi, fj, fdi[d1],
+                                                                        fdj[d2],
+                                                                        tls1, tls2, tls3,
+                                                                        tsig2)
+                                        if (c1 == ej2):
+                                            if (ei1 == ej1) and (ei2 == c2):
+                                                kern[d1,d2] += \
+                                                    three_body_helper_2(ci2[d1], ci1[d1], cj1[d2], cj2[d2], r22,
+                                                                        r13, r31, fi, fj, fdi[d1],
+                                                                        fdj[d2],
+                                                                        tls1, tls2, tls3,
+                                                                        tsig2)
+                                            if (ei1 == c2) and (ei2 == ej1):
+                                                kern[d1,d2] += \
+                                                    three_body_helper_2(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r12,
+                                                                        r23, r31, fi, fj, fdi[d1],
+                                                                        fdj[d2],
+                                                                        tls1, tls2, tls3,
+                                                                        tsig2)
 
     return kern
 
@@ -1186,14 +1157,14 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                            cross_bond_inds_1, cross_bond_inds_2,
                            cross_bond_dists_1, cross_bond_dists_2,
                            triplets_1, triplets_2,
-                           d1, d2, sig, ls, r_cut, cutoff_func,
+                           sig, ls, r_cut, cutoff_func,
                            nspec, spec_mask, ntriplet, triplet_mask,
                            cut3b_mask):
     """Kernel gradient for 3-body force comparisons."""
 
-    kern = 0
-    sig_derv = np.zeros(ntriplet, dtype=np.float64)
-    ls_derv = np.zeros(ntriplet, dtype=np.float64)
+    kern = np.zeros((3, 3), dtype=np.float64)
+    sig_derv = np.zeros((ntriplet, 3, 3), dtype=np.float64)
+    ls_derv = np.zeros((ntriplet, 3, 3), dtype=np.float64)
 
     # pre-compute constants that appear in the inner loop
     sig2, sig3, ls1, ls2, ls3, ls4, ls5, ls6 = grad_constants(sig, ls)
@@ -1203,7 +1174,7 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = bond_array_1[m, d1]
+        ci1 = bond_array_1[m, 1:4]
         fi1, fdi1 = cutoff_func(r_cut, ri1, ci1)
         ei1 = etypes1[m]
 
@@ -1220,7 +1191,7 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
 
                 ri3 = cross_bond_dists_1[m, m + n + 1]
                 ri2 = bond_array_1[ind1, 0]
-                ci2 = bond_array_1[ind1, d1]
+                ci2 = bond_array_1[ind1, 1:4]
 
                 bei2 = spec_mask[ei2]
 
@@ -1247,7 +1218,7 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                     if ej1 in tr_spec1:
                         tr_spec1.remove(ej1)
                         rj1 = bond_array_2[p, 0]
-                        cj1 = bond_array_2[p, d2]
+                        cj1 = bond_array_2[p, 1:4]
                         fj1, fdj1 = cutoff_func(r_cut, rj1, cj1)
 
                         for q in range(triplets_2[p]):
@@ -1257,7 +1228,7 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                                 ind2 = cross_bond_inds_2[p, p + q + 1]
                                 rj3 = cross_bond_dists_2[p, p + q + 1]
                                 rj2 = bond_array_2[ind2, 0]
-                                cj2 = bond_array_2[ind2, d2]
+                                cj2 = bond_array_2[ind2, 1:4]
                                 ej2 = etypes2[ind2]
 
                                 fj2, fdj2 = cutoff_func(r_cut, rj2, cj2)
@@ -1276,83 +1247,85 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                                 r32 = ri3 - rj2
                                 r33 = ri3 - rj3
 
-                                if (c1 == c2):
-                                    if (ei1 == ej1) and (ei2 == ej2):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_1(ci1, ci2, cj1, cj2,
-                                                                     r11, r22, r33, fi, fj,
-                                                                     fdi, fdj, tls1, tls2,
-                                                                     tls3, tls4, tls5,
-                                                                     tls6,
-                                                                     tsig2, tsig3)
-                                        kern += kern_term
-                                        sig_derv[ttypei] += sig_term
-                                        ls_derv[ttypei] += ls_term
+                                for d1 in range(3):
+                                    for d2 in range(3):
+                                        if (c1 == c2):
+                                            if (ei1 == ej1) and (ei2 == ej2):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_1(ci1[d1], ci2[d1], cj1[d2], cj2[d2],
+                                                                             r11, r22, r33, fi, fj,
+                                                                             fdi[d1], fdj[d2], tls1, tls2,
+                                                                             tls3, tls4, tls5,
+                                                                             tls6,
+                                                                             tsig2, tsig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[ttypei, d1, d2] += sig_term
+                                                ls_derv[ttypei, d1, d2] += ls_term
 
-                                    if (ei1 == ej2) and (ei2 == ej1):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_1(ci1, ci2, cj2, cj1,
-                                                                     r12, r21, r33, fi, fj,
-                                                                     fdi, fdj, tls1, tls2,
-                                                                     tls3, tls4, tls5,
-                                                                     tls6,
-                                                                     tsig2, tsig3)
-                                        kern += kern_term
-                                        sig_derv[ttypei] += sig_term
-                                        ls_derv[ttypei] += ls_term
+                                            if (ei1 == ej2) and (ei2 == ej1):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_1(ci1[d1], ci2[d1], cj2[d2], cj1[d2],
+                                                                             r12, r21, r33, fi, fj,
+                                                                             fdi[d1], fdj[d2], tls1, tls2,
+                                                                             tls3, tls4, tls5,
+                                                                             tls6,
+                                                                             tsig2, tsig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[ttypei, d1, d2] += sig_term
+                                                ls_derv[ttypei, d1, d2] += ls_term
 
-                                if (c1 == ej1):
-                                    if (ei1 == ej2) and (ei2 == c2):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_2(ci2, ci1, cj2, cj1,
-                                                                     r21, r13, r32, fi, fj,
-                                                                     fdi, fdj, tls1, tls2,
-                                                                     tls3, tls4, tls5,
-                                                                     tls6,
-                                                                     tsig2, tsig3)
-                                        kern += kern_term
-                                        sig_derv[ttypei] += sig_term
-                                        ls_derv[ttypei] += ls_term
+                                        if (c1 == ej1):
+                                            if (ei1 == ej2) and (ei2 == c2):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_2(ci2[d1], ci1[d1], cj2[d2], cj1[d2],
+                                                                             r21, r13, r32, fi, fj,
+                                                                             fdi[d1], fdj[d2], tls1, tls2,
+                                                                             tls3, tls4, tls5,
+                                                                             tls6,
+                                                                             tsig2, tsig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[ttypei, d1, d2] += sig_term
+                                                ls_derv[ttypei, d1, d2] += ls_term
 
-                                    if (ei1 == c2) and (ei2 == ej2):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_2(ci1, ci2, cj2, cj1,
-                                                                     r11, r23, r32, fi, fj,
-                                                                     fdi, fdj, tls1, tls2,
-                                                                     tls3, tls4, tls5,
-                                                                     tls6,
-                                                                     tsig2, tsig3)
-                                        kern += kern_term
-                                        sig_derv[ttypei] += sig_term
-                                        ls_derv[ttypei] += ls_term
+                                            if (ei1 == c2) and (ei2 == ej2):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_2(ci1[d1], ci2[d1], cj2[d2], cj1[d2],
+                                                                             r11, r23, r32, fi, fj,
+                                                                             fdi[d1], fdj[d2], tls1, tls2,
+                                                                             tls3, tls4, tls5,
+                                                                             tls6,
+                                                                             tsig2, tsig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[ttypei, d1, d2] += sig_term
+                                                ls_derv[ttypei, d1, d2] += ls_term
 
-                                if (c1 == ej2):
-                                    if (ei1 == ej1) and (ei2 == c2):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_2(ci2, ci1, cj1, cj2,
-                                                                     r22, r13, r31, fi, fj,
-                                                                     fdi, fdj, tls1, tls2,
-                                                                     tls3, tls4, tls5,
-                                                                     tls6,
-                                                                     tsig2, tsig3)
-                                        kern += kern_term
-                                        sig_derv[ttypei] += sig_term
-                                        ls_derv[ttypei] += ls_term
+                                        if (c1 == ej2):
+                                            if (ei1 == ej1) and (ei2 == c2):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_2(ci2[d1], ci1[d1], cj1[d2], cj2[d2],
+                                                                             r22, r13, r31, fi, fj,
+                                                                             fdi[d1], fdj[d2], tls1, tls2,
+                                                                             tls3, tls4, tls5,
+                                                                             tls6,
+                                                                             tsig2, tsig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[ttypei, d1, d2] += sig_term
+                                                ls_derv[ttypei, d1, d2] += ls_term
 
-                                    if (ei1 == c2) and (ei2 == ej1):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_2(ci1, ci2, cj1, cj2,
-                                                                     r12, r23, r31, fi, fj,
-                                                                     fdi, fdj, tls1, tls2,
-                                                                     tls3, tls4, tls5,
-                                                                     tls6,
-                                                                     tsig2, tsig3)
+                                            if (ei1 == c2) and (ei2 == ej1):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_2(ci1[d1], ci2[d1], cj1[d2], cj2[d2],
+                                                                             r12, r23, r31, fi, fj,
+                                                                             fdi[d1], fdj[d2], tls1, tls2,
+                                                                             tls3, tls4, tls5,
+                                                                             tls6,
+                                                                             tsig2, tsig3)
 
-                                        kern += kern_term
-                                        sig_derv[ttypei] += sig_term
-                                        ls_derv[ttypei] += ls_term
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[ttypei, d1, d2] += sig_term
+                                                ls_derv[ttypei, d1, d2] += ls_term
 
-    return kern, np.hstack((sig_derv, ls_derv))
+    return kern, np.vstack((sig_derv, ls_derv))
 
 
 @njit
@@ -1361,11 +1334,11 @@ def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                                cross_bond_inds_1, cross_bond_inds_2,
                                cross_bond_dists_1, cross_bond_dists_2,
                                triplets_1, triplets_2,
-                               d1, sig, ls, r_cut, cutoff_func,
+                               sig, ls, r_cut, cutoff_func,
                                nspec, spec_mask, triplet_mask, cut3b_mask):
     """Kernel for 3-body force/energy comparisons."""
 
-    kern = 0
+    kern = np.zeros(3, dtype=np.float64)
 
     # pre-compute constants that appear in the inner loop
     sig2 = sig * sig
@@ -1377,7 +1350,7 @@ def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = bond_array_1[m, d1]
+        ci1 = bond_array_1[m, 1:4]
         fi1, fdi1 = cutoff_func(r_cut, ri1, ci1)
         ei1 = etypes1[m]
 
@@ -1392,7 +1365,7 @@ def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
             if c2 in tr_spec:
                 tr_spec.remove(c2)
                 ri2 = bond_array_1[ind1, 0]
-                ci2 = bond_array_1[ind1, d1]
+                ci2 = bond_array_1[ind1, 1:4]
                 fi2, fdi2 = cutoff_func(r_cut, ri2, ci2)
 
                 bei2 = spec_mask[ei2]
@@ -1442,39 +1415,37 @@ def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                                 r32 = ri3 - rj2
                                 r33 = ri3 - rj3
 
-                                if (c1 == c2):
-                                    if (ei1 == ej1) and (ei2 == ej2):
-                                        kern += three_body_en_helper(ci1, ci2, r11, r22,
-                                                                     r33, fi, fj, fdi,
-                                                                     tls1,
-                                                                     tls2, tsig2)
-                                    if (ei1 == ej2) and (ei2 == ej1):
-                                        kern += three_body_en_helper(ci1, ci2, r12, r21,
-                                                                     r33, fi, fj, fdi,
-                                                                     tls1,
-                                                                     tls2, tsig2)
-                                if (c1 == ej1):
-                                    if (ei1 == ej2) and (ei2 == c2):
-                                        kern += three_body_en_helper(ci1, ci2, r13, r21,
-                                                                     r32, fi, fj, fdi,
-                                                                     tls1,
-                                                                     tls2, tsig2)
-                                    if (ei1 == c2) and (ei2 == ej2):
-                                        kern += three_body_en_helper(ci1, ci2, r11, r23,
-                                                                     r32, fi, fj, fdi,
-                                                                     tls1,
-                                                                     tls2, tsig2)
-                                if (c1 == ej2):
-                                    if (ei1 == ej1) and (ei2 == c2):
-                                        kern += three_body_en_helper(ci1, ci2, r13, r22,
-                                                                     r31, fi, fj, fdi,
-                                                                     tls1,
-                                                                     tls2, tsig2)
-                                    if (ei1 == c2) and (ei2 == ej1):
-                                        kern += three_body_en_helper(ci1, ci2, r12, r23,
-                                                                     r31, fi, fj, fdi,
-                                                                     tls1,
-                                                                     tls2, tsig2)
+                                for d1 in range(3):
+
+                                    if (c1 == c2):
+                                        if (ei1 == ej1) and (ei2 == ej2):
+                                            kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r11, r22,
+                                                                         r33, fi, fj, fdi[d1],
+                                                                         tls1, tls2, tsig2)
+                                        if (ei1 == ej2) and (ei2 == ej1):
+                                            kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r12, r21,
+                                                                         r33, fi, fj, fdi[d1],
+                                                                         tls1, tls2, tsig2)
+                                    if (c1 == ej1):
+                                        if (ei1 == ej2) and (ei2 == c2):
+                                            kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r13, r21,
+                                                                         r32, fi, fj, fdi[d1],
+                                                                         tls1, tls2, tsig2)
+                                        if (ei1 == c2) and (ei2 == ej2):
+                                            kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r11, r23,
+                                                                         r32, fi, fj, fdi[d1],
+                                                                         tls1, tls2, tsig2)
+                                    if (c1 == ej2):
+                                        if (ei1 == ej1) and (ei2 == c2):
+                                            kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r13, r22,
+                                                                         r31, fi, fj, fdi[d1],
+                                                                         tls1,
+                                                                         tls2, tsig2)
+                                        if (ei1 == c2) and (ei2 == ej1):
+                                            kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r12, r23,
+                                                                         r31, fi, fj, fdi[d1],
+                                                                         tls1,
+                                                                         tls2, tsig2)
 
     return kern
 
@@ -1591,7 +1562,7 @@ def three_body_mc_en_jit(bond_array_1, c1, etypes1,
 
 @njit
 def two_body_mc_jit(bond_array_1, c1, etypes1, bond_array_2, c2, etypes2,
-                    d1, d2, sig, ls, r_cut, cutoff_func,
+                    sig, ls, r_cut, cutoff_func,
                     nspec, spec_mask, bond_mask):
     """Multicomponent two-body force/force kernel accelerated with Numba's
     njit decorator.
@@ -1599,7 +1570,7 @@ def two_body_mc_jit(bond_array_1, c1, etypes1, bond_array_2, c2, etypes2,
     of the same type.
     """
 
-    kern = 0
+    kern = np.zeros((3, 3), dtype=np.float64)
 
     ls1 = 1 / (2 * ls * ls)
     ls2 = 1 / (ls * ls)
@@ -1614,7 +1585,7 @@ def two_body_mc_jit(bond_array_1, c1, etypes1, bond_array_2, c2, etypes2,
 
         if ((c2 == e1) or (c2 == c1)):
             ri = bond_array_1[m, 0]
-            ci = bond_array_1[m, d1]
+            ci = bond_array_1[m, 1:4]
 
             be1 = spec_mask[e1]
             btype = bond_mask[bc1n + be1]
@@ -1633,17 +1604,19 @@ def two_body_mc_jit(bond_array_1, c1, etypes1, bond_array_2, c2, etypes2,
                 # check if bonds agree
                 if (c1 == c2 and e1 == e2) or (c1 == e2 and c2 == e1):
                     rj = bond_array_2[n, 0]
-                    cj = bond_array_2[n, d2]
+                    cj = bond_array_2[n, 1:4]
                     fj, fdj = cutoff_func(tr_cut, rj, cj)
                     r11 = ri - rj
 
-                    A = ci * cj
-                    B = r11 * ci
-                    C = r11 * cj
                     D = r11 * r11
+                    for d1 in range(3):
+                        B = r11 * ci[d1]
+                        for d2 in range(3):
+                            A = ci[d1] * cj[d2]
+                            C = r11 * cj[d2]
 
-                    kern += force_helper(A, B, C, D, fi, fj, fdi, fdj,
-                                         tls1, tls2, tls3, tsig2)
+                            kern[d1, d2] += force_helper(A, B, C, D, fi, fj, fdi[d1], fdj[d2],
+                                                         tls1, tls2, tls3, tsig2)
 
     return kern
 
@@ -1651,14 +1624,14 @@ def two_body_mc_jit(bond_array_1, c1, etypes1, bond_array_2, c2, etypes2,
 @njit
 def two_body_mc_grad_jit(bond_array_1, c1, etypes1,
                          bond_array_2, c2, etypes2,
-                         d1, d2, sig, ls, r_cut, cutoff_func,
+                         sig, ls, r_cut, cutoff_func,
                          nspec, spec_mask, nbond, bond_mask):
     """Multicomponent two-body force/force kernel gradient accelerated with
     Numba's njit decorator."""
 
-    kern = 0
-    sig_derv = np.zeros(nbond, dtype=np.float64)
-    ls_derv = np.zeros(nbond, dtype=np.float64)
+    kern = np.zeros((3, 3), dtype=np.float64)
+    sig_derv = np.zeros((nbond, 3, 3), dtype=np.float64)
+    ls_derv = np.zeros((nbond, 3, 3), dtype=np.float64)
 
     ls1 = 1 / (2 * ls * ls)
     ls2 = 1 / (ls * ls)
@@ -1677,7 +1650,7 @@ def two_body_mc_grad_jit(bond_array_1, c1, etypes1,
         e1 = etypes1[m]
         if ((c2 == e1) or (c2 == c1)):
             ri = bond_array_1[m, 0]
-            ci = bond_array_1[m, d1]
+            ci = bond_array_1[m, 1:4]
 
             be1 = spec_mask[e1]
             btype = bond_mask[bc1n + be1]
@@ -1700,40 +1673,41 @@ def two_body_mc_grad_jit(bond_array_1, c1, etypes1,
                 # check if bonds agree
                 if (c1 == c2 and e1 == e2) or (c1 == e2 and c2 == e1):
                     rj = bond_array_2[n, 0]
-                    cj = bond_array_2[n, d2]
+                    cj = bond_array_2[n, 1:4]
                     fj, fdj = cutoff_func(tr_cut, rj, cj)
 
                     r11 = ri - rj
 
-                    A = ci * cj
-                    B = r11 * ci
-                    C = r11 * cj
+
                     D = r11 * r11
+                    for d1 in range(3):
+                        B = r11 * ci[d1]
+                        for d2 in range(3):
+                            A = ci[d1] * cj[d2]
+                            C = r11 * cj[d2]
 
-                    kern_term, sig_term, ls_term = \
-                        grad_helper(A, B, C, D, fi, fj, fdi, fdj,
-                                    tls1, tls2, tls3,
-                                    tls4, tls5, tls6,
-                                    tsig2, tsig3)
+                            kern_term, sig_term, ls_term = \
+                                grad_helper(A, B, C, D, fi, fj, fdi[d1], fdj[d2],
+                                            tls1, tls2, tls3,
+                                            tls4, tls5, tls6,
+                                            tsig2, tsig3)
 
-                    kern += kern_term
-                    sig_derv[btype] += sig_term
-                    ls_derv[btype] += ls_term
+                            kern[d1, d2] += kern_term
+                            sig_derv[btype, d1, d2] += sig_term
+                            ls_derv[btype, d1, d2] += ls_term
 
-    kern_grad = np.hstack((sig_derv, ls_derv))
-
-    return kern, kern_grad
+    return kern, np.vstack((sig_derv, ls_derv))
 
 
 @njit
 def two_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                              bond_array_2, c2, etypes2,
-                             d1, sig, ls, r_cut, cutoff_func,
+                             sig, ls, r_cut, cutoff_func,
                              nspec, spec_mask, bond_mask):
     """Multicomponent two-body force/energy kernel accelerated with
     Numba's njit decorator."""
 
-    kern = 0
+    kern = np.zeros(3, dtype=np.float64)
 
     ls1 = 1 / (2 * ls * ls)
     ls2 = 1 / (ls * ls)
@@ -1746,7 +1720,7 @@ def two_body_mc_force_en_jit(bond_array_1, c1, etypes1,
         e1 = etypes1[m]
         if ((c2 == e1) or (c2 == c1)):
             ri = bond_array_1[m, 0]
-            ci = bond_array_1[m, d1]
+            ci = bond_array_1[m, 1:4]
 
             be1 = spec_mask[e1]
             btype = bond_mask[bc1n + be1]
@@ -1767,11 +1741,12 @@ def two_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                     fj, _ = cutoff_func(tr_cut, rj, 0)
 
                     r11 = ri - rj
-                    B = r11 * ci
                     D = r11 * r11
-                    kern += force_energy_helper(B, D, fi, fj, fdi,
-                                                tls1, tls2,
-                                                tsig2)
+                    for d1 in range(3):
+                        B = r11 * ci[d1]
+                        kern[d1] += force_energy_helper(B, D, fi, fj, fdi[d1],
+                                                    tls1, tls2,
+                                                    tsig2)
 
     return kern
 
@@ -1816,8 +1791,7 @@ def two_body_mc_en_jit(bond_array_1, c1, etypes1,
 
     return kern
 
-
-def many_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
+def many_body_mc(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                  nspec, spec_mask,
                  nbond, bond_mask, ntriplet, triplet_mask,
                  ncut3b, cut3b_mask,
@@ -1861,11 +1835,11 @@ def many_body_mc(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
                                    env1.ctype, env2.ctype,
                                    env1.etypes_mb, env2.etypes_mb,
                                    env1.unique_species, env2.unique_species,
-                                   d1, d2, sigm, lsm,
+                                   sigm, lsm,
                                    nspec, spec_mask, mb_mask)
 
 
-def many_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
+def many_body_mc_grad(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                       nspec, spec_mask,
                       nbond, bond_mask, ntriplet, triplet_mask,
                       ncut3b, cut3b_mask,
@@ -1913,11 +1887,11 @@ def many_body_mc_grad(env1, env2, d1, d2, cutoff_2b, cutoff_3b, cutoff_mb,
                                         env1.ctype, env2.ctype,
                                         env1.etypes_mb, env2.etypes_mb,
                                         env1.unique_species, env2.unique_species,
-                                        d1, d2, sigm, lsm,
+                                        sigm, lsm,
                                         nspec, spec_mask, nmb, mb_mask)
 
 
-def many_body_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
+def many_body_mc_force_en(env1, env2, cutoff_2b, cutoff_3b, cutoff_mb,
                           nspec, spec_mask,
                           nbond, bond_mask, ntriplet, triplet_mask,
                           ncut3b, cut3b_mask,
@@ -1944,7 +1918,7 @@ def many_body_mc_force_en(env1, env2, d1, cutoff_2b, cutoff_3b, cutoff_mb,
                                             env1.ctype, env2.ctype,
                                             env1.etypes_mb,
                                             env1.unique_species, env2.unique_species,
-                                            d1, sigm, lsm,
+                                            sigm, lsm,
                                             nspec, spec_mask, mb_mask)
 
 

--- a/flare/kernels/mc_simple.py
+++ b/flare/kernels/mc_simple.py
@@ -722,10 +722,10 @@ def many_body_mc_force_en(env1, env2, hyps, cutoffs,
     """
     # divide by three to account for triple counting
     return many_body_mc_force_en_jit(env1.q_array, env2.q_array,
-                              env1.q_neigh_array, env1.q_neigh_grads,
-                              env1.ctype, env2.ctype, env1.etypes_mb,
-                              env1.unique_species, env2.unique_species,
-                              hyps[0], hyps[1])
+                                     env1.q_neigh_array, env1.q_neigh_grads,
+                                     env1.ctype, env2.ctype, env1.etypes_mb,
+                                     env1.unique_species, env2.unique_species,
+                                     hyps[0], hyps[1])
 
 
 def many_body_mc_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
@@ -879,27 +879,27 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                                     for d2 in range(3):
                                         if (c1 == c2):
                                             if (ei1 == ej1) and (ei2 == ej2):
-                                                kern[d1,d2] += \
+                                                kern[d1, d2] += \
                                                     three_body_helper_1(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r11,
                                                                         r22, r33, fi, fj, fdi[d1], fdj[d2],
                                                                         ls1, ls2, ls3,
                                                                         sig2)
                                             if (ei1 == ej2) and (ei2 == ej1):
-                                                kern[d1,d2] += \
+                                                kern[d1, d2] += \
                                                     three_body_helper_1(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r12,
                                                                         r21, r33, fi, fj, fdi[d1], fdj[d2],
                                                                         ls1, ls2, ls3,
                                                                         sig2)
                                         if (c1 == ej1):
                                             if (ei1 == ej2) and (ei2 == c2):
-                                                kern[d1,d2] += \
+                                                kern[d1, d2] += \
                                                     three_body_helper_2(ci2[d1], ci1[d1], cj2[d2], cj1[d2], r21,
                                                                         r13, r32, fi, fj, fdi[d1],
                                                                         fdj[d2],
                                                                         ls1, ls2, ls3,
                                                                         sig2)
                                             if (ei1 == c2) and (ei2 == ej2):
-                                                kern[d1,d2] += \
+                                                kern[d1, d2] += \
                                                     three_body_helper_2(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r11,
                                                                         r23, r32, fi, fj, fdi[d1],
                                                                         fdj[d2],
@@ -907,14 +907,14 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                                                                         sig2)
                                         if (c1 == ej2):
                                             if (ei1 == ej1) and (ei2 == c2):
-                                                kern[d1,d2] += \
+                                                kern[d1, d2] += \
                                                     three_body_helper_2(ci2[d1], ci1[d1], cj1[d2], cj2[d2], r22,
                                                                         r13, r31, fi, fj, fdi[d1],
                                                                         fdj[d2],
                                                                         ls1, ls2, ls3,
                                                                         sig2)
                                             if (ei1 == c2) and (ei2 == ej1):
-                                                kern[d1,d2] += \
+                                                kern[d1, d2] += \
                                                     three_body_helper_2(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r12,
                                                                         r23, r31, fi, fj, fdi[d1],
                                                                         fdj[d2],
@@ -1251,32 +1251,32 @@ def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                                     if (c1 == c2):
                                         if (ei1 == ej1) and (ei2 == ej2):
                                             kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r11, r22,
-                                                                         r33, fi, fj, fdi[d1],
-                                                                         ls1, ls2, sig2)
+                                                                             r33, fi, fj, fdi[d1],
+                                                                             ls1, ls2, sig2)
                                         if (ei1 == ej2) and (ei2 == ej1):
                                             kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r12, r21,
-                                                                         r33, fi, fj, fdi[d1],
-                                                                         ls1, ls2, sig2)
+                                                                             r33, fi, fj, fdi[d1],
+                                                                             ls1, ls2, sig2)
                                     if (c1 == ej1):
                                         if (ei1 == ej2) and (ei2 == c2):
                                             kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r13, r21,
-                                                                         r32, fi, fj, fdi[d1],
-                                                                         ls1, ls2, sig2)
+                                                                             r32, fi, fj, fdi[d1],
+                                                                             ls1, ls2, sig2)
                                         if (ei1 == c2) and (ei2 == ej2):
                                             kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r11, r23,
-                                                                         r32, fi, fj, fdi[d1],
-                                                                         ls1, ls2, sig2)
+                                                                             r32, fi, fj, fdi[d1],
+                                                                             ls1, ls2, sig2)
                                     if (c1 == ej2):
                                         if (ei1 == ej1) and (ei2 == c2):
                                             kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r13, r22,
-                                                                         r31, fi, fj, fdi[d1],
-                                                                         ls1,
-                                                                         ls2, sig2)
+                                                                             r31, fi, fj, fdi[d1],
+                                                                             ls1,
+                                                                             ls2, sig2)
                                         if (ei1 == c2) and (ei2 == ej1):
                                             kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r12, r23,
-                                                                         r31, fi, fj, fdi[d1],
-                                                                         ls1,
-                                                                         ls2, sig2)
+                                                                             r31, fi, fj, fdi[d1],
+                                                                             ls1,
+                                                                             ls2, sig2)
 
     return kern
 
@@ -1547,7 +1547,6 @@ def two_body_mc_grad_jit(bond_array_1, c1, etypes1,
 
                     r11 = ri - rj
 
-
                     D = r11 * r11
                     for d1 in range(3):
                         B = r11 * ci[d1]
@@ -1623,8 +1622,8 @@ def two_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                     for d1 in range(3):
                         B = r11 * ci[d1]
                         kern[d1] += force_energy_helper(B, D, fi, fj, fdi[d1],
-                                                    ls1, ls2,
-                                                    sig2)
+                                                        ls1, ls2,
+                                                        sig2)
 
     return kern
 
@@ -1733,8 +1732,8 @@ def many_body_mc_jit(q_array_1, q_array_2,
     for s in useful_species:
 
         # Calculate many-body descriptor values for central atoms 1 and 2
-        s1 = np.where(species1==s)[0][0]
-        s2 = np.where(species2==s)[0][0]
+        s1 = np.where(species1 == s)[0][0]
+        s2 = np.where(species2 == s)[0][0]
         q1 = q_array_1[s1]
         q2 = q_array_2[s2]
 
@@ -1848,8 +1847,8 @@ def many_body_mc_grad_jit(q_array_1, q_array_2,
         list(set(species1).intersection(set(species2))), dtype=np.int8)
 
     for s in useful_species:
-        s1 = np.where(species1==s)[0][0]
-        s2 = np.where(species2==s)[0][0]
+        s1 = np.where(species1 == s)[0][0]
+        s2 = np.where(species2 == s)[0][0]
         q1 = q_array_1[s1]
         q2 = q_array_2[s2]
 
@@ -1860,7 +1859,6 @@ def many_body_mc_grad_jit(q_array_1, q_array_2,
         else:
             k12 = 0
             dk12 = 0
-
 
         # Compute  ki2s, qi1_grads, and qis
         for i in range(q_neigh_array_1.shape[0]):
@@ -1912,21 +1910,21 @@ def many_body_mc_grad_jit(q_array_1, q_array_2,
 
                 for d1 in range(3):
                     for d2 in range(3):
-                         kern_term  = q1i_grads[d1] * q2j_grads[d2] * k12
-                         kern_term += qi1_grads[d1] * q2j_grads[d2] * ki2s
-                         kern_term += q1i_grads[d1] * qj2_grads[d2] * k1js
-                         kern_term += qi1_grads[d1] * qj2_grads[d2] * kij
+                        kern_term = q1i_grads[d1] * q2j_grads[d2] * k12
+                        kern_term += qi1_grads[d1] * q2j_grads[d2] * ki2s
+                        kern_term += q1i_grads[d1] * qj2_grads[d2] * k1js
+                        kern_term += qi1_grads[d1] * qj2_grads[d2] * kij
 
-                         sig_term = 2. / sig * kern_term
+                        sig_term = 2. / sig * kern_term
 
-                         ls_term  = q1i_grads[d1] * q2j_grads[d2] * dk12
-                         ls_term += qi1_grads[d1] * q2j_grads[d2] * dki2s
-                         ls_term += q1i_grads[d1] * qj2_grads[d2] * dk1js
-                         ls_term += qi1_grads[d1] * qj2_grads[d2] * dkij
+                        ls_term = q1i_grads[d1] * q2j_grads[d2] * dk12
+                        ls_term += qi1_grads[d1] * q2j_grads[d2] * dki2s
+                        ls_term += q1i_grads[d1] * qj2_grads[d2] * dk1js
+                        ls_term += qi1_grads[d1] * qj2_grads[d2] * dkij
 
-                         kern[d1, d2] += kern_term
-                         sig_derv[d1, d2] += sig_term
-                         ls_derv[d1, d2] += ls_term
+                        kern[d1, d2] += kern_term
+                        sig_derv[d1, d2] += sig_term
+                        ls_derv[d1, d2] += ls_term
 
     return kern, np.stack((sig_derv, ls_derv))
 
@@ -1958,8 +1956,8 @@ def many_body_mc_force_en_jit(q_array_1, q_array_2,
         list(set(species1).intersection(set(species2))), dtype=np.int8)
 
     for s in useful_species:
-        s1 = np.where(species1==s)[0][0]
-        s2 = np.where(species2==s)[0][0]
+        s1 = np.where(species1 == s)[0][0]
+        s2 = np.where(species2 == s)[0][0]
         q1 = q_array_1[s1]
         q2 = q_array_2[s2]
 
@@ -2025,8 +2023,8 @@ def many_body_mc_en_jit(q_array_1, q_array_2, c1, c2,
 
     if c1 == c2:
         for s in useful_species:
-            q1 = q_array_1[np.where(species1==s)[0][0]]
-            q2 = q_array_2[np.where(species2==s)[0][0]]
+            q1 = q_array_1[np.where(species1 == s)[0][0]]
+            q2 = q_array_2[np.where(species2 == s)[0][0]]
             q1q2diff = q1 - q2
             kern += sig * sig * exp(-q1q2diff * q1q2diff / (2 * ls * ls))
     return kern

--- a/flare/kernels/mc_simple.py
+++ b/flare/kernels/mc_simple.py
@@ -21,7 +21,7 @@ from typing import Callable
 
 
 def two_plus_three_body_mc(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                           d1: int, d2: int, hyps: 'ndarray',
+                           hyps: 'ndarray',
                            cutoffs: 'ndarray',
                            cutoff_func: Callable = cf.quadratic_cutoff) \
         -> float:
@@ -30,8 +30,6 @@ def two_plus_three_body_mc(env1: AtomicEnvironment, env2: AtomicEnvironment,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig1, ls1,
             sig2, ls2, sig_n).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
@@ -51,7 +49,7 @@ def two_plus_three_body_mc(env1: AtomicEnvironment, env2: AtomicEnvironment,
 
     two_term = two_body_mc_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                                env2.bond_array_2, env2.ctype, env2.etypes,
-                               d1, d2, sig2, ls2, r_cut_2, cutoff_func)
+                               sig2, ls2, r_cut_2, cutoff_func)
 
     three_term = \
         three_body_mc_jit(env1.bond_array_3, env1.ctype, env1.etypes,
@@ -59,14 +57,14 @@ def two_plus_three_body_mc(env1: AtomicEnvironment, env2: AtomicEnvironment,
                           env1.cross_bond_inds, env2.cross_bond_inds,
                           env1.cross_bond_dists, env2.cross_bond_dists,
                           env1.triplet_counts, env2.triplet_counts,
-                          d1, d2, sig3, ls3, r_cut_3, cutoff_func)
+                          sig3, ls3, r_cut_3, cutoff_func)
 
     return two_term + three_term
 
 
 def two_plus_three_body_mc_grad(env1: AtomicEnvironment,
                                 env2: AtomicEnvironment,
-                                d1: int, d2: int, hyps: 'ndarray',
+                                hyps: 'ndarray',
                                 cutoffs: 'ndarray',
                                 cutoff_func: Callable = cf.quadratic_cutoff) \
         -> ('float', 'ndarray'):
@@ -76,8 +74,6 @@ def two_plus_three_body_mc_grad(env1: AtomicEnvironment,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig1, ls1,
             sig2, ls2, sig_n).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
@@ -100,7 +96,7 @@ def two_plus_three_body_mc_grad(env1: AtomicEnvironment,
     kern2, grad2 = \
         two_body_mc_grad_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                              env2.bond_array_2, env2.ctype, env2.etypes,
-                             d1, d2, sig2, ls2, r_cut_2, cutoff_func)
+                             sig2, ls2, r_cut_2, cutoff_func)
 
     kern3, grad3 = \
         three_body_mc_grad_jit(env1.bond_array_3, env1.ctype, env1.etypes,
@@ -108,15 +104,15 @@ def two_plus_three_body_mc_grad(env1: AtomicEnvironment,
                                env1.cross_bond_inds, env2.cross_bond_inds,
                                env1.cross_bond_dists, env2.cross_bond_dists,
                                env1.triplet_counts, env2.triplet_counts,
-                               d1, d2, sig3, ls3, r_cut_3,
+                               sig3, ls3, r_cut_3,
                                cutoff_func)
 
-    return kern2 + kern3, np.array([grad2[0], grad2[1], grad3[0], grad3[1]])
+    return kern2 + kern3, np.vstack((grad2, grad3))
 
 
 def two_plus_three_mc_force_en(env1: AtomicEnvironment,
                                env2: AtomicEnvironment,
-                               d1: int, hyps: 'ndarray', cutoffs: 'ndarray',
+                               hyps: 'ndarray', cutoffs: 'ndarray',
                                cutoff_func: Callable = cf.quadratic_cutoff) \
         -> float:
     """2+3-body multi-element kernel between a force component and a local
@@ -127,7 +123,6 @@ def two_plus_three_mc_force_en(env1: AtomicEnvironment,
             force component.
         env2 (AtomicEnvironment): Local environment associated with the
             local energy.
-        d1 (int): Force component of the first environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig1, ls1,
             sig2, ls2).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
@@ -148,7 +143,7 @@ def two_plus_three_mc_force_en(env1: AtomicEnvironment,
     two_term = \
         two_body_mc_force_en_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                                  env2.bond_array_2, env2.ctype, env2.etypes,
-                                 d1, sig2, ls2, r_cut_2, cutoff_func) / 2
+                                 sig2, ls2, r_cut_2, cutoff_func) / 2
 
     three_term = \
         three_body_mc_force_en_jit(env1.bond_array_3, env1.ctype, env1.etypes,
@@ -157,7 +152,7 @@ def two_plus_three_mc_force_en(env1: AtomicEnvironment,
                                    env1.cross_bond_dists,
                                    env2.cross_bond_dists,
                                    env1.triplet_counts, env2.triplet_counts,
-                                   d1, sig3, ls3, r_cut_3, cutoff_func) / 3
+                                   sig3, ls3, r_cut_3, cutoff_func) / 3
 
     return two_term + three_term
 
@@ -209,15 +204,13 @@ def two_plus_three_mc_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
 
 def two_plus_three_plus_many_body_mc(env1: AtomicEnvironment,
                                      env2: AtomicEnvironment,
-                                     d1: int, d2: int, hyps, cutoffs,
+                                     hyps, cutoffs,
                                      cutoff_func=cf.quadratic_cutoff):
     """2+3-body single-element kernel between two force components.
 
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig1, ls1,
             sig2, ls2, sig3, ls3, sig_n).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
@@ -241,7 +234,7 @@ def two_plus_three_plus_many_body_mc(env1: AtomicEnvironment,
 
     two_term = two_body_mc_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                                env2.bond_array_2, env2.ctype, env2.etypes,
-                               d1, d2, sig2, ls2, r_cut_2, cutoff_func)
+                               sig2, ls2, r_cut_2, cutoff_func)
 
     three_term = \
         three_body_mc_jit(env1.bond_array_3, env1.ctype, env1.etypes,
@@ -249,7 +242,7 @@ def two_plus_three_plus_many_body_mc(env1: AtomicEnvironment,
                           env1.cross_bond_inds, env2.cross_bond_inds,
                           env1.cross_bond_dists, env2.cross_bond_dists,
                           env1.triplet_counts, env2.triplet_counts,
-                          d1, d2, sig3, ls3, r_cut_3, cutoff_func)
+                          sig3, ls3, r_cut_3, cutoff_func)
 
     many_term = \
         many_body_mc_jit(env1.q_array, env2.q_array,
@@ -258,22 +251,20 @@ def two_plus_three_plus_many_body_mc(env1: AtomicEnvironment,
                          env1.ctype, env2.ctype,
                          env1.etypes_mb, env2.etypes_mb,
                          env1.unique_species, env2.unique_species,
-                         d1, d2, sigm, lsm)
+                         sigm, lsm)
 
     return two_term + three_term + many_term
 
 
 def two_plus_three_plus_many_body_mc_grad(env1: AtomicEnvironment,
                                           env2: AtomicEnvironment,
-                                          d1: int, d2: int, hyps, cutoffs,
+                                          hyps, cutoffs,
                                           cutoff_func=cf.quadratic_cutoff):
     """2+3+many-body single-element kernel between two force components.
 
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig1, ls1,
             sig2, ls2, sig3, ls3, sig_n).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
@@ -298,7 +289,7 @@ def two_plus_three_plus_many_body_mc_grad(env1: AtomicEnvironment,
     kern2, grad2 = \
         two_body_mc_grad_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                              env2.bond_array_2, env2.ctype, env2.etypes,
-                             d1, d2, sig2, ls2, r_cut_2, cutoff_func)
+                             sig2, ls2, r_cut_2, cutoff_func)
 
     kern3, grad3 = \
         three_body_mc_grad_jit(env1.bond_array_3, env1.ctype, env1.etypes,
@@ -306,7 +297,7 @@ def two_plus_three_plus_many_body_mc_grad(env1: AtomicEnvironment,
                                env1.cross_bond_inds, env2.cross_bond_inds,
                                env1.cross_bond_dists, env2.cross_bond_dists,
                                env1.triplet_counts, env2.triplet_counts,
-                               d1, d2, sig3, ls3, r_cut_3, cutoff_func)
+                               sig3, ls3, r_cut_3, cutoff_func)
 
     kern_many, gradm = \
         many_body_mc_grad_jit(env1.q_array, env2.q_array,
@@ -315,14 +306,14 @@ def two_plus_three_plus_many_body_mc_grad(env1: AtomicEnvironment,
                               env1.ctype, env2.ctype,
                               env1.etypes_mb, env2.etypes_mb,
                               env1.unique_species, env2.unique_species,
-                              d1, d2, sigm, lsm)
+                              sigm, lsm)
 
-    return kern2 + kern3 + kern_many, np.hstack([grad2, grad3, gradm])
+    return kern2 + kern3 + kern_many, np.vstack((grad2, grad3, gradm))
 
 
 def two_plus_three_plus_many_body_mc_force_en(env1: AtomicEnvironment,
                                               env2: AtomicEnvironment,
-                                              d1: int, hyps, cutoffs,
+                                              hyps, cutoffs,
                                               cutoff_func=cf.quadratic_cutoff):
     """2+3+many-body single-element kernel between two force and energy
         components.
@@ -330,7 +321,6 @@ def two_plus_three_plus_many_body_mc_force_en(env1: AtomicEnvironment,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig1, ls1,
             sig2, ls2, sig3, ls3, sig_n).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
@@ -355,7 +345,7 @@ def two_plus_three_plus_many_body_mc_force_en(env1: AtomicEnvironment,
     two_term = \
         two_body_mc_force_en_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                                  env2.bond_array_2, env2.ctype, env2.etypes,
-                                 d1, sig2, ls2, r_cut_2, cutoff_func) / 2
+                                 sig2, ls2, r_cut_2, cutoff_func) / 2
 
     three_term = \
         three_body_mc_force_en_jit(env1.bond_array_3, env1.ctype, env1.etypes,
@@ -364,14 +354,14 @@ def two_plus_three_plus_many_body_mc_force_en(env1: AtomicEnvironment,
                                    env1.cross_bond_dists,
                                    env2.cross_bond_dists,
                                    env1.triplet_counts, env2.triplet_counts,
-                                   d1, sig3, ls3, r_cut_3, cutoff_func) / 3
+                                   sig3, ls3, r_cut_3, cutoff_func) / 3
 
     many_term = \
         many_body_mc_force_en_jit(env1.q_array, env2.q_array,
                                   env1.q_neigh_array, env1.q_neigh_grads,
                                   env1.ctype, env2.ctype, env1.etypes_mb,
                                   env1.unique_species, env2.unique_species,
-                                  d1, sigm, lsm)
+                                  sigm, lsm)
 
     return two_term + three_term + many_term
 
@@ -432,15 +422,13 @@ def two_plus_three_plus_many_body_mc_en(env1: AtomicEnvironment,
 
 
 def three_body_mc(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                  d1: int, d2: int, hyps: 'ndarray', cutoffs: 'ndarray',
+                  hyps: 'ndarray', cutoffs: 'ndarray',
                   cutoff_func: Callable = cf.quadratic_cutoff) -> float:
     """3-body multi-element kernel between two force components.
 
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
             cutoffs.
@@ -458,11 +446,11 @@ def three_body_mc(env1: AtomicEnvironment, env2: AtomicEnvironment,
                              env1.cross_bond_inds, env2.cross_bond_inds,
                              env1.cross_bond_dists, env2.cross_bond_dists,
                              env1.triplet_counts, env2.triplet_counts,
-                             d1, d2, sig, ls, r_cut, cutoff_func)
+                             sig, ls, r_cut, cutoff_func)
 
 
 def three_body_mc_grad(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                       d1: int, d2: int, hyps: 'ndarray', cutoffs: 'ndarray',
+                       hyps: 'ndarray', cutoffs: 'ndarray',
                        cutoff_func: Callable = cf.quadratic_cutoff) \
         -> ('float', 'ndarray'):
     """3-body multi-element kernel between two force components and its
@@ -471,8 +459,6 @@ def three_body_mc_grad(env1: AtomicEnvironment, env2: AtomicEnvironment,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
             cutoffs.
@@ -492,11 +478,11 @@ def three_body_mc_grad(env1: AtomicEnvironment, env2: AtomicEnvironment,
                                   env1.cross_bond_inds, env2.cross_bond_inds,
                                   env1.cross_bond_dists, env2.cross_bond_dists,
                                   env1.triplet_counts, env2.triplet_counts,
-                                  d1, d2, sig, ls, r_cut, cutoff_func)
+                                  sig, ls, r_cut, cutoff_func)
 
 
 def three_body_mc_force_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                           d1: int, hyps: 'ndarray', cutoffs: 'ndarray',
+                           hyps: 'ndarray', cutoffs: 'ndarray',
                            cutoff_func: Callable = cf.quadratic_cutoff) \
         -> float:
     """3-body multi-element kernel between a force component and a local
@@ -507,7 +493,6 @@ def three_body_mc_force_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
             force component.
         env2 (AtomicEnvironment): Local environment associated with the
             local energy.
-        d1 (int): Force component of the first environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
             cutoffs.
@@ -529,7 +514,7 @@ def three_body_mc_force_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
                                       env1.cross_bond_dists,
                                       env2.cross_bond_dists,
                                       env1.triplet_counts, env2.triplet_counts,
-                                      d1, sig, ls, r_cut, cutoff_func) / 3
+                                      sig, ls, r_cut, cutoff_func) / 3
 
 
 def three_body_mc_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
@@ -567,15 +552,13 @@ def three_body_mc_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
 
 
 def two_body_mc(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                d1: float, d2: float, hyps: 'ndarray', cutoffs: 'ndarray',
+                hyps: 'ndarray', cutoffs: 'ndarray',
                 cutoff_func: Callable = cf.quadratic_cutoff) -> float:
     """2-body multi-element kernel between two force components.
 
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): One-element array containing the 2-body
             cutoff.
@@ -590,11 +573,11 @@ def two_body_mc(env1: AtomicEnvironment, env2: AtomicEnvironment,
 
     return two_body_mc_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                            env2.bond_array_2, env2.ctype, env2.etypes,
-                           d1, d2, sig, ls, r_cut, cutoff_func)
+                           sig, ls, r_cut, cutoff_func)
 
 
 def two_body_mc_grad(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                     d1: int, d2: int, hyps: 'ndarray', cutoffs: 'ndarray',
+                     hyps: 'ndarray', cutoffs: 'ndarray',
                      cutoff_func: Callable = cf.quadratic_cutoff) \
         -> (float, 'ndarray'):
     """2-body multi-element kernel between two force components and its
@@ -603,8 +586,6 @@ def two_body_mc_grad(env1: AtomicEnvironment, env2: AtomicEnvironment,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): One-element array containing the 2-body
             cutoff.
@@ -621,11 +602,11 @@ def two_body_mc_grad(env1: AtomicEnvironment, env2: AtomicEnvironment,
 
     return two_body_mc_grad_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                                 env2.bond_array_2, env2.ctype, env2.etypes,
-                                d1, d2, sig, ls, r_cut, cutoff_func)
+                                sig, ls, r_cut, cutoff_func)
 
 
 def two_body_mc_force_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                         d1: int, hyps: 'ndarray', cutoffs: 'ndarray',
+                         hyps: 'ndarray', cutoffs: 'ndarray',
                          cutoff_func: Callable = cf.quadratic_cutoff) \
         -> float:
     """2-body multi-element kernel between a force component and a local
@@ -636,7 +617,6 @@ def two_body_mc_force_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
             force component.
         env2 (AtomicEnvironment): Local environment associated with the
             local energy.
-        d1 (int): Force component of the first environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): One-element array containing the 2-body
             cutoff.
@@ -651,7 +631,7 @@ def two_body_mc_force_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
 
     return two_body_mc_force_en_jit(env1.bond_array_2, env1.ctype, env1.etypes,
                                     env2.bond_array_2, env2.ctype, env2.etypes,
-                                    d1, sig, ls, r_cut, cutoff_func) / 2
+                                    sig, ls, r_cut, cutoff_func) / 2
 
 
 def two_body_mc_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
@@ -686,15 +666,13 @@ def two_body_mc_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
 
 
 def many_body_mc(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                 d1: int, d2: int, hyps: 'ndarray', cutoffs: 'ndarray',
+                 hyps: 'ndarray', cutoffs: 'ndarray',
                  cutoff_func: Callable = cf.quadratic_cutoff) -> float:
     """many-body multi-element kernel between two force components.
 
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
             cutoffs.
@@ -709,11 +687,11 @@ def many_body_mc(env1: AtomicEnvironment, env2: AtomicEnvironment,
                             env1.ctype, env2.ctype,
                             env1.etypes_mb, env2.etypes_mb,
                             env1.unique_species, env2.unique_species,
-                            d1, d2, hyps[0], hyps[1])
+                            hyps[0], hyps[1])
 
 
 def many_body_mc_grad(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                      d1: int, d2: int, hyps: 'ndarray', cutoffs: 'ndarray',
+                      hyps: 'ndarray', cutoffs: 'ndarray',
                       cutoff_func: Callable = cf.quadratic_cutoff) -> float:
     """gradient manybody-body multi-element kernel between two force components.
 
@@ -724,10 +702,10 @@ def many_body_mc_grad(env1: AtomicEnvironment, env2: AtomicEnvironment,
                                  env1.ctype, env2.ctype,
                                  env1.etypes_mb, env2.etypes_mb,
                                  env1.unique_species, env2.unique_species,
-                                 d1, d2, hyps[0], hyps[1])
+                                 hyps[0], hyps[1])
 
 
-def many_body_mc_force_en(env1, env2, d1, hyps, cutoffs,
+def many_body_mc_force_en(env1, env2, hyps, cutoffs,
                           cutoff_func=cf.quadratic_cutoff):
     """many-body single-element kernel between two local energies.
 
@@ -747,7 +725,7 @@ def many_body_mc_force_en(env1, env2, d1, hyps, cutoffs,
                               env1.q_neigh_array, env1.q_neigh_grads,
                               env1.ctype, env2.ctype, env1.etypes_mb,
                               env1.unique_species, env2.unique_species,
-                              d1, hyps[0], hyps[1])
+                              hyps[0], hyps[1])
 
 
 def many_body_mc_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
@@ -783,7 +761,7 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                       cross_bond_inds_1, cross_bond_inds_2,
                       cross_bond_dists_1, cross_bond_dists_2,
                       triplets_1, triplets_2,
-                      d1, d2, sig, ls, r_cut, cutoff_func):
+                      sig, ls, r_cut, cutoff_func):
     """3-body multi-element kernel between two force components accelerated
     with Numba.
 
@@ -820,8 +798,6 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
         triplets_2 (np.ndarray): One dimensional array of integers whose entry
             m is the number of atoms in the second local environment that are
             within a distance r_cut of atom m.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         sig (float): 3-body signal variance hyperparameter.
         ls (float): 3-body length scale hyperparameter.
         r_cut (float): 3-body cutoff radius.
@@ -830,7 +806,7 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
     Return:
         float: Value of the 3-body kernel.
     """
-    kern = 0.0
+    kern = np.zeros((3, 3), dtype=np.float64)
 
     # pre-compute constants that appear in the inner loop
     sig2 = sig * sig
@@ -838,26 +814,24 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
     ls2 = 1 / (ls * ls)
     ls3 = ls2 * ls2
 
-    # first loop over the first 3-body environment
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = bond_array_1[m, d1]
-        fi1, fdi1 = cutoff_func(r_cut, ri1, ci1)
+        ci1 = bond_array_1[m, 1:4]
         ei1 = etypes1[m]
 
-        # second loop over the first 3-body environment
-        for n in range(triplets_1[m]):
+        fi1, fdi1 = cutoff_func(r_cut, ri1, ci1)
 
-            # skip if species does not match
+        for n in range(triplets_1[m]):
             ind1 = cross_bond_inds_1[m, m + n + 1]
             ei2 = etypes1[ind1]
+
             tr_spec = [c1, ei1, ei2]
             c2_ind = tr_spec
             if c2 in tr_spec:
                 tr_spec.remove(c2)
 
                 ri2 = bond_array_1[ind1, 0]
-                ci2 = bond_array_1[ind1, d1]
+                ci2 = bond_array_1[ind1, 1:4]
                 fi2, fdi2 = cutoff_func(r_cut, ri2, ci2)
 
                 ri3 = cross_bond_dists_1[m, m + n + 1]
@@ -866,29 +840,24 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                 fi = fi1 * fi2 * fi3
                 fdi = fdi1 * fi2 * fi3 + fi1 * fdi2 * fi3
 
-                # first loop over the second 3-body environment
                 for p in range(bond_array_2.shape[0]):
-
                     ej1 = etypes2[p]
-
                     tr_spec1 = [tr_spec[0], tr_spec[1]]
                     if ej1 in tr_spec1:
                         tr_spec1.remove(ej1)
-
                         rj1 = bond_array_2[p, 0]
-                        cj1 = bond_array_2[p, d2]
+                        cj1 = bond_array_2[p, 1:4]
                         fj1, fdj1 = cutoff_func(r_cut, rj1, cj1)
 
-                        # second loop over the second 3-body environment
                         for q in range(triplets_2[p]):
-
                             ind2 = cross_bond_inds_2[p, p + 1 + q]
                             ej2 = etypes2[ind2]
                             if ej2 == tr_spec1[0]:
-
+                                ind2 = cross_bond_inds_2[p, p + 1 + q]
                                 rj2 = bond_array_2[ind2, 0]
-                                cj2 = bond_array_2[ind2, d2]
+                                cj2 = bond_array_2[ind2, 1:4]
                                 fj2, fdj2 = cutoff_func(r_cut, rj2, cj2)
+                                ej2 = etypes2[ind2]
 
                                 rj3 = cross_bond_dists_2[p, p + 1 + q]
                                 fj3, _ = cutoff_func(r_cut, rj3, 0)
@@ -906,52 +875,51 @@ def three_body_mc_jit(bond_array_1, c1, etypes1,
                                 r32 = ri3 - rj2
                                 r33 = ri3 - rj3
 
-                                # consider six permutations
-                                if (c1 == c2):
-                                    if (ei1 == ej1) and (ei2 == ej2):
-                                        kern += \
-                                            three_body_helper_1(ci1, ci2, cj1,
-                                                                cj2, r11, r22,
-                                                                r33, fi, fj,
-                                                                fdi, fdj, ls1,
-                                                                ls2, ls3, sig2)
-                                    if (ei1 == ej2) and (ei2 == ej1):
-                                        kern += \
-                                            three_body_helper_1(ci1, ci2, cj2,
-                                                                cj1, r12, r21,
-                                                                r33, fi, fj,
-                                                                fdi, fdj, ls1,
-                                                                ls2, ls3, sig2)
-                                if (c1 == ej1):
-                                    if (ei1 == ej2) and (ei2 == c2):
-                                        kern += \
-                                            three_body_helper_2(ci2, ci1, cj2,
-                                                                cj1, r21, r13,
-                                                                r32, fi, fj,
-                                                                fdi, fdj, ls1,
-                                                                ls2, ls3, sig2)
-                                    if (ei1 == c2) and (ei2 == ej2):
-                                        kern += \
-                                            three_body_helper_2(ci1, ci2, cj2,
-                                                                cj1, r11, r23,
-                                                                r32, fi, fj,
-                                                                fdi, fdj, ls1,
-                                                                ls2, ls3, sig2)
-                                if (c1 == ej2):
-                                    if (ei1 == ej1) and (ei2 == c2):
-                                        kern += \
-                                            three_body_helper_2(ci2, ci1, cj1,
-                                                                cj2, r22, r13,
-                                                                r31, fi, fj,
-                                                                fdi, fdj, ls1,
-                                                                ls2, ls3, sig2)
-                                    if (ei1 == c2) and (ei2 == ej1):
-                                        kern += \
-                                            three_body_helper_2(ci1, ci2, cj1,
-                                                                cj2, r12, r23,
-                                                                r31, fi, fj,
-                                                                fdi, fdj, ls1,
-                                                                ls2, ls3, sig2)
+                                for d1 in range(3):
+                                    for d2 in range(3):
+                                        if (c1 == c2):
+                                            if (ei1 == ej1) and (ei2 == ej2):
+                                                kern[d1,d2] += \
+                                                    three_body_helper_1(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r11,
+                                                                        r22, r33, fi, fj, fdi[d1], fdj[d2],
+                                                                        ls1, ls2, ls3,
+                                                                        sig2)
+                                            if (ei1 == ej2) and (ei2 == ej1):
+                                                kern[d1,d2] += \
+                                                    three_body_helper_1(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r12,
+                                                                        r21, r33, fi, fj, fdi[d1], fdj[d2],
+                                                                        ls1, ls2, ls3,
+                                                                        sig2)
+                                        if (c1 == ej1):
+                                            if (ei1 == ej2) and (ei2 == c2):
+                                                kern[d1,d2] += \
+                                                    three_body_helper_2(ci2[d1], ci1[d1], cj2[d2], cj1[d2], r21,
+                                                                        r13, r32, fi, fj, fdi[d1],
+                                                                        fdj[d2],
+                                                                        ls1, ls2, ls3,
+                                                                        sig2)
+                                            if (ei1 == c2) and (ei2 == ej2):
+                                                kern[d1,d2] += \
+                                                    three_body_helper_2(ci1[d1], ci2[d1], cj2[d2], cj1[d2], r11,
+                                                                        r23, r32, fi, fj, fdi[d1],
+                                                                        fdj[d2],
+                                                                        ls1, ls2, ls3,
+                                                                        sig2)
+                                        if (c1 == ej2):
+                                            if (ei1 == ej1) and (ei2 == c2):
+                                                kern[d1,d2] += \
+                                                    three_body_helper_2(ci2[d1], ci1[d1], cj1[d2], cj2[d2], r22,
+                                                                        r13, r31, fi, fj, fdi[d1],
+                                                                        fdj[d2],
+                                                                        ls1, ls2, ls3,
+                                                                        sig2)
+                                            if (ei1 == c2) and (ei2 == ej1):
+                                                kern[d1,d2] += \
+                                                    three_body_helper_2(ci1[d1], ci2[d1], cj1[d2], cj2[d2], r12,
+                                                                        r23, r31, fi, fj, fdi[d1],
+                                                                        fdj[d2],
+                                                                        ls1, ls2, ls3,
+                                                                        sig2)
 
     return kern
 
@@ -962,7 +930,7 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                            cross_bond_inds_1, cross_bond_inds_2,
                            cross_bond_dists_1, cross_bond_dists_2,
                            triplets_1, triplets_2,
-                           d1, d2, sig, ls, r_cut, cutoff_func):
+                           sig, ls, r_cut, cutoff_func):
     """3-body multi-element kernel between two force components and its
     gradient with respect to the hyperparameters.
 
@@ -999,8 +967,6 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
         triplets_2 (np.ndarray): One dimensional array of integers whose entry
             m is the number of atoms in the second local environment that are
             within a distance r_cut of atom m.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         sig (float): 3-body signal variance hyperparameter.
         ls (float): 3-body length scale hyperparameter.
         r_cut (float): 3-body cutoff radius.
@@ -1011,31 +977,30 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
             Value of the 3-body kernel and its gradient with respect to the
             hyperparameters.
     """
-    kern = 0.0
-    sig_derv = 0.0
-    ls_derv = 0.0
-    kern_grad = np.zeros(2, dtype=np.float64)
+    kern = np.zeros((3, 3), dtype=np.float64)
+    sig_derv = np.zeros((3, 3), dtype=np.float64)
+    ls_derv = np.zeros((3, 3), dtype=np.float64)
 
     # pre-compute constants that appear in the inner loop
     sig2, sig3, ls1, ls2, ls3, ls4, ls5, ls6 = grad_constants(sig, ls)
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = bond_array_1[m, d1]
+        ci1 = bond_array_1[m, 1:4]
         fi1, fdi1 = cutoff_func(r_cut, ri1, ci1)
         ei1 = etypes1[m]
 
         for n in range(triplets_1[m]):
             ind1 = cross_bond_inds_1[m, m + n + 1]
-            ri3 = cross_bond_dists_1[m, m + n + 1]
-            ri2 = bond_array_1[ind1, 0]
-            ci2 = bond_array_1[ind1, d1]
             ei2 = etypes1[ind1]
-
             tr_spec = [c1, ei1, ei2]
             c2_ind = tr_spec
             if c2 in tr_spec:
                 tr_spec.remove(c2)
+
+                ri3 = cross_bond_dists_1[m, m + n + 1]
+                ri2 = bond_array_1[ind1, 0]
+                ci2 = bond_array_1[ind1, 1:4]
 
                 fi2, fdi2 = cutoff_func(r_cut, ri2, ci2)
                 fi3, _ = cutoff_func(r_cut, ri3, 0)
@@ -1044,24 +1009,23 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                 fdi = fdi1 * fi2 * fi3 + fi1 * fdi2 * fi3
 
                 for p in range(bond_array_2.shape[0]):
-                    rj1 = bond_array_2[p, 0]
-                    cj1 = bond_array_2[p, d2]
-                    fj1, fdj1 = cutoff_func(r_cut, rj1, cj1)
                     ej1 = etypes2[p]
-
                     tr_spec1 = [tr_spec[0], tr_spec[1]]
                     if ej1 in tr_spec1:
                         tr_spec1.remove(ej1)
+                        rj1 = bond_array_2[p, 0]
+                        cj1 = bond_array_2[p, 1:4]
+                        fj1, fdj1 = cutoff_func(r_cut, rj1, cj1)
 
                         for q in range(triplets_2[p]):
-                            ind2 = cross_bond_inds_2[p, p + q + 1]
+                            ind2 = cross_bond_inds_2[p, p + 1 + q]
                             ej2 = etypes2[ind2]
-
                             if ej2 == tr_spec1[0]:
-
+                                ind2 = cross_bond_inds_2[p, p + q + 1]
                                 rj3 = cross_bond_dists_2[p, p + q + 1]
                                 rj2 = bond_array_2[ind2, 0]
-                                cj2 = bond_array_2[ind2, d2]
+                                cj2 = bond_array_2[ind2, 1:4]
+                                ej2 = etypes2[ind2]
 
                                 fj2, fdj2 = cutoff_func(r_cut, rj2, cj2)
                                 fj3, _ = cutoff_func(r_cut, rj3, 0)
@@ -1079,80 +1043,91 @@ def three_body_mc_grad_jit(bond_array_1, c1, etypes1,
                                 r32 = ri3 - rj2
                                 r33 = ri3 - rj3
 
-                                if (c1 == c2):
-                                    if (ei1 == ej1) and (ei2 == ej2):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_1(ci1, ci2, cj1, cj2,
-                                                                     r11, r22, r33, fi, fj,
-                                                                     fdi, fdj, ls1, ls2,
-                                                                     ls3, ls4, ls5, ls6,
-                                                                     sig2, sig3)
-                                        kern += kern_term
-                                        sig_derv += sig_term
-                                        ls_derv += ls_term
+                                for d1 in range(3):
+                                    ci1_d1 = ci1[d1]
+                                    ci2_d1 = ci2[d1]
+                                    fdi_d1 = fdi[d1]
+                                    for d2 in range(3):
+                                        cj1_d2 = cj1[d2]
+                                        cj2_d2 = cj2[d2]
+                                        fdj_d2 = fdj[d2]
+                                        if (c1 == c2):
+                                            if (ei1 == ej1) and (ei2 == ej2):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_1(ci1_d1, ci2_d1, cj1_d2, cj2_d2,
+                                                                             r11, r22, r33, fi, fj,
+                                                                             fdi_d1, fdj_d2, ls1, ls2,
+                                                                             ls3, ls4, ls5,
+                                                                             ls6,
+                                                                             sig2, sig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[d1, d2] += sig_term
+                                                ls_derv[d1, d2] += ls_term
 
-                                    if (ei1 == ej2) and (ei2 == ej1):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_1(ci1, ci2, cj2, cj1,
-                                                                     r12, r21, r33, fi, fj,
-                                                                     fdi, fdj, ls1, ls2,
-                                                                     ls3, ls4, ls5, ls6,
-                                                                     sig2, sig3)
-                                        kern += kern_term
-                                        sig_derv += sig_term
-                                        ls_derv += ls_term
+                                            if (ei1 == ej2) and (ei2 == ej1):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_1(ci1_d1, ci2_d1, cj2_d2, cj1_d2,
+                                                                             r12, r21, r33, fi, fj,
+                                                                             fdi_d1, fdj_d2, ls1, ls2,
+                                                                             ls3, ls4, ls5,
+                                                                             ls6,
+                                                                             sig2, sig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[d1, d2] += sig_term
+                                                ls_derv[d1, d2] += ls_term
 
-                                if (c1 == ej1):
-                                    if (ei1 == ej2) and (ei2 == c2):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_2(ci2, ci1, cj2, cj1,
-                                                                     r21, r13, r32, fi, fj,
-                                                                     fdi, fdj, ls1, ls2,
-                                                                     ls3, ls4, ls5, ls6,
-                                                                     sig2, sig3)
-                                        kern += kern_term
-                                        sig_derv += sig_term
-                                        ls_derv += ls_term
+                                        if (c1 == ej1):
+                                            if (ei1 == ej2) and (ei2 == c2):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_2(ci2_d1, ci1_d1, cj2_d2, cj1_d2,
+                                                                             r21, r13, r32, fi, fj,
+                                                                             fdi_d1, fdj_d2, ls1, ls2,
+                                                                             ls3, ls4, ls5,
+                                                                             ls6,
+                                                                             sig2, sig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[d1, d2] += sig_term
+                                                ls_derv[d1, d2] += ls_term
 
-                                    if (ei1 == c2) and (ei2 == ej2):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_2(ci1, ci2, cj2, cj1,
-                                                                     r11, r23, r32, fi, fj,
-                                                                     fdi, fdj, ls1, ls2,
-                                                                     ls3, ls4, ls5, ls6,
-                                                                     sig2, sig3)
-                                        kern += kern_term
-                                        sig_derv += sig_term
-                                        ls_derv += ls_term
+                                            if (ei1 == c2) and (ei2 == ej2):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_2(ci1_d1, ci2_d1, cj2_d2, cj1_d2,
+                                                                             r11, r23, r32, fi, fj,
+                                                                             fdi_d1, fdj_d2, ls1, ls2,
+                                                                             ls3, ls4, ls5,
+                                                                             ls6,
+                                                                             sig2, sig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[d1, d2] += sig_term
+                                                ls_derv[d1, d2] += ls_term
 
-                                if (c1 == ej2):
-                                    if (ei1 == ej1) and (ei2 == c2):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_2(ci2, ci1, cj1, cj2,
-                                                                     r22, r13, r31, fi, fj,
-                                                                     fdi, fdj, ls1, ls2,
-                                                                     ls3, ls4, ls5, ls6,
-                                                                     sig2, sig3)
-                                        kern += kern_term
-                                        sig_derv += sig_term
-                                        ls_derv += ls_term
+                                        if (c1 == ej2):
+                                            if (ei1 == ej1) and (ei2 == c2):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_2(ci2_d1, ci1_d1, cj1_d2, cj2_d2,
+                                                                             r22, r13, r31, fi, fj,
+                                                                             fdi_d1, fdj_d2, ls1, ls2,
+                                                                             ls3, ls4, ls5,
+                                                                             ls6,
+                                                                             sig2, sig3)
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[d1, d2] += sig_term
+                                                ls_derv[d1, d2] += ls_term
 
-                                    if (ei1 == c2) and (ei2 == ej1):
-                                        kern_term, sig_term, ls_term = \
-                                            three_body_grad_helper_2(ci1, ci2, cj1, cj2,
-                                                                     r12, r23, r31, fi, fj,
-                                                                     fdi, fdj, ls1, ls2,
-                                                                     ls3, ls4, ls5, ls6,
-                                                                     sig2, sig3)
+                                            if (ei1 == c2) and (ei2 == ej1):
+                                                kern_term, sig_term, ls_term = \
+                                                    three_body_grad_helper_2(ci1_d1, ci2_d1, cj1_d2, cj2_d2,
+                                                                             r12, r23, r31, fi, fj,
+                                                                             fdi_d1, fdj_d2, ls1, ls2,
+                                                                             ls3, ls4, ls5,
+                                                                             ls6,
+                                                                             sig2, sig3)
 
-                                        kern += kern_term
-                                        sig_derv += sig_term
-                                        ls_derv += ls_term
+                                                kern[d1, d2] += kern_term
+                                                sig_derv[d1, d2] += sig_term
+                                                ls_derv[d1, d2] += ls_term
 
-    kern_grad[0] = sig_derv
-    kern_grad[1] = ls_derv
-
-    return kern, kern_grad
+    return kern, np.stack((sig_derv, ls_derv))
 
 
 @njit
@@ -1161,7 +1136,7 @@ def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                                cross_bond_inds_1, cross_bond_inds_2,
                                cross_bond_dists_1, cross_bond_dists_2,
                                triplets_1, triplets_2,
-                               d1, sig, ls, r_cut, cutoff_func):
+                               sig, ls, r_cut, cutoff_func):
     """3-body multi-element kernel between a force component and a local
     energy accelerated with Numba.
 
@@ -1208,7 +1183,7 @@ def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
         float:
             Value of the 3-body force/energy kernel.
     """
-    kern = 0
+    kern = np.zeros(3, dtype=np.float64)
 
     # pre-compute constants that appear in the inner loop
     sig2 = sig * sig
@@ -1217,21 +1192,20 @@ def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = bond_array_1[m, d1]
+        ci1 = bond_array_1[m, 1:4]
         fi1, fdi1 = cutoff_func(r_cut, ri1, ci1)
         ei1 = etypes1[m]
 
         for n in range(triplets_1[m]):
             ind1 = cross_bond_inds_1[m, m + n + 1]
-            ri2 = bond_array_1[ind1, 0]
-            ci2 = bond_array_1[ind1, d1]
-            fi2, fdi2 = cutoff_func(r_cut, ri2, ci2)
             ei2 = etypes1[ind1]
-
             tr_spec = [c1, ei1, ei2]
             c2_ind = tr_spec
             if c2 in tr_spec:
                 tr_spec.remove(c2)
+                ri2 = bond_array_1[ind1, 0]
+                ci2 = bond_array_1[ind1, 1:4]
+                fi2, fdi2 = cutoff_func(r_cut, ri2, ci2)
 
                 ri3 = cross_bond_dists_1[m, m + n + 1]
                 fi3, _ = cutoff_func(r_cut, ri3, 0)
@@ -1240,25 +1214,25 @@ def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                 fdi = fdi1 * fi2 * fi3 + fi1 * fdi2 * fi3
 
                 for p in range(bond_array_2.shape[0]):
-                    ej1 = etypes2[p]
 
+                    ej1 = etypes2[p]
                     tr_spec1 = [tr_spec[0], tr_spec[1]]
                     if ej1 in tr_spec1:
                         tr_spec1.remove(ej1)
-
                         rj1 = bond_array_2[p, 0]
                         fj1, _ = cutoff_func(r_cut, rj1, 0)
 
                         for q in range(triplets_2[p]):
 
-                            ind2 = cross_bond_inds_2[p, p + q + 1]
+                            ind2 = cross_bond_inds_2[p, p + 1 + q]
                             ej2 = etypes2[ind2]
                             if ej2 == tr_spec1[0]:
 
+                                ind2 = cross_bond_inds_2[p, p + q + 1]
                                 rj2 = bond_array_2[ind2, 0]
                                 fj2, _ = cutoff_func(r_cut, rj2, 0)
+                                ej2 = etypes2[ind2]
                                 rj3 = cross_bond_dists_2[p, p + q + 1]
-
                                 fj3, _ = cutoff_func(r_cut, rj3, 0)
                                 fj = fj1 * fj2 * fj3
 
@@ -1272,33 +1246,37 @@ def three_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                                 r32 = ri3 - rj2
                                 r33 = ri3 - rj3
 
-                                if (c1 == c2):
-                                    if (ei1 == ej1) and (ei2 == ej2):
-                                        kern += three_body_en_helper(ci1, ci2, r11, r22,
-                                                                     r33, fi, fj, fdi, ls1,
-                                                                     ls2, sig2)
-                                    if (ei1 == ej2) and (ei2 == ej1):
-                                        kern += three_body_en_helper(ci1, ci2, r12, r21,
-                                                                     r33, fi, fj, fdi, ls1,
-                                                                     ls2, sig2)
-                                if (c1 == ej1):
-                                    if (ei1 == ej2) and (ei2 == c2):
-                                        kern += three_body_en_helper(ci1, ci2, r13, r21,
-                                                                     r32, fi, fj, fdi, ls1,
-                                                                     ls2, sig2)
-                                    if (ei1 == c2) and (ei2 == ej2):
-                                        kern += three_body_en_helper(ci1, ci2, r11, r23,
-                                                                     r32, fi, fj, fdi, ls1,
-                                                                     ls2, sig2)
-                                if (c1 == ej2):
-                                    if (ei1 == ej1) and (ei2 == c2):
-                                        kern += three_body_en_helper(ci1, ci2, r13, r22,
-                                                                     r31, fi, fj, fdi, ls1,
-                                                                     ls2, sig2)
-                                    if (ei1 == c2) and (ei2 == ej1):
-                                        kern += three_body_en_helper(ci1, ci2, r12, r23,
-                                                                     r31, fi, fj, fdi, ls1,
-                                                                     ls2, sig2)
+                                for d1 in range(3):
+
+                                    if (c1 == c2):
+                                        if (ei1 == ej1) and (ei2 == ej2):
+                                            kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r11, r22,
+                                                                         r33, fi, fj, fdi[d1],
+                                                                         ls1, ls2, sig2)
+                                        if (ei1 == ej2) and (ei2 == ej1):
+                                            kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r12, r21,
+                                                                         r33, fi, fj, fdi[d1],
+                                                                         ls1, ls2, sig2)
+                                    if (c1 == ej1):
+                                        if (ei1 == ej2) and (ei2 == c2):
+                                            kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r13, r21,
+                                                                         r32, fi, fj, fdi[d1],
+                                                                         ls1, ls2, sig2)
+                                        if (ei1 == c2) and (ei2 == ej2):
+                                            kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r11, r23,
+                                                                         r32, fi, fj, fdi[d1],
+                                                                         ls1, ls2, sig2)
+                                    if (c1 == ej2):
+                                        if (ei1 == ej1) and (ei2 == c2):
+                                            kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r13, r22,
+                                                                         r31, fi, fj, fdi[d1],
+                                                                         ls1,
+                                                                         ls2, sig2)
+                                        if (ei1 == c2) and (ei2 == ej1):
+                                            kern[d1] += three_body_en_helper(ci1[d1], ci2[d1], r12, r23,
+                                                                         r31, fi, fj, fdi[d1],
+                                                                         ls1,
+                                                                         ls2, sig2)
 
     return kern
 
@@ -1356,7 +1334,7 @@ def three_body_mc_en_jit(bond_array_1, c1, etypes1,
             Value of the 3-body local energy kernel.
     """
 
-    kern = 0
+    kern = 0.0
 
     sig2 = sig * sig
     ls2 = 1 / (2 * ls * ls)
@@ -1445,7 +1423,7 @@ def three_body_mc_en_jit(bond_array_1, c1, etypes1,
 @njit
 def two_body_mc_jit(bond_array_1, c1, etypes1,
                     bond_array_2, c2, etypes2,
-                    d1, d2, sig, ls, r_cut, cutoff_func):
+                    sig, ls, r_cut, cutoff_func):
     """2-body multi-element kernel between two force components accelerated
     with Numba.
 
@@ -1460,8 +1438,6 @@ def two_body_mc_jit(bond_array_1, c1, etypes1,
         c2 (int): Species of the central atom of the second local environment.
         etypes2 (np.ndarray): Species of atoms in the second local
             environment.
-        d1 (int): Force component of the first environment (1=x, 2=y, 3=z).
-        d2 (int): Force component of the second environment (1=x, 2=y, 3=z).
         sig (float): 2-body signal variance hyperparameter.
         ls (float): 2-body length scale hyperparameter.
         r_cut (float): 2-body cutoff radius.
@@ -1470,7 +1446,7 @@ def two_body_mc_jit(bond_array_1, c1, etypes1,
     Return:
         float: Value of the 2-body kernel.
     """
-    kern = 0
+    kern = np.zeros((3, 3), dtype=np.float64)
 
     ls1 = 1 / (2 * ls * ls)
     ls2 = 1 / (ls * ls)
@@ -1478,28 +1454,33 @@ def two_body_mc_jit(bond_array_1, c1, etypes1,
     sig2 = sig * sig
 
     for m in range(bond_array_1.shape[0]):
-        ri = bond_array_1[m, 0]
-        ci = bond_array_1[m, d1]
-        fi, fdi = cutoff_func(r_cut, ri, ci)
         e1 = etypes1[m]
 
-        for n in range(bond_array_2.shape[0]):
-            e2 = etypes2[n]
+        if ((c2 == e1) or (c2 == c1)):
+            ri = bond_array_1[m, 0]
+            ci = bond_array_1[m, 1:4]
 
-            # check if bonds agree
-            if (c1 == c2 and e1 == e2) or (c1 == e2 and c2 == e1):
-                rj = bond_array_2[n, 0]
-                cj = bond_array_2[n, d2]
-                fj, fdj = cutoff_func(r_cut, rj, cj)
-                r11 = ri - rj
+            fi, fdi = cutoff_func(r_cut, ri, ci)
 
-                A = ci * cj
-                B = r11 * ci
-                C = r11 * cj
-                D = r11 * r11
+            for n in range(bond_array_2.shape[0]):
+                e2 = etypes2[n]
 
-                kern += force_helper(A, B, C, D, fi, fj, fdi, fdj,
-                                     ls1, ls2, ls3, sig2)
+                # check if bonds agree
+                if (c1 == c2 and e1 == e2) or (c1 == e2 and c2 == e1):
+                    rj = bond_array_2[n, 0]
+                    cj = bond_array_2[n, 1:4]
+                    fj, fdj = cutoff_func(r_cut, rj, cj)
+                    r11 = ri - rj
+
+                    D = r11 * r11
+                    for d1 in range(3):
+                        B = r11 * ci[d1]
+                        for d2 in range(3):
+                            A = ci[d1] * cj[d2]
+                            C = r11 * cj[d2]
+
+                            kern[d1, d2] += force_helper(A, B, C, D, fi, fj, fdi[d1], fdj[d2],
+                                                         ls1, ls2, ls3, sig2)
 
     return kern
 
@@ -1507,7 +1488,7 @@ def two_body_mc_jit(bond_array_1, c1, etypes1,
 @njit
 def two_body_mc_grad_jit(bond_array_1, c1, etypes1,
                          bond_array_2, c2, etypes2,
-                         d1, d2, sig, ls, r_cut, cutoff_func):
+                         sig, ls, r_cut, cutoff_func):
     """2-body multi-element kernel between two force components and its
     gradient with respect to the hyperparameters.
 
@@ -1522,8 +1503,6 @@ def two_body_mc_grad_jit(bond_array_1, c1, etypes1,
         c2 (int): Species of the central atom of the second local environment.
         etypes2 (np.ndarray): Species of atoms in the second local
             environment.
-        d1 (int): Force component of the first environment (1=x, 2=y, 3=z).
-        d2 (int): Force component of the second environment (1=x, 2=y, 3=z).
         sig (float): 2-body signal variance hyperparameter.
         ls (float): 2-body length scale hyperparameter.
         r_cut (float): 2-body cutoff radius.
@@ -1535,10 +1514,9 @@ def two_body_mc_grad_jit(bond_array_1, c1, etypes1,
             hyperparameters.
     """
 
-    kern = 0.0
-    sig_derv = 0.0
-    ls_derv = 0.0
-    kern_grad = np.zeros(2, dtype=np.float64)
+    kern = np.zeros((3, 3), dtype=np.float64)
+    sig_derv = np.zeros((3, 3), dtype=np.float64)
+    ls_derv = np.zeros((3, 3), dtype=np.float64)
 
     ls1 = 1 / (2 * ls * ls)
     ls2 = 1 / (ls * ls)
@@ -1551,45 +1529,49 @@ def two_body_mc_grad_jit(bond_array_1, c1, etypes1,
     sig3 = 2 * sig
 
     for m in range(bond_array_1.shape[0]):
-        ri = bond_array_1[m, 0]
-        ci = bond_array_1[m, d1]
-        fi, fdi = cutoff_func(r_cut, ri, ci)
         e1 = etypes1[m]
+        if ((c2 == e1) or (c2 == c1)):
+            ri = bond_array_1[m, 0]
+            ci = bond_array_1[m, 1:4]
 
-        for n in range(bond_array_2.shape[0]):
-            e2 = etypes2[n]
+            fi, fdi = cutoff_func(r_cut, ri, ci)
 
-            # check if bonds agree
-            if (c1 == c2 and e1 == e2) or (c1 == e2 and c2 == e1):
-                rj = bond_array_2[n, 0]
-                cj = bond_array_2[n, d2]
-                fj, fdj = cutoff_func(r_cut, rj, cj)
+            for n in range(bond_array_2.shape[0]):
+                e2 = etypes2[n]
 
-                r11 = ri - rj
+                # check if bonds agree
+                if (c1 == c2 and e1 == e2) or (c1 == e2 and c2 == e1):
+                    rj = bond_array_2[n, 0]
+                    cj = bond_array_2[n, 1:4]
+                    fj, fdj = cutoff_func(r_cut, rj, cj)
 
-                A = ci * cj
-                B = r11 * ci
-                C = r11 * cj
-                D = r11 * r11
+                    r11 = ri - rj
 
-                kern_term, sig_term, ls_term = \
-                    grad_helper(A, B, C, D, fi, fj, fdi, fdj, ls1, ls2, ls3,
-                                ls4, ls5, ls6, sig2, sig3)
 
-                kern += kern_term
-                sig_derv += sig_term
-                ls_derv += ls_term
+                    D = r11 * r11
+                    for d1 in range(3):
+                        B = r11 * ci[d1]
+                        for d2 in range(3):
+                            A = ci[d1] * cj[d2]
+                            C = r11 * cj[d2]
 
-    kern_grad[0] = sig_derv
-    kern_grad[1] = ls_derv
+                            kern_term, sig_term, ls_term = \
+                                grad_helper(A, B, C, D, fi, fj, fdi[d1], fdj[d2],
+                                            ls1, ls2, ls3,
+                                            ls4, ls5, ls6,
+                                            sig2, sig3)
 
-    return kern, kern_grad
+                            kern[d1, d2] += kern_term
+                            sig_derv[d1, d2] += sig_term
+                            ls_derv[d1, d2] += ls_term
+
+    return kern, np.stack((sig_derv, ls_derv))
 
 
 @njit
 def two_body_mc_force_en_jit(bond_array_1, c1, etypes1,
                              bond_array_2, c2, etypes2,
-                             d1, sig, ls, r_cut, cutoff_func):
+                             sig, ls, r_cut, cutoff_func):
     """2-body multi-element kernel between a force component and a local
     energy accelerated with Numba.
 
@@ -1604,7 +1586,6 @@ def two_body_mc_force_en_jit(bond_array_1, c1, etypes1,
         c2 (int): Species of the central atom of the second local environment.
         etypes2 (np.ndarray): Species of atoms in the second local
             environment.
-        d1 (int): Force component of the first environment (1=x, 2=y, 3=z).
         sig (float): 2-body signal variance hyperparameter.
         ls (float): 2-body length scale hyperparameter.
         r_cut (float): 2-body cutoff radius.
@@ -1615,30 +1596,35 @@ def two_body_mc_force_en_jit(bond_array_1, c1, etypes1,
             Value of the 2-body force/energy kernel.
     """
 
-    kern = 0
+    kern = np.zeros(3, dtype=np.float64)
 
     ls1 = 1 / (2 * ls * ls)
     ls2 = 1 / (ls * ls)
     sig2 = sig * sig
 
     for m in range(bond_array_1.shape[0]):
-        ri = bond_array_1[m, 0]
-        ci = bond_array_1[m, d1]
-        fi, fdi = cutoff_func(r_cut, ri, ci)
         e1 = etypes1[m]
+        if ((c2 == e1) or (c2 == c1)):
+            ri = bond_array_1[m, 0]
+            ci = bond_array_1[m, 1:4]
 
-        for n in range(bond_array_2.shape[0]):
-            e2 = etypes2[n]
+            fi, fdi = cutoff_func(r_cut, ri, ci)
 
-            # check if bonds agree
-            if (c1 == c2 and e1 == e2) or (c1 == e2 and c2 == e1):
-                rj = bond_array_2[n, 0]
-                fj, _ = cutoff_func(r_cut, rj, 0)
+            for n in range(bond_array_2.shape[0]):
+                e2 = etypes2[n]
 
-                r11 = ri - rj
-                B = r11 * ci
-                D = r11 * r11
-                kern += force_energy_helper(B, D, fi, fj, fdi, ls1, ls2, sig2)
+                # check if bonds agree
+                if (c1 == c2 and e1 == e2) or (c1 == e2 and c2 == e1):
+                    rj = bond_array_2[n, 0]
+                    fj, _ = cutoff_func(r_cut, rj, 0)
+
+                    r11 = ri - rj
+                    D = r11 * r11
+                    for d1 in range(3):
+                        B = r11 * ci[d1]
+                        kern[d1] += force_energy_helper(B, D, fi, fj, fdi[d1],
+                                                    ls1, ls2,
+                                                    sig2)
 
     return kern
 
@@ -1670,7 +1656,7 @@ def two_body_mc_en_jit(bond_array_1, c1, etypes1,
         float:
             Value of the 2-body local energy kernel.
     """
-    kern = 0
+    kern = 0.0
 
     ls1 = 1 / (2 * ls * ls)
     sig2 = sig * sig
@@ -1696,13 +1682,13 @@ def two_body_mc_en_jit(bond_array_1, c1, etypes1,
 #                 many body multicomponent kernel (numba)
 # -----------------------------------------------------------------------------
 
-
+@njit
 def many_body_mc_jit(q_array_1, q_array_2,
                      q_neigh_array_1, q_neigh_array_2,
                      q_neigh_grads_1, q_neigh_grads_2,
                      c1, c2, etypes1, etypes2,
                      species1, species2,
-                     d1, d2, sig, ls):
+                     sig, ls):
     """many-body multi-element kernel between two force components accelerated
     with Numba.
 
@@ -1729,8 +1715,6 @@ def many_body_mc_jit(q_array_1, q_array_2,
             of atoms in env 2
         species1 (np.ndarray): all the atomic species present in trajectory 1
         species2 (np.ndarray): all the atomic species present in trajectory 2
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         sig (float): many-body signal variance hyperparameter.
         ls (float): many-body length scale hyperparameter.
         r_cut (float): many-body cutoff radius.
@@ -1740,7 +1724,7 @@ def many_body_mc_jit(q_array_1, q_array_2,
         float: Value of the many-body kernel.
     """
 
-    kern = 0
+    kern = np.zeros((3, 3), dtype=np.float64)
 
     useful_species = np.array(
         list(set(species1).intersection(set(species2))), dtype=np.int8)
@@ -1759,21 +1743,23 @@ def many_body_mc_jit(q_array_1, q_array_2,
         if c1 == c2:
             k12 = k_sq_exp_double_dev(q1, q2, sig, ls)
         else:
-            k12 = 0
+            k12 = 0.0
 
         # initialize arrays of many body descriptors and gradients for the
         # neighbour atoms in the two configurations
         # Loop over neighbours i of 1st configuration
         for i in range(q_neigh_array_1.shape[0]):
-            qis = q1i_grads = qi1_grads = ki2s = 0
+            qis = ki2s = 0.0
+            q1i_grads = np.zeros(3, dtype=np.float64)
+            qi1_grads = np.zeros(3, dtype=np.float64)
 
             if etypes1[i] == s:
                 # derivative of pairwise component of many body descriptor q1i
-                q1i_grads = q_neigh_grads_1[i, d1-1]
+                q1i_grads = q_neigh_grads_1[i, :]
 
             if c1 == s:
                 # derivative of pairwise component of many body descriptor qi1
-                qi1_grads = q_neigh_grads_1[i, d1-1]
+                qi1_grads = q_neigh_grads_1[i, :]
 
             # Calculate many-body descriptor value for i
             qis = q_neigh_array_1[i, s1]
@@ -1783,13 +1769,15 @@ def many_body_mc_jit(q_array_1, q_array_2,
 
             # Loop over neighbours j of 2
             for j in range(q_neigh_array_2.shape[0]):
-                qjs = qj2_grads = q2j_grads = k1js = 0
+                qjs = k1js = 0.0
+                qj2_grads = np.zeros(3, dtype=np.float64)
+                q2j_grads = np.zeros(3, dtype=np.float64)
 
                 if etypes2[j] == s:
-                    q2j_grads = q_neigh_grads_2[j, d2-1]
+                    q2j_grads = q_neigh_grads_2[j, :]
 
                 if c2 == s:
-                    qj2_grads = q_neigh_grads_2[j, d2-1]
+                    qj2_grads = q_neigh_grads_2[j, :]
 
                 # Calculate many-body descriptor value for j
                 qjs = q_neigh_array_2[j, s2]
@@ -1802,10 +1790,12 @@ def many_body_mc_jit(q_array_1, q_array_2,
                 else:
                     kij = 0
 
-                kern += q1i_grads * q2j_grads * k12
-                kern += qi1_grads * q2j_grads * ki2s
-                kern += q1i_grads * qj2_grads * k1js
-                kern += qi1_grads * qj2_grads * kij
+                for d1 in range(3):
+                    for d2 in range(3):
+                        kern[d1, d2] += q1i_grads[d1] * q2j_grads[d2] * k12
+                        kern[d1, d2] += qi1_grads[d1] * q2j_grads[d2] * ki2s
+                        kern[d1, d2] += q1i_grads[d1] * qj2_grads[d2] * k1js
+                        kern[d1, d2] += qi1_grads[d1] * qj2_grads[d2] * kij
     return kern
 
 
@@ -1814,7 +1804,7 @@ def many_body_mc_grad_jit(q_array_1, q_array_2,
                           q_neigh_array_1, q_neigh_array_2,
                           q_neigh_grads_1, q_neigh_grads_2,
                           c1, c2, etypes1, etypes2,
-                          species1, species2, d1, d2, sig, ls):
+                          species1, species2, sig, ls):
     """gradient of many-body multi-element kernel between two force components
     w.r.t. the hyperparameters, accelerated with Numba.
 
@@ -1841,8 +1831,6 @@ def many_body_mc_grad_jit(q_array_1, q_array_2,
             of atoms in env 2
         species1 (np.ndarray): all the atomic species present in trajectory 1
         species2 (np.ndarray): all the atomic species present in trajectory 2
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         sig (float): many-body signal variance hyperparameter.
         ls (float): many-body length scale hyperparameter.
         r_cut (float): many-body cutoff radius.
@@ -1852,14 +1840,12 @@ def many_body_mc_grad_jit(q_array_1, q_array_2,
         array: Value of the many-body kernel and its gradient w.r.t. sig and ls
     """
 
-    kern = 0.0
-    sig_derv = 0.0
-    ls_derv = 0.0
+    kern = np.zeros((3, 3), dtype=np.float64)
+    sig_derv = np.zeros((3, 3), dtype=np.float64)
+    ls_derv = np.zeros((3, 3), dtype=np.float64)
 
     useful_species = np.array(
         list(set(species1).intersection(set(species2))), dtype=np.int8)
-
-    print(species1, species2)
 
     for s in useful_species:
         s1 = np.where(species1==s)[0][0]
@@ -1878,12 +1864,15 @@ def many_body_mc_grad_jit(q_array_1, q_array_2,
 
         # Compute  ki2s, qi1_grads, and qis
         for i in range(q_neigh_array_1.shape[0]):
-            qis = q1i_grads = qi1_grads = ki2s = dki2s = 0
+            qis = ki2s = dki2s = 0
+            q1i_grads = np.zeros(3, dtype=np.float64)
+            qi1_grads = np.zeros(3, dtype=np.float64)
+
             if etypes1[i] == s:
-                q1i_grads = q_neigh_grads_1[i, d1-1]
+                q1i_grads = q_neigh_grads_1[i, :]
 
             if c1 == s:
-                qi1_grads = q_neigh_grads_1[i, d1-1]
+                qi1_grads = q_neigh_grads_1[i, :]
 
             # Calculate many-body descriptor value for i
             qis = q_neigh_array_1[i, s1]
@@ -1895,13 +1884,15 @@ def many_body_mc_grad_jit(q_array_1, q_array_2,
 
             # Loop over neighbours j of 2
             for j in range(q_neigh_array_2.shape[0]):
-                qjs = qj2_grads = q2j_grads = k1js = dk1js = 0
+                qjs = k1js = dk1js = 0.0
+                q2j_grads = np.zeros(3, dtype=np.float64)
+                qj2_grads = np.zeros(3, dtype=np.float64)
 
                 if etypes2[j] == s:
-                    q2j_grads = q_neigh_grads_2[j, d2-1]
+                    q2j_grads = q_neigh_grads_2[j, :]
 
                 if c2 == s:
-                    qj2_grads = q_neigh_grads_2[j, d2-1]
+                    qj2_grads = q_neigh_grads_2[j, :]
 
                 # Calculate many-body descriptor value for j
                 qjs = q_neigh_array_2[j, s2]
@@ -1919,32 +1910,32 @@ def many_body_mc_grad_jit(q_array_1, q_array_2,
                     kij = 0
                     dkij = 0
 
-                kern_term  = q1i_grads * q2j_grads * k12
-                kern_term += qi1_grads * q2j_grads * ki2s
-                kern_term += q1i_grads * qj2_grads * k1js
-                kern_term += qi1_grads * qj2_grads * kij
+                for d1 in range(3):
+                    for d2 in range(3):
+                         kern_term  = q1i_grads[d1] * q2j_grads[d2] * k12
+                         kern_term += qi1_grads[d1] * q2j_grads[d2] * ki2s
+                         kern_term += q1i_grads[d1] * qj2_grads[d2] * k1js
+                         kern_term += qi1_grads[d1] * qj2_grads[d2] * kij
 
-                sig_term = 2. / sig * kern_term
+                         sig_term = 2. / sig * kern_term
 
-                ls_term  = q1i_grads * q2j_grads * dk12
-                ls_term += qi1_grads * q2j_grads * dki2s
-                ls_term += q1i_grads * qj2_grads * dk1js
-                ls_term += qi1_grads * qj2_grads * dkij
+                         ls_term  = q1i_grads[d1] * q2j_grads[d2] * dk12
+                         ls_term += qi1_grads[d1] * q2j_grads[d2] * dki2s
+                         ls_term += q1i_grads[d1] * qj2_grads[d2] * dk1js
+                         ls_term += qi1_grads[d1] * qj2_grads[d2] * dkij
 
-                kern += kern_term
-                sig_derv += sig_term
-                ls_derv += ls_term
+                         kern[d1, d2] += kern_term
+                         sig_derv[d1, d2] += sig_term
+                         ls_derv[d1, d2] += ls_term
 
-    grad = np.array([sig_derv, ls_derv])
-
-    return kern, grad
+    return kern, np.stack((sig_derv, ls_derv))
 
 
 @njit
 def many_body_mc_force_en_jit(q_array_1, q_array_2,
                               q_neigh_array_1, q_neigh_grads_1,
                               c1, c2, etypes1,
-                              species1, species2, d1, sig, ls):
+                              species1, species2, sig, ls):
     """many-body many-element kernel between force and energy components accelerated
     with Numba.
 
@@ -1954,7 +1945,6 @@ def many_body_mc_force_en_jit(q_array_1, q_array_2,
         etypes1 (np.ndarray): atomic species of atoms in env 1
         species1 (np.ndarray): all the atomic species present in trajectory 1
         species2 (np.ndarray): all the atomic species present in trajectory 2
-        d1 (int): Force component of the first environment.
         sig (float): many-body signal variance hyperparameter.
         ls (float): many-body length scale hyperparameter.
 
@@ -1962,7 +1952,7 @@ def many_body_mc_force_en_jit(q_array_1, q_array_2,
         float: Value of the many-body kernel.
     """
 
-    kern = 0
+    kern = np.zeros(3, dtype=np.float64)
 
     useful_species = np.array(
         list(set(species1).intersection(set(species2))), dtype=np.int8)
@@ -1976,18 +1966,23 @@ def many_body_mc_force_en_jit(q_array_1, q_array_2,
         if c1 == c2:
             k12 = k_sq_exp_dev(q1, q2, sig, ls)
         else:
-            k12 = 0
+            k12 = 0.0
 
         # Loop over neighbours i of 1
         for i in range(q_neigh_array_1.shape[0]):
-            qi1_grads = q1i_grads = 0
-            ki2s = 0
+            q1i_grads = np.zeros(3, dtype=np.float64)
+            qi1_grads = np.zeros(3, dtype=np.float64)
+            ki2s = 0.0
 
             if etypes1[i] == s:
-                q1i_grads = q_neigh_grads_1[i, d1-1]
+                q1i_grads[0] += q_neigh_grads_1[i, 0]
+                q1i_grads[1] += q_neigh_grads_1[i, 1]
+                q1i_grads[2] += q_neigh_grads_1[i, 2]
 
             if c1 == s:
-                qi1_grads = q_neigh_grads_1[i, d1-1]
+                qi1_grads[0] += q_neigh_grads_1[i, 0]
+                qi1_grads[1] += q_neigh_grads_1[i, 1]
+                qi1_grads[2] += q_neigh_grads_1[i, 2]
 
             if c2 == etypes1[i]:
                 # Calculate many-body descriptor value for i
@@ -1999,7 +1994,7 @@ def many_body_mc_force_en_jit(q_array_1, q_array_2,
     return kern
 
 
-#@njit
+@njit
 def many_body_mc_en_jit(q_array_1, q_array_2, c1, c2,
                         species1, species2, sig, ls):
     """many-body many-element kernel between energy components accelerated
@@ -2026,7 +2021,7 @@ def many_body_mc_en_jit(q_array_1, q_array_2, c1, c2,
     """
     useful_species = np.array(
         list(set(species1).intersection(set(species2))), dtype=np.int8)
-    kern = 0
+    kern = 0.0
 
     if c1 == c2:
         for s in useful_species:

--- a/flare/kernels/sc.py
+++ b/flare/kernels/sc.py
@@ -687,29 +687,25 @@ def two_body_jit(bond_array_1, bond_array_2, sig, ls,
 
     for m in range(bond_array_1.shape[0]):
         ri = bond_array_1[m, 0]
-        ci = np.zeros((3, 3), dtype=np.float64)
-        ci[0, :] += bond_array_1[m, 1]
-        ci[1, :] += bond_array_1[m, 2]
-        ci[2, :] += bond_array_1[m, 3]
+        ci = bond_array_1[m, 1:]
         fi, fdi = cutoff_func(r_cut, ri, ci)
 
         for n in range(bond_array_2.shape[0]):
             rj = bond_array_2[n, 0]
-            cj = np.zeros((3, 3), dtype=np.float64)
-            cj[:, 0] += bond_array_2[n, 1]
-            cj[:, 1] += bond_array_2[n, 2]
-            cj[:, 2] += bond_array_2[n, 3]
+            cj = bond_array_2[n, 1:]
             fj, fdj = cutoff_func(r_cut, rj, cj)
 
             r11 = ri - rj
 
-            A = ci * cj
-            B = r11 * ci
-            C = r11 * cj
             D = r11 * r11
-
-            kern += force_helper(A, B, C, D, fi, fj, fdi, fdj, ls1, ls2,
-                                 ls3, sig2)
+            for d1 in range(3):
+                for d2 in range(3):
+                    A = ci[d1] * cj[d2]
+                    B = r11 * ci[d1]
+                    C = r11 * cj[d2]
+                    kern[d1, d2] += force_helper(A, B, C, D, fi, fj,
+                                                 fdi[d1], fdj[d2], ls1,
+                                                 ls2, ls3, sig2)
 
     return kern
 
@@ -744,34 +740,30 @@ def two_body_grad_jit(bond_array_1, bond_array_2, sig, ls,
 
     for m in range(bond_array_1.shape[0]):
         ri = bond_array_1[m, 0]
-        ci = np.zeros((3, 3), dtype=np.float64)
-        ci[0, :] += bond_array_1[m, 1]
-        ci[1, :] += bond_array_1[m, 2]
-        ci[2, :] += bond_array_1[m, 3]
+        ci = bond_array_1[m, 1:]
         fi, fdi = cutoff_func(r_cut, ri, ci)
 
         for n in range(bond_array_2.shape[0]):
             rj = bond_array_2[n, 0]
-            cj = np.zeros((3, 3), dtype=np.float64)
-            cj[:, 0] += bond_array_2[n, 1]
-            cj[:, 1] += bond_array_2[n, 2]
-            cj[:, 2] += bond_array_2[n, 3]
+            cj = bond_array_2[n, 1:]
             fj, fdj = cutoff_func(r_cut, rj, cj)
 
             r11 = ri - rj
 
-            A = ci * cj
-            B = r11 * ci
-            C = r11 * cj
             D = r11 * r11
 
-            kern_term, sig_term, ls_term = \
-                grad_helper(A, B, C, D, fi, fj, fdi, fdj, ls1, ls2, ls3, ls4,
-                            ls5, ls6, sig2, sig3)
+            for d1 in range(3):
+                for d2 in range(3):
+                     A = ci[d1] * cj[d2]
+                     B = r11 * ci[d1]
+                     C = r11 * cj[d2]
+                     kern_term, sig_term, ls_term = \
+                         grad_helper(A, B, C, D, fi, fj, fdi[d1], fdj[d2],
+                                     ls1, ls2, ls3, ls4, ls5, ls6, sig2, sig3)
 
-            kern += kern_term
-            sig_derv += sig_term
-            ls_derv += ls_term
+                     kern[d1, d2] += kern_term
+                     sig_derv[d1, d2] += sig_term
+                     ls_derv[d1, d2] += ls_term
 
     return kern, ls_derv, sig_derv
 
@@ -915,19 +907,13 @@ def three_body_jit(bond_array_1, bond_array_2,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = np.zeros((3, 3), dtype=np.float64)
-        ci1[0, :] += bond_array_1[m, 1]
-        ci1[1, :] += bond_array_1[m, 2]
-        ci1[2, :] += bond_array_1[m, 3]
+        ci1 = bond_array_1[m, 1:]
         fi1, fdi1 = cutoff_func(r_cut, ri1, ci1)
 
         for n in range(triplets_1[m]):
             ind1 = cross_bond_inds_1[m, m + n + 1]
             ri2 = bond_array_1[ind1, 0]
-            ci2 = np.zeros((3, 3), dtype=np.float64)
-            ci2[0, :] += bond_array_1[ind1, 1]
-            ci2[1, :] += bond_array_1[ind1, 2]
-            ci2[2, :] += bond_array_1[ind1, 3]
+            ci2 = bond_array_1[ind1, 1:]
             fi2, fdi2 = cutoff_func(r_cut, ri2, ci2)
 
             ri3 = cross_bond_dists_1[m, m + n + 1]
@@ -938,19 +924,13 @@ def three_body_jit(bond_array_1, bond_array_2,
 
             for p in range(bond_array_2.shape[0]):
                 rj1 = bond_array_2[p, 0]
-                cj1 = np.zeros((3, 3), dtype=np.float64)
-                cj1[:, 0] += bond_array_2[p, 1]
-                cj1[:, 1] += bond_array_2[p, 2]
-                cj1[:, 2] += bond_array_2[p, 3]
+                cj1 = bond_array_2[p, 1:]
                 fj1, fdj1 = cutoff_func(r_cut, rj1, cj1)
 
                 for q in range(triplets_2[p]):
                     ind2 = cross_bond_inds_2[p, p + 1 + q]
                     rj2 = bond_array_2[ind2, 0]
-                    cj2 = np.zeros((3, 3), dtype=np.float64)
-                    cj2[:, 0] += bond_array_2[ind2, 1]
-                    cj2[:, 1] += bond_array_2[ind2, 2]
-                    cj2[:, 2] += bond_array_2[ind2, 3]
+                    cj2 = bond_array_2[ind2, 1:]
                     fj2, fdj2 = cutoff_func(r_cut, rj2, cj2)
 
                     rj3 = cross_bond_dists_2[p, p + 1 + q]
@@ -959,9 +939,14 @@ def three_body_jit(bond_array_1, bond_array_2,
                     fj = fj1 * fj2 * fj3
                     fdj = fdj1 * fj2 * fj3 + fj1 * fdj2 * fj3
 
-                    kern += triplet_kernel(ci1, ci2, cj1, cj2, ri1, ri2, ri3,
-                                           rj1, rj2, rj3, fi, fj, fdi, fdj,
-                                           ls1, ls2, ls3, sig2)
+                    for d1 in range(3):
+                        for d2 in range(3):
+                             kern[d1, d2] += triplet_kernel(ci1[d1], ci2[d1],
+                                                            cj1[d2], cj2[d2],
+                                                            ri1, ri2, ri3,
+                                                            rj1, rj2, rj3,
+                                                            fi, fj, fdi[d1], fdj[d2],
+                                                            ls1, ls2, ls3, sig2)
     return kern
 
 
@@ -1021,20 +1006,14 @@ def three_body_grad_jit(bond_array_1, bond_array_2,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = np.zeros((3, 3), dtype=np.float64)
-        ci1[0, :] += bond_array_1[m, 1]
-        ci1[1, :] += bond_array_1[m, 2]
-        ci1[2, :] += bond_array_1[m, 3]
+        ci1 = bond_array_1[m, 1:]
         fi1, fdi1 = cutoff_func(r_cut, ri1, ci1)
 
         for n in range(triplets_1[m]):
             ind1 = cross_bond_inds_1[m, m + n + 1]
             ri3 = cross_bond_dists_1[m, m + n + 1]
             ri2 = bond_array_1[ind1, 0]
-            ci2 = np.zeros((3, 3), dtype=np.float64)
-            ci2[0, :] += bond_array_1[ind1, 1]
-            ci2[1, :] += bond_array_1[ind1, 2]
-            ci2[2, :] += bond_array_1[ind1, 3]
+            ci2 = bond_array_1[ind1, 1:]
 
             fi2, fdi2 = cutoff_func(r_cut, ri2, ci2)
             fi3, _ = cutoff_func(r_cut, ri3, 0)
@@ -1044,20 +1023,14 @@ def three_body_grad_jit(bond_array_1, bond_array_2,
 
             for p in range(bond_array_2.shape[0]):
                 rj1 = bond_array_2[p, 0]
-                cj1 = np.zeros((3, 3), dtype=np.float64)
-                cj1[:, 0] += bond_array_2[p, 1]
-                cj1[:, 1] += bond_array_2[p, 2]
-                cj1[:, 2] += bond_array_2[p, 3]
+                cj1 = bond_array_2[p, 1:]
                 fj1, fdj1 = cutoff_func(r_cut, rj1, cj1)
 
                 for q in range(triplets_2[p]):
                     ind2 = cross_bond_inds_2[p, p + q + 1]
                     rj3 = cross_bond_dists_2[p, p + q + 1]
                     rj2 = bond_array_2[ind2, 0]
-                    cj2 = np.zeros((3, 3), dtype=np.float64)
-                    cj2[:, 0] += bond_array_2[ind2, 1]
-                    cj2[:, 1] += bond_array_2[ind2, 2]
-                    cj2[:, 2] += bond_array_2[ind2, 3]
+                    cj2 = bond_array_2[ind2, 1:]
 
                     fj2, fdj2 = cutoff_func(r_cut, rj2, cj2)
                     fj3, _ = cutoff_func(r_cut, rj3, 0)
@@ -1065,15 +1038,20 @@ def three_body_grad_jit(bond_array_1, bond_array_2,
                     fj = fj1 * fj2 * fj3
                     fdj = fdj1 * fj2 * fj3 + fj1 * fdj2 * fj3
 
-                    N, O, X = \
-                        triplet_kernel_grad(ci1, ci2, cj1, cj2, ri1, ri2, ri3,
-                                            rj1, rj2, rj3, fi, fj, fdi, fdj,
-                                            ls1, ls2, ls3, ls4, ls5, ls6, sig2,
-                                            sig3)
+                    for d1 in range(3):
+                        for d2 in range(3):
+                            N, O, X = \
+                                triplet_kernel_grad(ci1[d1], ci2[d1],
+                                                    cj1[d2], cj2[d2],
+                                                    ri1, ri2, ri3,
+                                                    rj1, rj2, rj3,
+                                                    fi, fj, fdi[d1], fdj[d2],
+                                                    ls1, ls2, ls3, ls4, ls5,
+                                                    ls6, sig2, sig3)
 
-                    kern += N
-                    sig_derv += O
-                    ls_derv += X
+                            kern[d1, d2] += N
+                            sig_derv[d1, d2] += O
+                            ls_derv[d1, d2] += X
 
     return kern, sig_derv, ls_derv
 
@@ -1325,9 +1303,10 @@ def many_body_jit(q_array_1, q_array_2,
 
             kij = k_sq_exp_double_dev(qis, qjs, sig, ls)
 
+            k12ij = (k12 + ki2s + k1js + kij)
             for d1 in range(3):
                 for d2 in range(3):
-                    kern[d1,d2] += qi_grad[d1] * qj_grad[d2] * (k12 + ki2s + k1js + kij)
+                    kern[d1, d2] += qi_grad[d1] * qj_grad[d2] * k12ij
 
     return kern
 
@@ -1372,28 +1351,24 @@ def many_body_grad_jit(q_array_1, q_array_2,
     k12 = k_sq_exp_double_dev(q1, q2, sig, ls)
 
     for i in range(q_neigh_array_1.shape[0]):
-        qi_grad = np.zeros((3, 3), dtype=np.float64)
-        qi_grad[0, :] += q_neigh_grads_1[i, 0]
-        qi_grad[1, :] += q_neigh_grads_1[i, 1]
-        qi_grad[2, :] += q_neigh_grads_1[i, 2]
+        qi_grad = q_neigh_grads_1[i, :]
         qis = np.sum(q_neigh_array_1[i, :])
         ki2s = k_sq_exp_double_dev(qis, q2, sig, ls)
 
         for j in range(q_neigh_array_2.shape[0]):
-            qj_grad = np.zeros((3, 3), dtype=np.float64)
-            qj_grad[0, :] += q_neigh_grads_2[j, 0]
-            qj_grad[1, :] += q_neigh_grads_2[j, 1]
-            qj_grad[2, :] += q_neigh_grads_2[j, 2]
+            qj_grad = q_neigh_grads_2[j, :]
             qjs = np.sum(q_neigh_array_2[j, :])
             k1js = k_sq_exp_double_dev(q1, qjs, sig, ls)
 
             kij = k_sq_exp_double_dev(qis, qjs, sig, ls)
-
-            kern_term = qi_grad * qj_grad * (k12 + ki2s + k1js + kij)
-            sig_derv += 2. / sig * kern_term
-            ls_derv += qi_grad * qj_grad * \
-                mb_grad_helper_ls(q1, q2, qis, qjs, sig, ls)
-            kern += kern_term
+            mgh = mb_grad_helper_ls(q1, q2, qis, qjs, sig, ls)
+            k12ij = (k12 + ki2s + k1js + kij)
+            for d1 in range(3):
+                for d2 in range(3):
+                    kern_term = qi_grad[d1] * qj_grad[d2] * k12ij
+                    sig_derv[d1, d2] += 2. / sig * kern_term
+                    ls_derv[d1, d2] += qi_grad[d1] * qj_grad[d2] * mgh
+                    kern[d1, d2] += kern_term
 
     return kern, sig_derv, ls_derv
 

--- a/flare/kernels/sc.py
+++ b/flare/kernels/sc.py
@@ -56,15 +56,12 @@ from flare.kernels.kernels import force_helper, grad_constants, grad_helper, \
 
 
 def two_plus_three_body(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                        d1: int, d2: int, hyps, cutoffs,
-                        cutoff_func=cf.quadratic_cutoff):
+                        hyps, cutoffs, cutoff_func=cf.quadratic_cutoff):
     """2+3-body single-element kernel between two force components.
 
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig1, ls1,
             sig2, ls2, sig_n).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
@@ -76,18 +73,18 @@ def two_plus_three_body(env1: AtomicEnvironment, env2: AtomicEnvironment,
     """
 
     two_term = two_body_jit(env1.bond_array_2, env2.bond_array_2,
-                            d1, d2, hyps[0], hyps[1], cutoffs[0], cutoff_func)
+                            hyps[0], hyps[1], cutoffs[0], cutoff_func)
 
     three_term = \
         three_body_jit(env1.bond_array_3, env2.bond_array_3,
                        env1.cross_bond_inds, env2.cross_bond_inds,
                        env1.cross_bond_dists, env2.cross_bond_dists,
                        env1.triplet_counts, env2.triplet_counts,
-                       d1, d2, hyps[2], hyps[3], cutoffs[1], cutoff_func)
+                       hyps[2], hyps[3], cutoffs[1], cutoff_func)
     return two_term + three_term
 
 
-def two_plus_three_body_grad(env1, env2, d1, d2, hyps, cutoffs,
+def two_plus_three_body_grad(env1, env2, hyps, cutoffs,
                              cutoff_func=cf.quadratic_cutoff):
     """2+3-body single-element kernel between two force components and its
     gradient with respect to the hyperparameters.
@@ -95,8 +92,6 @@ def two_plus_three_body_grad(env1, env2, d1, d2, hyps, cutoffs,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig1, ls1,
             sig2, ls2, sig_n).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
@@ -110,19 +105,19 @@ def two_plus_three_body_grad(env1, env2, d1, d2, hyps, cutoffs,
 
     kern2, ls2, sig2 = \
         two_body_grad_jit(env1.bond_array_2, env2.bond_array_2,
-                          d1, d2, hyps[0], hyps[1], cutoffs[0], cutoff_func)
+                          hyps[0], hyps[1], cutoffs[0], cutoff_func)
 
     kern3, sig3, ls3 = \
         three_body_grad_jit(env1.bond_array_3, env2.bond_array_3,
                             env1.cross_bond_inds, env2.cross_bond_inds,
                             env1.cross_bond_dists, env2.cross_bond_dists,
                             env1.triplet_counts, env2.triplet_counts,
-                            d1, d2, hyps[2], hyps[3], cutoffs[1], cutoff_func)
+                            hyps[2], hyps[3], cutoffs[1], cutoff_func)
 
-    return kern2 + kern3, np.array([sig2, ls2, sig3, ls3])
+    return kern2 + kern3, np.stack((sig2, ls2, sig3, ls3))
 
 
-def two_plus_three_force_en(env1, env2, d1, hyps, cutoffs,
+def two_plus_three_force_en(env1, env2, hyps, cutoffs,
                             cutoff_func=cf.quadratic_cutoff):
     """2+3-body single-element kernel between a force component and a local
     energy.
@@ -132,7 +127,6 @@ def two_plus_three_force_en(env1, env2, d1, hyps, cutoffs,
             force component.
         env2 (AtomicEnvironment): Local environment associated with the
             local energy.
-        d1 (int): Force component of the first environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig1, ls1,
             sig2, ls2).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
@@ -144,7 +138,7 @@ def two_plus_three_force_en(env1, env2, d1, hyps, cutoffs,
     """
 
     two_term = two_body_force_en_jit(env1.bond_array_2, env2.bond_array_2,
-                                     d1, hyps[0], hyps[1], cutoffs[0],
+                                     hyps[0], hyps[1], cutoffs[0],
                                      cutoff_func) / 2
 
     three_term = \
@@ -153,7 +147,7 @@ def two_plus_three_force_en(env1, env2, d1, hyps, cutoffs,
                                 env1.cross_bond_dists,
                                 env2.cross_bond_dists,
                                 env1.triplet_counts, env2.triplet_counts,
-                                d1, hyps[2], hyps[3], cutoffs[1],
+                                hyps[2], hyps[3], cutoffs[1],
                                 cutoff_func) / 3
 
     return two_term + three_term
@@ -195,15 +189,13 @@ def two_plus_three_en(env1, env2, hyps, cutoffs,
 
 
 def two_plus_three_plus_many_body(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                                  d1: int, d2: int, hyps, cutoffs,
+                                  hyps, cutoffs,
                                   cutoff_func=cf.quadratic_cutoff):
     """2+3-body single-element kernel between two force components.
 
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig2, ls2,
             sig3, ls3, sigm, lsm, sig_n).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
@@ -215,33 +207,31 @@ def two_plus_three_plus_many_body(env1: AtomicEnvironment, env2: AtomicEnvironme
     """
 
     two_term = two_body_jit(env1.bond_array_2, env2.bond_array_2,
-                            d1, d2, hyps[0], hyps[1], cutoffs[0], cutoff_func)
+                            hyps[0], hyps[1], cutoffs[0], cutoff_func)
 
     three_term = \
         three_body_jit(env1.bond_array_3, env2.bond_array_3,
                        env1.cross_bond_inds, env2.cross_bond_inds,
                        env1.cross_bond_dists, env2.cross_bond_dists,
                        env1.triplet_counts, env2.triplet_counts,
-                       d1, d2, hyps[2], hyps[3], cutoffs[1], cutoff_func)
+                       hyps[2], hyps[3], cutoffs[1], cutoff_func)
 
-    many_term =  many_body_jit(env1.q_array, env2.q_array, 
-                         env1.q_neigh_array, env2.q_neigh_array, 
+    many_term =  many_body_jit(env1.q_array, env2.q_array,
+                         env1.q_neigh_array, env2.q_neigh_array,
                          env1.q_neigh_grads, env2.q_neigh_grads,
-                         d1, d2, hyps[4], hyps[5])
+                         hyps[4], hyps[5])
 
     return two_term + three_term + many_term
 
 
 def two_plus_three_plus_many_body_grad(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                                       d1: int, d2: int, hyps, cutoffs,
+                                       hyps, cutoffs,
                                        cutoff_func=cf.quadratic_cutoff):
     """2+3+many-body single-element kernel between two force components.
 
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig2, ls2,
             sig3, ls3, sigm, lsm, sig_n).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
@@ -254,32 +244,31 @@ def two_plus_three_plus_many_body_grad(env1: AtomicEnvironment, env2: AtomicEnvi
 
     kern2, ls2, sig2 = \
         two_body_grad_jit(env1.bond_array_2, env2.bond_array_2,
-                          d1, d2, hyps[0], hyps[1], cutoffs[0], cutoff_func)
+                          hyps[0], hyps[1], cutoffs[0], cutoff_func)
 
     kern3, sig3, ls3 = \
         three_body_grad_jit(env1.bond_array_3, env2.bond_array_3,
                             env1.cross_bond_inds, env2.cross_bond_inds,
                             env1.cross_bond_dists, env2.cross_bond_dists,
                             env1.triplet_counts, env2.triplet_counts,
-                            d1, d2, hyps[2], hyps[3], cutoffs[1], cutoff_func)
+                            hyps[2], hyps[3], cutoffs[1], cutoff_func)
 
     kern_many, sigm, lsm = many_body_grad_jit(env1.q_array, env2.q_array,
                                        env1.q_neigh_array, env2.q_neigh_array,
                                        env1.q_neigh_grads, env2.q_neigh_grads,
-                                       d1, d2, hyps[4], hyps[5])
+                                       hyps[4], hyps[5])
 
-    return kern2 + kern3 + kern_many, np.array([sig2, ls2, sig3, ls3, sigm, lsm])
+    return kern2 + kern3 + kern_many, np.stack((sig2, ls2, sig3, ls3, sigm, lsm))
 
 
 def two_plus_three_plus_many_body_force_en(env1: AtomicEnvironment, env2: AtomicEnvironment,
-                                           d1: int,  hyps, cutoffs,
+                                           hyps, cutoffs,
                                            cutoff_func=cf.quadratic_cutoff):
     """2+3+many-body single-element kernel between two force and energy components.
 
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig2, ls2,
             sig3, ls3, sigm, lsm, sig_n).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
@@ -291,7 +280,7 @@ def two_plus_three_plus_many_body_force_en(env1: AtomicEnvironment, env2: Atomic
     """
 
     two_term = two_body_force_en_jit(env1.bond_array_2, env2.bond_array_2,
-                                     d1, hyps[0], hyps[1], cutoffs[0],
+                                     hyps[0], hyps[1], cutoffs[0],
                                      cutoff_func) / 2
 
     three_term = \
@@ -300,12 +289,12 @@ def two_plus_three_plus_many_body_force_en(env1: AtomicEnvironment, env2: Atomic
                                 env1.cross_bond_dists,
                                 env2.cross_bond_dists,
                                 env1.triplet_counts, env2.triplet_counts,
-                                d1, hyps[2], hyps[3], cutoffs[1],
+                                hyps[2], hyps[3], cutoffs[1],
                                 cutoff_func) / 3
 
-    many_term = many_body_force_en_jit(env1.q_array, env2.q_array, 
-                                  env1.q_neigh_array, env1.q_neigh_grads, 
-                                  d1, hyps[4], hyps[5])
+    many_term = many_body_force_en_jit(env1.q_array, env2.q_array,
+                                  env1.q_neigh_array, env1.q_neigh_grads,
+                                  hyps[4], hyps[5])
 
     return two_term + three_term + many_term
 
@@ -347,15 +336,13 @@ def two_plus_three_plus_many_body_en(env1: AtomicEnvironment, env2: AtomicEnviro
 # -----------------------------------------------------------------------------
 
 
-def two_body(env1, env2, d1, d2, hyps, cutoffs,
+def two_body(env1, env2, hyps, cutoffs,
              cutoff_func=cf.quadratic_cutoff):
     """2-body single-element kernel between two force components.
 
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): One-element array containing the 2-body
             cutoff.
@@ -370,10 +357,10 @@ def two_body(env1, env2, d1, d2, hyps, cutoffs,
     r_cut = cutoffs[0]
 
     return two_body_jit(env1.bond_array_2, env2.bond_array_2,
-                        d1, d2, sig, ls, r_cut, cutoff_func)
+                        sig, ls, r_cut, cutoff_func)
 
 
-def two_body_grad(env1, env2, d1, d2, hyps, cutoffs,
+def two_body_grad(env1, env2, hyps, cutoffs,
                   cutoff_func=cf.quadratic_cutoff):
     """2-body single-element kernel between two force components and its
     gradient with respect to the hyperparameters.
@@ -381,8 +368,6 @@ def two_body_grad(env1, env2, d1, d2, hyps, cutoffs,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): One-element array containing the 2-body
             cutoff.
@@ -399,12 +384,11 @@ def two_body_grad(env1, env2, d1, d2, hyps, cutoffs,
 
     kernel, ls_derv, sig_derv = \
         two_body_grad_jit(env1.bond_array_2, env2.bond_array_2,
-                          d1, d2, sig, ls, r_cut, cutoff_func)
-    kernel_grad = np.array([sig_derv, ls_derv])
-    return kernel, kernel_grad
+                          sig, ls, r_cut, cutoff_func)
+    return kernel, np.stack((sig_derv, ls_derv))
 
 
-def two_body_force_en(env1, env2, d1, hyps, cutoffs,
+def two_body_force_en(env1, env2, hyps, cutoffs,
                       cutoff_func=cf.quadratic_cutoff):
     """2-body single-element kernel between a force component and a local
     energy.
@@ -414,7 +398,6 @@ def two_body_force_en(env1, env2, d1, hyps, cutoffs,
             force component.
         env2 (AtomicEnvironment): Local environment associated with the
             local energy.
-        d1 (int): Force component of the first environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): One-element array containing the 2-body
             cutoff.
@@ -430,7 +413,7 @@ def two_body_force_en(env1, env2, d1, hyps, cutoffs,
 
     # divide by two to account for double counting
     return two_body_force_en_jit(env1.bond_array_2, env2.bond_array_2,
-                                 d1, sig, ls, r_cut, cutoff_func) / 2
+                                 sig, ls, r_cut, cutoff_func) / 2
 
 
 def two_body_en(env1, env2, hyps, cutoffs,
@@ -461,15 +444,13 @@ def two_body_en(env1, env2, hyps, cutoffs,
 # -----------------------------------------------------------------------------
 
 
-def three_body(env1, env2, d1, d2, hyps, cutoffs,
+def three_body(env1, env2, hyps, cutoffs,
                cutoff_func=cf.quadratic_cutoff):
     """3-body single-element kernel between two force components.
 
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
             cutoffs.
@@ -487,10 +468,10 @@ def three_body(env1, env2, d1, d2, hyps, cutoffs,
                           env1.cross_bond_inds, env2.cross_bond_inds,
                           env1.cross_bond_dists, env2.cross_bond_dists,
                           env1.triplet_counts, env2.triplet_counts,
-                          d1, d2, sig, ls, r_cut, cutoff_func)
+                          sig, ls, r_cut, cutoff_func)
 
 
-def three_body_grad(env1, env2, d1, d2, hyps, cutoffs,
+def three_body_grad(env1, env2, hyps, cutoffs,
                     cutoff_func=cf.quadratic_cutoff):
     """3-body single-element kernel between two force components and its
     gradient with respect to the hyperparameters.
@@ -498,8 +479,6 @@ def three_body_grad(env1, env2, d1, d2, hyps, cutoffs,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
             cutoffs.
@@ -517,14 +496,13 @@ def three_body_grad(env1, env2, d1, d2, hyps, cutoffs,
                                                     env1.cross_bond_inds, env2.cross_bond_inds,
                                                     env1.cross_bond_dists, env2.cross_bond_dists,
                                                     env1.triplet_counts, env2.triplet_counts,
-                                                    d1, d2, sig, ls, r_cut, cutoff_func)
-
-    kernel_grad = np.array([sig_derv, ls_derv])
-
-    return kernel, kernel_grad
+                                                    sig, ls, r_cut, cutoff_func)
 
 
-def three_body_force_en(env1, env2, d1, hyps, cutoffs,
+    return kernel, np.stack((sig_derv, ls_derv))
+
+
+def three_body_force_en(env1, env2, hyps, cutoffs,
                         cutoff_func=cf.quadratic_cutoff):
     """3-body single-element kernel between a force component and a local
     energy.
@@ -534,7 +512,6 @@ def three_body_force_en(env1, env2, d1, hyps, cutoffs,
             force component.
         env2 (AtomicEnvironment): Local environment associated with the
             local energy.
-        d1 (int): Force component of the first environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): Two-element array containing the 2- and 3-body
             cutoffs.
@@ -553,7 +530,7 @@ def three_body_force_en(env1, env2, d1, hyps, cutoffs,
                                    env1.cross_bond_dists,
                                    env2.cross_bond_dists,
                                    env1.triplet_counts, env2.triplet_counts,
-                                   d1, sig, ls, r_cut, cutoff_func) / 3
+                                   sig, ls, r_cut, cutoff_func) / 3
 
 
 def three_body_en(env1, env2, hyps, cutoffs,
@@ -587,7 +564,7 @@ def three_body_en(env1, env2, hyps, cutoffs,
 # -----------------------------------------------------------------------------
 
 
-def many_body(env1, env2, d1, d2, hyps, cutoffs,
+def many_body(env1, env2, hyps, cutoffs,
               cutoff_func=cf.quadratic_cutoff):
     # TODO: need to deal with the conflict of cutoff functions
     """many-body single-element kernel between two forces.
@@ -595,8 +572,6 @@ def many_body(env1, env2, d1, d2, hyps, cutoffs,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): Two-element array containing the 2-, 3-, and
             many-body cutoffs.
@@ -606,13 +581,13 @@ def many_body(env1, env2, d1, d2, hyps, cutoffs,
         float: Value of the many-body force/force kernel.
     """
 
-    return many_body_jit(env1.q_array, env2.q_array, 
-                         env1.q_neigh_array, env2.q_neigh_array, 
+    return many_body_jit(env1.q_array, env2.q_array,
+                         env1.q_neigh_array, env2.q_neigh_array,
                          env1.q_neigh_grads, env2.q_neigh_grads,
-                         d1, d2, hyps[0], hyps[1])
+                         hyps[0], hyps[1])
 
 
-def many_body_grad(env1, env2, d1, d2, hyps, cutoffs,
+def many_body_grad(env1, env2, hyps, cutoffs,
                    cutoff_func=cf.quadratic_cutoff):
     """many-body single-element kernel between two force components and its
     gradient with respect to the hyperparameters.
@@ -620,8 +595,6 @@ def many_body_grad(env1, env2, d1, d2, hyps, cutoffs,
     Args:
         env1 (AtomicEnvironment): First local environment.
         env2 (AtomicEnvironment): Second local environment.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         hyps (np.ndarray): Hyperparameters of the kernel function (sig, ls).
         cutoffs (np.ndarray): Two-element array containing the 2-, 3-, and
             many-body cutoffs.
@@ -635,14 +608,12 @@ def many_body_grad(env1, env2, d1, d2, hyps, cutoffs,
     kernel, sig_derv, ls_derv = many_body_grad_jit(env1.q_array, env2.q_array,
                                        env1.q_neigh_array, env2.q_neigh_array,
                                        env1.q_neigh_grads, env2.q_neigh_grads,
-                                       d1, d2, hyps[0], hyps[1])
+                                       hyps[0], hyps[1])
 
-    kernel_grad = np.array([sig_derv, ls_derv])
-
-    return kernel, kernel_grad
+    return kernel, np.stack((sig_derv, ls_derv))
 
 
-def many_body_force_en(env1, env2, d1, hyps, cutoffs,
+def many_body_force_en(env1, env2, hyps, cutoffs,
                        cutoff_func=cf.quadratic_cutoff):
     """many-body single-element kernel between two local energies.
 
@@ -658,9 +629,9 @@ def many_body_force_en(env1, env2, d1, hyps, cutoffs,
         float: Value of the many-body force/energy kernel.
     """
 
-    return many_body_force_en_jit(env1.q_array, env2.q_array, 
-                                  env1.q_neigh_array, env1.q_neigh_grads, 
-                                  d1, hyps[0], hyps[1])
+    return many_body_force_en_jit(env1.q_array, env2.q_array,
+                                  env1.q_neigh_array, env1.q_neigh_grads,
+                                  hyps[0], hyps[1])
 
 
 def many_body_en(env1, env2, hyps, cutoffs,
@@ -688,7 +659,7 @@ def many_body_en(env1, env2, hyps, cutoffs,
 
 
 @njit
-def two_body_jit(bond_array_1, bond_array_2, d1, d2, sig, ls,
+def two_body_jit(bond_array_1, bond_array_2, sig, ls,
                  r_cut, cutoff_func):
     """2-body single-element kernel between two force components accelerated
     with Numba.
@@ -698,8 +669,6 @@ def two_body_jit(bond_array_1, bond_array_2, d1, d2, sig, ls,
             environment.
         bond_array_2 (np.ndarray): 2-body bond array of the second local
             environment.
-        d1 (int): Force component of the first environment (1=x, 2=y, 3=z).
-        d2 (int): Force component of the second environment (1=x, 2=y, 3=z).
         sig (float): 2-body signal variance hyperparameter.
         ls (float): 2-body length scale hyperparameter.
         r_cut (float): 2-body cutoff radius.
@@ -708,7 +677,8 @@ def two_body_jit(bond_array_1, bond_array_2, d1, d2, sig, ls,
     Return:
         float: Value of the 2-body kernel.
     """
-    kern = 0
+
+    kern = np.zeros((3, 3), dtype=np.float64)
 
     ls1 = 1 / (2 * ls * ls)
     ls2 = 1 / (ls * ls)
@@ -717,13 +687,20 @@ def two_body_jit(bond_array_1, bond_array_2, d1, d2, sig, ls,
 
     for m in range(bond_array_1.shape[0]):
         ri = bond_array_1[m, 0]
-        ci = bond_array_1[m, d1]
+        ci = np.zeros((3, 3), dtype=np.float64)
+        ci[0, :] += bond_array_1[m, 1]
+        ci[1, :] += bond_array_1[m, 2]
+        ci[2, :] += bond_array_1[m, 3]
         fi, fdi = cutoff_func(r_cut, ri, ci)
 
         for n in range(bond_array_2.shape[0]):
             rj = bond_array_2[n, 0]
-            cj = bond_array_2[n, d2]
+            cj = np.zeros((3, 3), dtype=np.float64)
+            cj[:, 0] += bond_array_2[n, 1]
+            cj[:, 1] += bond_array_2[n, 2]
+            cj[:, 2] += bond_array_2[n, 3]
             fj, fdj = cutoff_func(r_cut, rj, cj)
+
             r11 = ri - rj
 
             A = ci * cj
@@ -738,7 +715,7 @@ def two_body_jit(bond_array_1, bond_array_2, d1, d2, sig, ls,
 
 
 @njit
-def two_body_grad_jit(bond_array_1, bond_array_2, d1, d2, sig, ls,
+def two_body_grad_jit(bond_array_1, bond_array_2, sig, ls,
                       r_cut, cutoff_func):
     """2-body single-element kernel between two force components and its
     gradient with respect to the hyperparameters.
@@ -748,8 +725,6 @@ def two_body_grad_jit(bond_array_1, bond_array_2, d1, d2, sig, ls,
             environment.
         bond_array_2 (np.ndarray): 2-body bond array of the second local
             environment.
-        d1 (int): Force component of the first environment (1=x, 2=y, 3=z).
-        d2 (int): Force component of the second environment (1=x, 2=y, 3=z).
         sig (float): 2-body signal variance hyperparameter.
         ls (float): 2-body length scale hyperparameter.
         r_cut (float): 2-body cutoff radius.
@@ -761,20 +736,26 @@ def two_body_grad_jit(bond_array_1, bond_array_2, d1, d2, sig, ls,
             hyperparameters.
     """
 
-    kern = 0
-    sig_derv = 0
-    ls_derv = 0
+    kern = np.zeros((3, 3), dtype=np.float64)
+    sig_derv = np.zeros((3, 3), dtype=np.float64)
+    ls_derv = np.zeros((3, 3), dtype=np.float64)
 
     sig2, sig3, ls1, ls2, ls3, ls4, ls5, ls6 = grad_constants(sig, ls)
 
     for m in range(bond_array_1.shape[0]):
         ri = bond_array_1[m, 0]
-        ci = bond_array_1[m, d1]
+        ci = np.zeros((3, 3), dtype=np.float64)
+        ci[0, :] += bond_array_1[m, 1]
+        ci[1, :] += bond_array_1[m, 2]
+        ci[2, :] += bond_array_1[m, 3]
         fi, fdi = cutoff_func(r_cut, ri, ci)
 
         for n in range(bond_array_2.shape[0]):
             rj = bond_array_2[n, 0]
-            cj = bond_array_2[n, d2]
+            cj = np.zeros((3, 3), dtype=np.float64)
+            cj[:, 0] += bond_array_2[n, 1]
+            cj[:, 1] += bond_array_2[n, 2]
+            cj[:, 2] += bond_array_2[n, 3]
             fj, fdj = cutoff_func(r_cut, rj, cj)
 
             r11 = ri - rj
@@ -796,7 +777,7 @@ def two_body_grad_jit(bond_array_1, bond_array_2, d1, d2, sig, ls,
 
 
 @njit
-def two_body_force_en_jit(bond_array_1, bond_array_2, d1, sig, ls, r_cut,
+def two_body_force_en_jit(bond_array_1, bond_array_2, sig, ls, r_cut,
                           cutoff_func):
     """2-body single-element kernel between a force component and a local
     energy accelerated with Numba.
@@ -806,7 +787,6 @@ def two_body_force_en_jit(bond_array_1, bond_array_2, d1, sig, ls, r_cut,
             environment.
         bond_array_2 (np.ndarray): 2-body bond array of the second local
             environment.
-        d1 (int): Force component of the first environment (1=x, 2=y, 3=z).
         sig (float): 2-body signal variance hyperparameter.
         ls (float): 2-body length scale hyperparameter.
         r_cut (float): 2-body cutoff radius.
@@ -816,7 +796,7 @@ def two_body_force_en_jit(bond_array_1, bond_array_2, d1, sig, ls, r_cut,
         float:
             Value of the 2-body force/energy kernel.
     """
-    kern = 0
+    kern = np.zeros(3, dtype=np.float64)
 
     ls1 = 1 / (2 * ls * ls)
     ls2 = 1 / (ls * ls)
@@ -824,7 +804,7 @@ def two_body_force_en_jit(bond_array_1, bond_array_2, d1, sig, ls, r_cut,
 
     for m in range(bond_array_1.shape[0]):
         ri = bond_array_1[m, 0]
-        ci = bond_array_1[m, d1]
+        ci = bond_array_1[m, 1:4]
         fi, fdi = cutoff_func(r_cut, ri, ci)
 
         for n in range(bond_array_2.shape[0]):
@@ -858,7 +838,7 @@ def two_body_en_jit(bond_array_1, bond_array_2, sig, ls, r_cut, cutoff_func):
         float:
             Value of the 2-body local energy kernel.
     """
-    kern = 0
+    kern = 0.0
 
     ls1 = 1 / (2 * ls * ls)
     sig2 = sig * sig
@@ -886,7 +866,7 @@ def three_body_jit(bond_array_1, bond_array_2,
                    cross_bond_inds_1, cross_bond_inds_2,
                    cross_bond_dists_1, cross_bond_dists_2,
                    triplets_1, triplets_2,
-                   d1, d2, sig, ls, r_cut, cutoff_func):
+                   sig, ls, r_cut, cutoff_func):
     """3-body single-element kernel between two force components accelerated
     with Numba.
 
@@ -917,8 +897,6 @@ def three_body_jit(bond_array_1, bond_array_2,
         triplets_2 (np.ndarray): One dimensional array of integers whose entry
             m is the number of atoms in the second local environment that are
             within a distance r_cut of atom m.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         sig (float): 3-body signal variance hyperparameter.
         ls (float): 3-body length scale hyperparameter.
         r_cut (float): 3-body cutoff radius.
@@ -927,7 +905,7 @@ def three_body_jit(bond_array_1, bond_array_2,
     Return:
         float: Value of the 3-body kernel.
     """
-    kern = 0
+    kern = np.zeros((3, 3), dtype=np.float64)
 
     # pre-compute constants that appear in the inner loop
     sig2 = sig * sig
@@ -937,13 +915,19 @@ def three_body_jit(bond_array_1, bond_array_2,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = bond_array_1[m, d1]
+        ci1 = np.zeros((3, 3), dtype=np.float64)
+        ci1[0, :] += bond_array_1[m, 1]
+        ci1[1, :] += bond_array_1[m, 2]
+        ci1[2, :] += bond_array_1[m, 3]
         fi1, fdi1 = cutoff_func(r_cut, ri1, ci1)
 
         for n in range(triplets_1[m]):
             ind1 = cross_bond_inds_1[m, m + n + 1]
             ri2 = bond_array_1[ind1, 0]
-            ci2 = bond_array_1[ind1, d1]
+            ci2 = np.zeros((3, 3), dtype=np.float64)
+            ci2[0, :] += bond_array_1[ind1, 1]
+            ci2[1, :] += bond_array_1[ind1, 2]
+            ci2[2, :] += bond_array_1[ind1, 3]
             fi2, fdi2 = cutoff_func(r_cut, ri2, ci2)
 
             ri3 = cross_bond_dists_1[m, m + n + 1]
@@ -954,13 +938,19 @@ def three_body_jit(bond_array_1, bond_array_2,
 
             for p in range(bond_array_2.shape[0]):
                 rj1 = bond_array_2[p, 0]
-                cj1 = bond_array_2[p, d2]
+                cj1 = np.zeros((3, 3), dtype=np.float64)
+                cj1[:, 0] += bond_array_2[p, 1]
+                cj1[:, 1] += bond_array_2[p, 2]
+                cj1[:, 2] += bond_array_2[p, 3]
                 fj1, fdj1 = cutoff_func(r_cut, rj1, cj1)
 
                 for q in range(triplets_2[p]):
                     ind2 = cross_bond_inds_2[p, p + 1 + q]
                     rj2 = bond_array_2[ind2, 0]
-                    cj2 = bond_array_2[ind2, d2]
+                    cj2 = np.zeros((3, 3), dtype=np.float64)
+                    cj2[:, 0] += bond_array_2[ind2, 1]
+                    cj2[:, 1] += bond_array_2[ind2, 2]
+                    cj2[:, 2] += bond_array_2[ind2, 3]
                     fj2, fdj2 = cutoff_func(r_cut, rj2, cj2)
 
                     rj3 = cross_bond_dists_2[p, p + 1 + q]
@@ -980,7 +970,7 @@ def three_body_grad_jit(bond_array_1, bond_array_2,
                         cross_bond_inds_1, cross_bond_inds_2,
                         cross_bond_dists_1, cross_bond_dists_2,
                         triplets_1, triplets_2,
-                        d1, d2, sig, ls, r_cut, cutoff_func):
+                        sig, ls, r_cut, cutoff_func):
     """3-body single-element kernel between two force components and its
     gradient with respect to the hyperparameters.
 
@@ -1011,8 +1001,6 @@ def three_body_grad_jit(bond_array_1, bond_array_2,
         triplets_2 (np.ndarray): One dimensional array of integers whose entry
             m is the number of atoms in the second local environment that are
             within a distance r_cut of atom m.
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         sig (float): 3-body signal variance hyperparameter.
         ls (float): 3-body length scale hyperparameter.
         r_cut (float): 3-body cutoff radius.
@@ -1024,23 +1012,29 @@ def three_body_grad_jit(bond_array_1, bond_array_2,
             hyperparameters.
     """
 
-    kern = 0
-    sig_derv = 0
-    ls_derv = 0
+    kern = np.zeros((3, 3), dtype=np.float64)
+    sig_derv = np.zeros((3, 3), dtype=np.float64)
+    ls_derv = np.zeros((3, 3), dtype=np.float64)
 
     # pre-compute constants that appear in the inner loop
     sig2, sig3, ls1, ls2, ls3, ls4, ls5, ls6 = grad_constants(sig, ls)
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = bond_array_1[m, d1]
+        ci1 = np.zeros((3, 3), dtype=np.float64)
+        ci1[0, :] += bond_array_1[m, 1]
+        ci1[1, :] += bond_array_1[m, 2]
+        ci1[2, :] += bond_array_1[m, 3]
         fi1, fdi1 = cutoff_func(r_cut, ri1, ci1)
 
         for n in range(triplets_1[m]):
             ind1 = cross_bond_inds_1[m, m + n + 1]
             ri3 = cross_bond_dists_1[m, m + n + 1]
             ri2 = bond_array_1[ind1, 0]
-            ci2 = bond_array_1[ind1, d1]
+            ci2 = np.zeros((3, 3), dtype=np.float64)
+            ci2[0, :] += bond_array_1[ind1, 1]
+            ci2[1, :] += bond_array_1[ind1, 2]
+            ci2[2, :] += bond_array_1[ind1, 3]
 
             fi2, fdi2 = cutoff_func(r_cut, ri2, ci2)
             fi3, _ = cutoff_func(r_cut, ri3, 0)
@@ -1050,14 +1044,20 @@ def three_body_grad_jit(bond_array_1, bond_array_2,
 
             for p in range(bond_array_2.shape[0]):
                 rj1 = bond_array_2[p, 0]
-                cj1 = bond_array_2[p, d2]
+                cj1 = np.zeros((3, 3), dtype=np.float64)
+                cj1[:, 0] += bond_array_2[p, 1]
+                cj1[:, 1] += bond_array_2[p, 2]
+                cj1[:, 2] += bond_array_2[p, 3]
                 fj1, fdj1 = cutoff_func(r_cut, rj1, cj1)
 
                 for q in range(triplets_2[p]):
                     ind2 = cross_bond_inds_2[p, p + q + 1]
                     rj3 = cross_bond_dists_2[p, p + q + 1]
                     rj2 = bond_array_2[ind2, 0]
-                    cj2 = bond_array_2[ind2, d2]
+                    cj2 = np.zeros((3, 3), dtype=np.float64)
+                    cj2[:, 0] += bond_array_2[ind2, 1]
+                    cj2[:, 1] += bond_array_2[ind2, 2]
+                    cj2[:, 2] += bond_array_2[ind2, 3]
 
                     fj2, fdj2 = cutoff_func(r_cut, rj2, cj2)
                     fj3, _ = cutoff_func(r_cut, rj3, 0)
@@ -1085,7 +1085,7 @@ def three_body_force_en_jit(bond_array_1, bond_array_2,
                             cross_bond_dists_1,
                             cross_bond_dists_2,
                             triplets_1, triplets_2,
-                            d1, sig, ls, r_cut, cutoff_func):
+                            sig, ls, r_cut, cutoff_func):
     """3-body single-element kernel between a force component and a local
     energy accelerated with Numba.
 
@@ -1116,7 +1116,6 @@ def three_body_force_en_jit(bond_array_1, bond_array_2,
         triplets_2 (np.ndarray): One dimensional array of integers whose entry
             m is the number of atoms in the second local environment that are
             within a distance r_cut of atom m.
-        d1 (int): Force component of the first environment (1=x, 2=y, 3=z).
         sig (float): 3-body signal variance hyperparameter.
         ls (float): 3-body length scale hyperparameter.
         r_cut (float): 3-body cutoff radius.
@@ -1127,7 +1126,7 @@ def three_body_force_en_jit(bond_array_1, bond_array_2,
             Value of the 3-body force/energy kernel.
     """
 
-    kern = 0
+    kern = np.zeros(3, dtype=np.float64)
 
     # pre-compute constants that appear in the inner loop
     sig2 = sig * sig
@@ -1136,13 +1135,14 @@ def three_body_force_en_jit(bond_array_1, bond_array_2,
 
     for m in range(bond_array_1.shape[0]):
         ri1 = bond_array_1[m, 0]
-        ci1 = bond_array_1[m, d1]
+        ci1 = bond_array_1[m, 1:4]
         fi1, fdi1 = cutoff_func(r_cut, ri1, ci1)
 
         for n in range(triplets_1[m]):
             ind1 = cross_bond_inds_1[m, m + n + 1]
             ri2 = bond_array_1[ind1, 0]
-            ci2 = bond_array_1[ind1, d1]
+            ci2 = bond_array_1[ind1, 1:4]
+
             fi2, fdi2 = cutoff_func(r_cut, ri2, ci2)
             ri3 = cross_bond_dists_1[m, m + n + 1]
             fi3, _ = cutoff_func(r_cut, ri3, 0)
@@ -1215,7 +1215,7 @@ def three_body_en_jit(bond_array_1, bond_array_2,
         float:
             Value of the 3-body local energy kernel.
     """
-    kern = 0
+    kern = 0.0
 
     sig2 = sig * sig
     ls2 = 1 / (2 * ls * ls)
@@ -1279,7 +1279,7 @@ def three_body_en_jit(bond_array_1, bond_array_2,
 def many_body_jit(q_array_1, q_array_2,
                   q_neigh_array_1, q_neigh_array_2,
                   q_neigh_grads_1, q_neigh_grads_2,
-                  d1, d2, sig, ls):
+                  sig, ls):
     # TODO: update the docs
     """many-body single-element kernel between two force components accelerated
     with Numba.
@@ -1297,8 +1297,6 @@ def many_body_jit(q_array_1, q_array_2,
             local environment
         num_neighbours_2 (np.ndarray): number of neighbours of each atom in the second
             local environment
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         sig (float): many-body signal variance hyperparameter.
         ls (float): many-body length scale hyperparameter.
         r_cut (float): many-body cutoff radius.
@@ -1307,7 +1305,8 @@ def many_body_jit(q_array_1, q_array_2,
     Return:
         float: Value of the many-body kernel.
     """
-    kern = 0
+
+    kern = np.zeros((3, 3), dtype=np.float64)
 
     # Calculate many-body descriptor values for 1 and 2
     q1 = np.sum(q_array_1)
@@ -1315,18 +1314,20 @@ def many_body_jit(q_array_1, q_array_2,
     k12 = k_sq_exp_double_dev(q1, q2, sig, ls)
 
     for i in range(q_neigh_array_1.shape[0]):
-        qi_grad = q_neigh_grads_1[i, d1-1]
+        qi_grad = q_neigh_grads_1[i, :]
         qis = np.sum(q_neigh_array_1[i, :])
         ki2s = k_sq_exp_double_dev(qis, q2, sig, ls)
 
         for j in range(q_neigh_array_2.shape[0]):
-            qj_grad = q_neigh_grads_2[j, d2-1]
+            qj_grad = q_neigh_grads_2[j, :]
             qjs = np.sum(q_neigh_array_2[j, :])
             k1js = k_sq_exp_double_dev(q1, qjs, sig, ls)
 
             kij = k_sq_exp_double_dev(qis, qjs, sig, ls)
 
-            kern += qi_grad * qj_grad * (k12 + ki2s + k1js + kij)
+            for d1 in range(3):
+                for d2 in range(3):
+                    kern[d1,d2] += qi_grad[d1] * qj_grad[d2] * (k12 + ki2s + k1js + kij)
 
     return kern
 
@@ -1334,7 +1335,7 @@ def many_body_jit(q_array_1, q_array_2,
 def many_body_grad_jit(q_array_1, q_array_2,
                        q_neigh_array_1, q_neigh_array_2,
                        q_neigh_grads_1, q_neigh_grads_2,
-                       d1, d2, sig, ls):
+                       sig, ls):
     # TODO: update the docs
     """gradient of many-body single-element kernel between two force components
     w.r.t. the hyperparameters, accelerated with Numba.
@@ -1352,8 +1353,6 @@ def many_body_grad_jit(q_array_1, q_array_2,
             local environment
         num_neighbours_2 (np.ndarray): number of neighbours of each atom in the second
             local environment
-        d1 (int): Force component of the first environment.
-        d2 (int): Force component of the second environment.
         sig (float): many-body signal variance hyperparameter.
         ls (float): many-body length scale hyperparameter.
         r_cut (float): many-body cutoff radius.
@@ -1363,9 +1362,9 @@ def many_body_grad_jit(q_array_1, q_array_2,
         array: Value of the many-body kernel and its gradient w.r.t. sig and ls
     """
 
-    kern = 0
-    sig_derv = 0
-    ls_derv = 0
+    kern = np.zeros((3, 3), dtype=np.float64)
+    sig_derv = np.zeros((3, 3), dtype=np.float64)
+    ls_derv = np.zeros((3, 3), dtype=np.float64)
 
     # Calculate many-body descriptor values for 1 and 2
     q1 = np.sum(q_array_1)
@@ -1373,12 +1372,18 @@ def many_body_grad_jit(q_array_1, q_array_2,
     k12 = k_sq_exp_double_dev(q1, q2, sig, ls)
 
     for i in range(q_neigh_array_1.shape[0]):
-        qi_grad = q_neigh_grads_1[i, d1-1]
+        qi_grad = np.zeros((3, 3), dtype=np.float64)
+        qi_grad[0, :] += q_neigh_grads_1[i, 0]
+        qi_grad[1, :] += q_neigh_grads_1[i, 1]
+        qi_grad[2, :] += q_neigh_grads_1[i, 2]
         qis = np.sum(q_neigh_array_1[i, :])
         ki2s = k_sq_exp_double_dev(qis, q2, sig, ls)
 
         for j in range(q_neigh_array_2.shape[0]):
-            qj_grad = q_neigh_grads_2[j, d2-1]
+            qj_grad = np.zeros((3, 3), dtype=np.float64)
+            qj_grad[0, :] += q_neigh_grads_2[j, 0]
+            qj_grad[1, :] += q_neigh_grads_2[j, 1]
+            qj_grad[2, :] += q_neigh_grads_2[j, 2]
             qjs = np.sum(q_neigh_array_2[j, :])
             k1js = k_sq_exp_double_dev(q1, qjs, sig, ls)
 
@@ -1395,7 +1400,7 @@ def many_body_grad_jit(q_array_1, q_array_2,
 
 @njit
 def many_body_force_en_jit(q_array_1, q_array_2, q_neigh_array_1,
-                           q_neigh_grads, d1, sig, ls):
+                           q_neigh_grads, sig, ls):
     """many-body single-element kernel between force and energy components accelerated
     with Numba.
 
@@ -1408,7 +1413,6 @@ def many_body_force_en_jit(q_array_1, q_array_2, q_neigh_array_1,
             of neighbours for the atoms in the first local environment.
         num_neighbours_1 (np.nsdarray): number of neighbours of each atom in the first
             local environment
-        d1 (int): Force component of the first environment.
         sig (float): many-body signal variance hyperparameter.
         ls (float): many-body length scale hyperparameter.
         r_cut (float): many-body cutoff radius.
@@ -1423,9 +1427,9 @@ def many_body_force_en_jit(q_array_1, q_array_2, q_neigh_array_1,
     k12 = k_sq_exp_dev(q1, q2, sig, ls)
 
     # Loop over neighbours i of 1
-    kern = 0
+    kern = np.zeros(3, dtype=np.float64)
     for i in range(q_neigh_array_1.shape[0]):
-        qi1_grad = q_neigh_grads[i, d1-1]
+        qi1_grad = q_neigh_grads[i]
         qis = np.sum(q_neigh_array_1[i, :])
         ki2s = k_sq_exp_dev(qis, q2, sig, ls)
         kern += - qi1_grad * (k12 + ki2s)
@@ -1451,7 +1455,7 @@ def many_body_en_jit(q_array_1, q_array_2, sig, ls):
     """
     q1 = np.sum(q_array_1) # use sum to be compatible with mc
     q2 = np.sum(q_array_2)
-    q1q2diff = q1 - q2 
+    q1q2diff = q1 - q2
     kern = sig * sig * exp(-q1q2diff * q1q2diff / (2 * ls * ls))
     return kern
 

--- a/flare/kernels/sc.py
+++ b/flare/kernels/sc.py
@@ -216,10 +216,10 @@ def two_plus_three_plus_many_body(env1: AtomicEnvironment, env2: AtomicEnvironme
                        env1.triplet_counts, env2.triplet_counts,
                        hyps[2], hyps[3], cutoffs[1], cutoff_func)
 
-    many_term =  many_body_jit(env1.q_array, env2.q_array,
-                         env1.q_neigh_array, env2.q_neigh_array,
-                         env1.q_neigh_grads, env2.q_neigh_grads,
-                         hyps[4], hyps[5])
+    many_term = many_body_jit(env1.q_array, env2.q_array,
+                              env1.q_neigh_array, env2.q_neigh_array,
+                              env1.q_neigh_grads, env2.q_neigh_grads,
+                              hyps[4], hyps[5])
 
     return two_term + three_term + many_term
 
@@ -254,9 +254,9 @@ def two_plus_three_plus_many_body_grad(env1: AtomicEnvironment, env2: AtomicEnvi
                             hyps[2], hyps[3], cutoffs[1], cutoff_func)
 
     kern_many, sigm, lsm = many_body_grad_jit(env1.q_array, env2.q_array,
-                                       env1.q_neigh_array, env2.q_neigh_array,
-                                       env1.q_neigh_grads, env2.q_neigh_grads,
-                                       hyps[4], hyps[5])
+                                              env1.q_neigh_array, env2.q_neigh_array,
+                                              env1.q_neigh_grads, env2.q_neigh_grads,
+                                              hyps[4], hyps[5])
 
     return kern2 + kern3 + kern_many, np.stack((sig2, ls2, sig3, ls3, sigm, lsm))
 
@@ -293,8 +293,8 @@ def two_plus_three_plus_many_body_force_en(env1: AtomicEnvironment, env2: Atomic
                                 cutoff_func) / 3
 
     many_term = many_body_force_en_jit(env1.q_array, env2.q_array,
-                                  env1.q_neigh_array, env1.q_neigh_grads,
-                                  hyps[4], hyps[5])
+                                       env1.q_neigh_array, env1.q_neigh_grads,
+                                       hyps[4], hyps[5])
 
     return two_term + three_term + many_term
 
@@ -498,7 +498,6 @@ def three_body_grad(env1, env2, hyps, cutoffs,
                                                     env1.triplet_counts, env2.triplet_counts,
                                                     sig, ls, r_cut, cutoff_func)
 
-
     return kernel, np.stack((sig_derv, ls_derv))
 
 
@@ -606,9 +605,9 @@ def many_body_grad(env1, env2, hyps, cutoffs,
     """
 
     kernel, sig_derv, ls_derv = many_body_grad_jit(env1.q_array, env2.q_array,
-                                       env1.q_neigh_array, env2.q_neigh_array,
-                                       env1.q_neigh_grads, env2.q_neigh_grads,
-                                       hyps[0], hyps[1])
+                                                   env1.q_neigh_array, env2.q_neigh_array,
+                                                   env1.q_neigh_grads, env2.q_neigh_grads,
+                                                   hyps[0], hyps[1])
 
     return kernel, np.stack((sig_derv, ls_derv))
 
@@ -754,16 +753,16 @@ def two_body_grad_jit(bond_array_1, bond_array_2, sig, ls,
 
             for d1 in range(3):
                 for d2 in range(3):
-                     A = ci[d1] * cj[d2]
-                     B = r11 * ci[d1]
-                     C = r11 * cj[d2]
-                     kern_term, sig_term, ls_term = \
-                         grad_helper(A, B, C, D, fi, fj, fdi[d1], fdj[d2],
-                                     ls1, ls2, ls3, ls4, ls5, ls6, sig2, sig3)
+                    A = ci[d1] * cj[d2]
+                    B = r11 * ci[d1]
+                    C = r11 * cj[d2]
+                    kern_term, sig_term, ls_term = \
+                        grad_helper(A, B, C, D, fi, fj, fdi[d1], fdj[d2],
+                                    ls1, ls2, ls3, ls4, ls5, ls6, sig2, sig3)
 
-                     kern[d1, d2] += kern_term
-                     sig_derv[d1, d2] += sig_term
-                     ls_derv[d1, d2] += ls_term
+                    kern[d1, d2] += kern_term
+                    sig_derv[d1, d2] += sig_term
+                    ls_derv[d1, d2] += ls_term
 
     return kern, ls_derv, sig_derv
 
@@ -941,12 +940,12 @@ def three_body_jit(bond_array_1, bond_array_2,
 
                     for d1 in range(3):
                         for d2 in range(3):
-                             kern[d1, d2] += triplet_kernel(ci1[d1], ci2[d1],
-                                                            cj1[d2], cj2[d2],
-                                                            ri1, ri2, ri3,
-                                                            rj1, rj2, rj3,
-                                                            fi, fj, fdi[d1], fdj[d2],
-                                                            ls1, ls2, ls3, sig2)
+                            kern[d1, d2] += triplet_kernel(ci1[d1], ci2[d1],
+                                                           cj1[d2], cj2[d2],
+                                                           ri1, ri2, ri3,
+                                                           rj1, rj2, rj3,
+                                                           fi, fj, fdi[d1], fdj[d2],
+                                                           ls1, ls2, ls3, sig2)
     return kern
 
 
@@ -1310,6 +1309,7 @@ def many_body_jit(q_array_1, q_array_2,
 
     return kern
 
+
 @njit
 def many_body_grad_jit(q_array_1, q_array_2,
                        q_neigh_array_1, q_neigh_array_2,
@@ -1428,7 +1428,7 @@ def many_body_en_jit(q_array_1, q_array_2, sig, ls):
     Return:
         float: Value of the many-body kernel.
     """
-    q1 = np.sum(q_array_1) # use sum to be compatible with mc
+    q1 = np.sum(q_array_1)  # use sum to be compatible with mc
     q2 = np.sum(q_array_2)
     q1q2diff = q1 - q2
     kern = sig * sig * exp(-q1q2diff * q1q2diff / (2 * ls * ls))
@@ -1512,9 +1512,8 @@ def triplet_kernel_grad(ci1, ci2, cj1, cj2, ri1, ri2, ri3, rj1, rj2, rj3, fi,
     X = X1 + X2 + X3 + X4 + X5 + X6
     return N, O, X
 
+
 @njit
-
-
 def triplet_force_en_kernel(ci1, ci2, ri1, ri2, ri3, rj1, rj2, rj3,
                             fi, fj, fdi, ls1, ls2, sig2):
     r11 = ri1 - rj1

--- a/flare/kernels/utils.py
+++ b/flare/kernels/utils.py
@@ -194,11 +194,11 @@ def from_grad_to_mask(grad, hyps_mask=None):
     else:
         hm = hyp_index
 
-    newgrad = np.zeros(len(hm), dtype=np.float64)
+    newgrad = [None]*len(hm)
     for i, mapid in enumerate(hm):
-        newgrad[i] = grad[mapid]
+        newgrad[i] = [grad[mapid]]
 
-    return newgrad
+    return np.vstack(newgrad)
 
 
 def kernel_str_to_array(kernel_name: str):

--- a/flare/kernels/utils.py
+++ b/flare/kernels/utils.py
@@ -85,7 +85,6 @@ def str_to_kernel_set(kernels: list = ['twobody', 'threebody'],
         stk[prefix+'_force_en']
 
 
-
 def from_mask_to_args(hyps, cutoffs, hyps_mask=None):
     """ Return the tuple of arguments needed for kernel function.
     The order of the tuple has to be exactly the same as the one taken by

--- a/flare/mgp/map3b.py
+++ b/flare/mgp/map3b.py
@@ -1,6 +1,5 @@
 import numpy as np
 from math import floor, ceil
-from time import time
 
 from typing import List
 
@@ -162,10 +161,6 @@ class SingleMap3body(SingleMapXbody):
             kernel_info: return value of the get_3b_kernel
         """
 
-        filename=f"{name}_{self.species_code}_{s}_{e}"
-        with open(filename, "a") as f:
-            print("open", time(), file=f)
-
         grid_kernel, _, _, cutoffs, hyps, hyps_mask = kernel_info
 
         args = from_mask_to_args(hyps, cutoffs, hyps_mask)
@@ -201,12 +196,10 @@ class SingleMap3body(SingleMapXbody):
         else:
             n_chunk = 1
 
-        timeloop = time()
         for m_index in range(s, e):
             data = training_data[m_index]
             kern_vec = []
             for g in range(n_chunk):
-                time0 = time()
                 gs = chunk_size * g
                 ge = np.min((chunk_size * (g + 1), n_grids))
                 grid_chunk = grids[gs:ge, :]
@@ -215,20 +208,13 @@ class SingleMap3body(SingleMapXbody):
                 kv_chunk = grid_kernel(kern_type, data, grid_chunk, fj_chunk, fdj_chunk,
                                        env12.ctype, env12.etypes, *args)
                 kern_vec.append(kv_chunk)
-                with open(filename, "a") as f:
-                    print("compute", m_index, g, time()-time0, file=f)
             kern_vec = np.hstack(kern_vec)
             k_v.append(kern_vec)
-        with open(filename, "a") as f:
-            print("end", time()-timeloop, file=f)
 
-        time0 = time()
         if len(k_v) > 0:
             k_v = np.vstack(k_v).T
         else:
             k_v = np.zeros((grids.shape[0], 0))
 
-        with open(filename, "a") as f:
-            print("done", time()-time0, file=f)
 
         return k_v

--- a/flare/mgp/mapxb.py
+++ b/flare/mgp/mapxb.py
@@ -95,7 +95,7 @@ class MapXbody:
         generate/load grids and get spline coefficients
         '''
 
-        self.kernel_info = get_kernel_term(self.kernel_name, 
+        self.kernel_info = get_kernel_term(self.kernel_name,
             GP.component, GP.hyps_mask, GP.hyps)
         self.hyps_mask = GP.hyps_mask
         self.hyps = GP.hyps
@@ -188,7 +188,7 @@ class MapXbody:
         new_mgp = mapxbody(**dictionary)
 
         # Restore kernel_info
-        new_mgp.kernel_info = get_kernel_term(dictionary['kernel_name'], 
+        new_mgp.kernel_info = get_kernel_term(dictionary['kernel_name'],
             'mc', dictionary['hyps_mask'], dictionary['hyps'])
 
         # Fill up the model with the saved coeffs
@@ -314,7 +314,7 @@ class SingleMapXbody:
                 GP.hyps_mask, GP.hyps)
         if self.use_grid_kern:
             try:
-                kernel_info = get_kernel_term(self.kernel_name, GP.component, 
+                kernel_info = get_kernel_term(self.kernel_name, GP.component,
                     GP.hyps_mask, GP.hyps, grid_kernel=True)
             except:
                 self.use_grid_kern = False
@@ -354,7 +354,7 @@ class SingleMapXbody:
             n_grid = np.prod(self.grid_num)
             return np.empty((n_grid, 0))
 
-        if self.use_grid_kern: 
+        if self.use_grid_kern:
             gengrid_func = self._gengrid_numba
         else:
             gengrid_func = self._gengrid_inner
@@ -413,7 +413,7 @@ class SingleMapXbody:
             if not self.skip_grid(grid_pt):
                 if self.map_force:
                     k12_v[b, :] = force_x_vector_unit(name, s, e, grid_env,
-                        force_x_kern, hyps, cutoffs, hyps_mask, 1)
+                        force_x_kern, hyps, cutoffs, hyps_mask)[:, 0]
                 else:
                     k12_v[b, :] = energy_x_vector_unit(name, s, e, grid_env,
                         energy_x_kern, hyps, cutoffs, hyps_mask)

--- a/flare/predict.py
+++ b/flare/predict.py
@@ -12,7 +12,7 @@ from flare.gp import GaussianProcess
 from flare.struc import Structure
 
 
-def predict_on_atom(param: Tuple[Structure, int, GaussianProcess]) -> (
+def predict_on_atom(param: Tuple[Structure, int, GaussianProcess], energy=False) -> (
         'np.ndarray', 'np.ndarray'):
     """
     Return the forces/std. dev. uncertainty associated with an individual atom
@@ -31,48 +31,15 @@ def predict_on_atom(param: Tuple[Structure, int, GaussianProcess]) -> (
     # Obtain the associated chemical environment
     chemenv = AtomicEnvironment(structure, atom, gp.cutoffs,
                                 cutoffs_mask=gp.hyps_mask)
-    components = []
-    stds = []
     # predict force components and standard deviations
-    for i in range(3):
-        force, var = gp.predict(chemenv, i + 1)
-        components.append(float(force))
-        stds.append(np.sqrt(np.abs(var)))
+    force, var = gp.predict(chemenv)
 
-    return np.array(components), np.array(stds)
+    if energy:
+        # predict local energy
+        local_energy = gp.predict_local_energy(chemenv)
+        return force, np.sqrt(np.abs(var)), local_energy
 
-
-def predict_on_atom_en(param: Tuple[Structure, int, GaussianProcess]) -> (
-        'np.ndarray', 'np.ndarray', float):
-    """
-    Return the forces/std. dev. uncertainty / energy associated with an
-    individual atom in a structure, without necessarily having cast it to a
-    chemical environment. In order to work with other functions,
-    all arguments are passed in as a tuple.
-
-    :param param: tuple of FLARE Structure, atom index, and Gaussian Process
-        object
-    :type param: Tuple(Structure, integer, GaussianProcess)
-    :return: 3-element force array, associated uncertainties, and local energy
-    :rtype: (np.ndarray, np.ndarray, float)
-    """
-    # Unpack the input tuple, convert a chemical environment
-    structure, atom, gp = param
-    # Obtain the associated chemical environment
-    chemenv = AtomicEnvironment(structure, atom, gp.cutoffs,
-                                cutoffs_mask=gp.hyps_mask)
-    comps = []
-    stds = []
-    # predict force components and standard deviations
-    for i in range(3):
-        force, var = gp.predict(chemenv, i + 1)
-        comps.append(float(force))
-        stds.append(np.sqrt(np.abs(var)))
-
-    # predict local energy
-    local_energy = gp.predict_local_energy(chemenv)
-
-    return np.array(comps), np.array(stds), local_energy
+    return force, np.sqrt(np.abs(var))
 
 
 def predict_on_atom_en_std(param):
@@ -90,140 +57,10 @@ def predict_on_atom_en_std(param):
 
 
 def predict_on_structure(structure: Structure, gp: GaussianProcess,
-                         n_cpus: int = None, write_to_structure: bool = True,
+                         n_cpus: int = None,
+                         write_to_structure: bool = True,
                          selective_atoms: List[int] = None,
-                         skipped_atom_value=0) \
-        -> ('np.ndarray', 'np.ndarray'):
-    """
-    Return the forces/std. dev. uncertainty associated with each
-    individual atom in a structure. Forces are stored directly to the
-    structure and are also returned.
-
-    :param structure: FLARE structure to obtain forces for, with N atoms
-    :param gp: Gaussian Process model
-    :param write_to_structure: Write results to structure's forces,
-                            std attributes
-    :param selective_atoms: Only predict on these atoms; e.g. [0,1,2] will
-                                only predict and return for those atoms
-    :param skipped_atom_value: What value to use for atoms that are skipped.
-            Defaults to 0 but other options could be e.g. NaN. Will NOT
-            write this to the structure if write_to_structure is True.
-    :return: N x 3 numpy array of foces, Nx3 numpy array of uncertainties
-    :rtype: (np.ndarray, np.ndarray)
-    """
-
-    forces = np.zeros((structure.nat, 3))
-    stds = np.zeros((structure.nat, 3))
-
-    if selective_atoms:
-        forces.fill(skipped_atom_value)
-        stds.fill(skipped_atom_value)
-    else:
-        selective_atoms = []
-
-    for n in range(structure.nat):
-
-        # Skip the atoms which we aren't predicting on if
-        # selective atoms is on
-        if n not in selective_atoms and selective_atoms:
-            continue
-
-        chemenv = AtomicEnvironment(structure, n, gp.cutoffs,
-                                    cutoffs_mask=gp.hyps_mask)
-
-        for i in range(3):
-            force, var = gp.predict(chemenv, i + 1)
-            forces[n][i] = float(force)
-            stds[n][i] = float(np.sqrt(np.absolute(var)))
-
-            if write_to_structure:
-                structure.forces[n][i] = force
-                structure.stds[n][i] = np.sqrt(np.abs(var))
-
-    return forces, stds
-
-
-def predict_on_structure_par(structure: Structure,
-                             gp: GaussianProcess,
-                             n_cpus: int = None,
-                             write_to_structure: bool = True,
-                             selective_atoms: List[int] = None,
-                             skipped_atom_value=0
-                             ) -> (
-        'np.ndarray', 'np.ndarray'):
-    """
-    Return the forces/std. dev. uncertainty associated with each
-    individual atom in a structure. Forces are stored directly to the
-    structure and are also returned.
-
-    :param structure: FLARE structure to obtain forces for, with N atoms
-    :param gp: Gaussian Process model
-    :param n_cpus: Number of cores to parallelize over
-    :param write_to_structure: Write results to structure's forces,
-                            std attributes
-    :param selective_atoms: Only predict on these atoms; e.g. [0,1,2] will
-                                only predict and return for those atoms
-    :param skipped_atom_value: What value to use for atoms that are skipped.
-            Defaults to 0 but other options could be e.g. NaN. Will NOT
-            write this to the structure if write_to_structure is True.
-    :return: N x 3 array of forces, N x 3 array of uncertainties
-    :rtype: (np.ndarray, np.ndarray)
-    """
-    # Just work in serial in the number of cpus is 1
-    if n_cpus == 1:
-        return predict_on_structure(structure=structure,
-                                    gp=gp,
-                                    n_cpus=n_cpus,
-                                    write_to_structure=write_to_structure,
-                                    selective_atoms=selective_atoms,
-                                    skipped_atom_value=skipped_atom_value)
-
-    forces = np.zeros(shape=(structure.nat, 3))
-    stds = np.zeros(shape=(structure.nat, 3))
-
-    if selective_atoms:
-        forces.fill(skipped_atom_value)
-        stds.fill(skipped_atom_value)
-    else:
-        selective_atoms = []
-
-    # Automatically detect number of cpus available
-    if n_cpus is None:
-        pool = mp.Pool(processes=mp.cpu_count())
-    else:
-        pool = mp.Pool(processes=n_cpus)
-
-    # Parallelize over atoms in structure
-    results = []
-    for atom in range(structure.nat):
-        # If selective atoms is on, skip ones that was skipped
-        if atom not in selective_atoms and selective_atoms:
-            # Keep length of results equal to nat
-            results.append(None)
-            continue
-        results.append(pool.apply_async(predict_on_atom,
-                                        args=[(structure, atom, gp)]))
-    pool.close()
-    pool.join()
-
-    for i in range(structure.nat):
-        if i not in selective_atoms and selective_atoms:
-            continue
-        r = results[i].get()
-        forces[i] = r[0]
-        stds[i] = r[1]
-        if write_to_structure:
-            structure.forces[i] = r[0]
-            structure.stds[i] = r[1]
-
-    return forces, stds
-
-
-def predict_on_structure_en(structure: Structure, gp: GaussianProcess,
-                            n_cpus: int = None,
-                            write_to_structure: bool = True,
-                            selective_atoms: List[int] = None,
-                            skipped_atom_value=0) -> (
+                         skipped_atom_value=0, energy=False) -> (
         'np.ndarray', 'np.ndarray', 'np.ndarray'):
     """
     Return the forces/std. dev. uncertainty / local energy associated with each
@@ -262,25 +99,28 @@ def predict_on_structure_en(structure: Structure, gp: GaussianProcess,
         chemenv = AtomicEnvironment(structure, n, gp.cutoffs,
                                     cutoffs_mask=gp.hyps_mask)
 
-        for i in range(3):
-            force, var = gp.predict(chemenv, i + 1)
-            forces[n][i] = float(force)
-            stds[n][i] = np.sqrt(np.abs(var))
+        force, var = gp.predict(chemenv)
+        forces[n] = force
+        stds[n] = np.sqrt(np.abs(var))
 
-            if write_to_structure and structure.forces is not None:
-                structure.forces[n][i] = float(force)
-                structure.stds[n][i] = np.sqrt(np.abs(var))
+        if write_to_structure and structure.forces is not None:
+            structure.forces[n] = force
+            structure.stds[n] = np.sqrt(np.abs(var))
 
-        local_energies[n] = gp.predict_local_energy(chemenv)
+        if energy:
+            local_energies[n] = gp.predict_local_energy(chemenv)
 
-    return forces, stds, local_energies
+    if energy:
+        return forces, stds, local_energies
+
+    return forces, stds
 
 
-def predict_on_structure_par_en(structure: Structure, gp: GaussianProcess,
-                                n_cpus: int = None,
-                                write_to_structure: bool = True,
-                                selective_atoms: List[int] = None,
-                                skipped_atom_value=0) -> (
+def predict_on_structure_par(structure: Structure, gp: GaussianProcess,
+                             n_cpus: int = None,
+                             write_to_structure: bool = True,
+                             selective_atoms: List[int] = None,
+                             skipped_atom_value=0, energy=False) -> (
         'np.ndarray', 'np.ndarray', 'np.ndarray'):
     """
     Return the forces/std. dev. uncertainty / local energy associated with each
@@ -296,10 +136,11 @@ def predict_on_structure_par_en(structure: Structure, gp: GaussianProcess,
     """
     # Work in serial if the number of cpus is 1
     if n_cpus == 1:
-        predict_on_structure_en(structure, gp,
-                                n_cpus, write_to_structure,
-                                selective_atoms,
-                                skipped_atom_value)
+        predict_on_structure(structure, gp,
+                             n_cpus, write_to_structure,
+                             selective_atoms,
+                             skipped_atom_value,
+                             energy)
 
     forces = np.zeros((structure.nat, 3))
     stds = np.zeros((structure.nat, 3))
@@ -327,8 +168,8 @@ def predict_on_structure_par_en(structure: Structure, gp: GaussianProcess,
             results.append(None)
             continue
 
-        results.append(pool.apply_async(predict_on_atom_en,
-                                        args=[(structure, atom_i, gp)]))
+        results.append(pool.apply_async(predict_on_atom,
+                                        args=[(structure, atom_i, gp), True]))
     pool.close()
     pool.join()
 
@@ -341,13 +182,17 @@ def predict_on_structure_par_en(structure: Structure, gp: GaussianProcess,
         r = results[i].get()
         forces[i][:] = r[0]
         stds[i][:] = r[1]
-        local_energies[i] = r[2]
+        if energy:
+            local_energies[i] = r[2]
 
         if write_to_structure:
             structure.forces[i] = forces[i]
             structure.stds[i] = stds[i]
 
-    return forces, stds, local_energies
+    if energy:
+        return forces, stds, local_energies
+    return forces, stds
+
 
 
 def predict_on_atom_mgp(atom: int, structure, mgp,

--- a/tests/fake_gp.py
+++ b/tests/fake_gp.py
@@ -157,7 +157,7 @@ def generate_mb_envs(cutoffs, cell, delt, d1, mask=None, kern_type='mc'):
     np.random.shuffle(threebody)
     species_1 = np.hstack([threebody, randint(1, 2)])
     if kern_type == 'sc':
-        species_1 = np.ones(species_1.shape)
+        species_1 = np.ones(species_1.shape, dtype=int)
     return generate_mb_envs_pos(positions0, species_1, cutoffs, cell, delt, d1, mask)
 
 

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -1,24 +1,21 @@
-import pytest
-import pickle
-import os
 import json
 import numpy as np
+import os
+import pickle
+import pytest
 
-from typing import List
+from copy import deepcopy
 from pytest import raises
 from scipy.optimize import OptimizeResult
+from typing import List
 
 import flare
 from flare.predict import predict_on_structure
 from flare.gp import GaussianProcess
 from flare.env import AtomicEnvironment
 from flare.struc import Structure
-import flare.kernels.sc as en
-import flare.kernels.mc_simple as mc_simple
-from flare.otf_parser import OtfAnalysis
 
-from .fake_gp import generate_hm, get_tstp, get_random_structure
-from copy import deepcopy
+from tests.fake_gp import generate_hm, get_tstp, get_random_structure
 multihyps_list = [True, False]
 
 
@@ -93,7 +90,7 @@ class TestDataUpdating():
         assert (len(test_gp.training_data) == params['noa']+oldsize)
         assert (len(test_gp.training_labels_np) == (params['noa']+oldsize)*3)
 
-#
+
 
 
 class TestTraining():
@@ -241,8 +238,8 @@ class TestIO():
         test_gp = all_gps[multihyps]
         the_str = str(test_gp)
         assert 'GaussianProcess Object' in the_str
-        assert 'Kernel: [\'twobody\', \'threebody\']' in the_str #, \'manybody\']' in the_str
-        assert 'Cutoffs: {\'twobody\': 0.8, \'threebody\': 0.8}' in the_str #, \'manybody\': 0.8}' in the_str
+        assert 'Kernel: [\'twobody\', \'threebody\', \'manybody\']' in the_str
+        assert 'Cutoffs: {\'twobody\': 0.8, \'threebody\': 0.8, \'manybody\': 0.8}' in the_str
         assert 'Model Likelihood: ' in the_str
         if not multihyps:
             assert 'Length ' in the_str

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -197,10 +197,10 @@ class TestAlgebra():
        test_gp = all_gps[multihyps]
        test_gp.parallel = par
        test_gp.per_atom_par = per_atom_par
-       pred = test_gp.predict(x_t=validation_env, d=1)
+       pred = test_gp.predict(x_t=validation_env)
        assert (len(pred) == 2)
-       assert (isinstance(pred[0], float))
-       assert (isinstance(pred[1], float))
+       assert (isinstance(pred[0][0], float))
+       assert (isinstance(pred[1][0], float))
 
    @pytest.mark.parametrize('par, n_cpus', [(True, 2),
                                             (False, 1)])
@@ -241,8 +241,8 @@ class TestIO():
         test_gp = all_gps[multihyps]
         the_str = str(test_gp)
         assert 'GaussianProcess Object' in the_str
-        assert 'Kernel: [\'twobody\', \'threebody\', \'manybody\']' in the_str
-        assert 'Cutoffs: {\'twobody\': 0.8, \'threebody\': 0.8, \'manybody\': 0.8}' in the_str
+        assert 'Kernel: [\'twobody\', \'threebody\']' in the_str #, \'manybody\']' in the_str
+        assert 'Cutoffs: {\'twobody\': 0.8, \'threebody\': 0.8}' in the_str #, \'manybody\': 0.8}' in the_str
         assert 'Model Likelihood: ' in the_str
         if not multihyps:
             assert 'Length ' in the_str
@@ -266,9 +266,9 @@ class TestIO():
 
         dumpcompare(new_gp_dict, old_gp_dict)
 
-        for d in [1, 2, 3]:
-            assert np.all(test_gp.predict(x_t=validation_env, d=d) ==
-                          new_gp.predict(x_t=validation_env, d=d))
+        test_predict = np.hstack(test_gp.predict(x_t=validation_env))
+        new_predict = np.hstack(new_gp.predict(x_t=validation_env))
+        assert np.array_equal(test_predict, new_predict)
         assert new_gp.training_data is not test_gp.training_data
 
     @pytest.mark.parametrize('multihyps', multihyps_list)
@@ -280,9 +280,9 @@ class TestIO():
 
         new_gp = GaussianProcess.from_file('test_gp_write.pickle')
 
-        for d in [1, 2, 3]:
-            assert np.all(test_gp.predict(x_t=validation_env, d=d) ==
-                          new_gp.predict(x_t=validation_env, d=d))
+        test_predict = np.hstack(test_gp.predict(x_t=validation_env))
+        new_predict = np.hstack(new_gp.predict(x_t=validation_env))
+        assert np.array_equal(test_predict, new_predict)
 
         try:
             os.remove('test_gp_write.pickle')
@@ -293,9 +293,10 @@ class TestIO():
 
         with open('test_gp_write.json', 'r') as f:
             new_gp = GaussianProcess.from_dict(json.loads(f.readline()))
-        for d in [1, 2, 3]:
-            assert np.all(test_gp.predict(x_t=validation_env, d=d) ==
-                          new_gp.predict(x_t=validation_env, d=d))
+
+        test_predict = np.hstack(test_gp.predict(x_t=validation_env))
+        new_predict = np.hstack(new_gp.predict(x_t=validation_env))
+        assert np.array_equal(test_predict, new_predict)
         os.remove('test_gp_write.json')
 
         with raises(ValueError):

--- a/tests/test_gp_from_aimd.py
+++ b/tests/test_gp_from_aimd.py
@@ -140,9 +140,8 @@ def test_seed_and_run():
 
     test_env = envs[0]
 
-    for d in [1, 2, 3]:
-        assert np.all(the_gp.predict(x_t=test_env, d=d) ==
-                      new_gp.predict(x_t=test_env, d=d))
+    assert np.isclose(the_gp.predict(x_t=test_env),
+                  new_gp.predict(x_t=test_env)).all()
 
     for f in glob(f"meth_test*"):
         remove(f)

--- a/tests/test_grid_kernel.py
+++ b/tests/test_grid_kernel.py
@@ -125,14 +125,9 @@ def get_reference(grid_env, species, parameter, same_hyps):
             hm['kernels'], "mc", None if same_hyps else hm)
     args = from_mask_to_args(hm['hyps'], hm['cutoffs'], None if same_hyps else hm)
 
-    energy_force = np.zeros(3, dtype=np.float)
-    # force_force = np.zeros(3, dtype=np.float)
-    # force_energy = np.zeros(3, dtype=np.float)
-    # energy_energy = np.zeros(3, dtype=np.float)
-    for i in range(3):
-        energy_force[i] = force_en_kernel(env, grid_env, i+1, *args)
+    energy_force = force_en_kernel(env, grid_env, *args)
         # force_energy[i] = force_en_kernel(env, grid_env, i, *args)
         # force_force[i] = kernel(grid_env, env, 0, i, *args)
-#     result = funcs[1][i](env1, env2, d1, *args1)
+#     result = funcs[1][i](env1, env2, *args1)
     return energy_force # , force_energy, force_force, energy_energy
 

--- a/tests/test_mc_sephyps.py
+++ b/tests/test_mc_sephyps.py
@@ -163,12 +163,16 @@ def test_check_sig_scale(kernels, diff_cutoff, d1, d2):
     assert isclose(result[0]/reference[0], scale**2, rtol=tol).all()
     for idx in range(reference[1].shape[0]):
         # check sig0
-        if (idx % 4) == 0:
-            assert isclose(result[1][idx]/reference[1][idx], scale, rtol=tol).all()
-        # check the rest, but skip sig 1
-        elif (idx % 4) != 1:
-            assert isclose(result[1][idx]/reference[1]
-                           [idx], scale**2, rtol=tol).all()
+        if np.min(np.abs(reference[1][idx]))>0:
+            if  and (idx % 4) == 0:
+                print(result[1][idx])
+                print(reference[1][idx])
+                assert isclose(result[1][idx]/reference[1][idx],
+                        scale, rtol=tol).all()
+            # check the rest, but skip sig 1
+            elif (idx % 4) != 1:
+                assert isclose(result[1][idx]/reference[1][idx],
+                        scale**2, rtol=tol).all()
 
 
 @pytest.mark.parametrize('kernels', list_to_test)

--- a/tests/test_mc_sephyps.py
+++ b/tests/test_mc_sephyps.py
@@ -16,9 +16,10 @@ from .fake_gp import generate_mb_envs, generate_mb_twin_envs
 list_to_test = [['twobody'], ['threebody'],
                 ['twobody', 'threebody'],
                 ['twobody', 'threebody', 'manybody']]
+short_list_to_test = [['twobody'], ['threebody'], ['manybody']]
 multi_cut = [False, True]
 
-@pytest.mark.parametrize('kernels', list_to_test)
+@pytest.mark.parametrize('kernels', short_list_to_test)
 @pytest.mark.parametrize('multi_cutoff', multi_cut)
 @pytest.mark.parametrize('d1, d2', [[1,1], [1, 2]])
 def test_force_en_multi_vs_simple(kernels, multi_cutoff, d1, d2):
@@ -99,7 +100,7 @@ def test_force_en_multi_vs_simple(kernels, multi_cutoff, d1, d2):
         assert(isclose(reference[1][i], joint_grad, rtol=tol).all())
 
 
-@pytest.mark.parametrize('kernels', list_to_test)
+@pytest.mark.parametrize('kernels', short_list_to_test)
 @pytest.mark.parametrize('diff_cutoff', multi_cut)
 @pytest.mark.parametrize('d1, d2', [[1,1], [1, 2]])
 def test_check_sig_scale(kernels, diff_cutoff, d1, d2):
@@ -164,7 +165,7 @@ def test_check_sig_scale(kernels, diff_cutoff, d1, d2):
     for idx in range(reference[1].shape[0]):
         # check sig0
         if np.min(np.abs(reference[1][idx]))>0:
-            if  and (idx % 4) == 0:
+            if (idx % 4) == 0:
                 print(result[1][idx])
                 print(reference[1][idx])
                 assert isclose(result[1][idx]/reference[1][idx],
@@ -175,7 +176,7 @@ def test_check_sig_scale(kernels, diff_cutoff, d1, d2):
                         scale**2, rtol=tol).all()
 
 
-@pytest.mark.parametrize('kernels', list_to_test)
+@pytest.mark.parametrize('kernels', short_list_to_test)
 @pytest.mark.parametrize('diff_cutoff', multi_cut)
 @pytest.mark.parametrize('d1, d2', [[1,1], [1, 2]])
 def test_force_bound_cutoff_compare(kernels, diff_cutoff, d1, d2):
@@ -255,7 +256,7 @@ def test_constraint(kernels, diff_cutoff, d1, d2):
         kern_finite_diff += 9*(calc1 - calc2) / 3.0 / delta
 
     kern_analytical = force_en_kernel(env1[0][0], env2[0][0], *args0)
-    kern_analytical = kern_analytical[d1-1, d2-1]
+    kern_analytical = kern_analytical[d1-1]
 
     tol = 1e-4
     print(kern_finite_diff, kern_analytical)
@@ -283,7 +284,7 @@ def test_force_en(kernels, diff_cutoff, d1):
     _, __, en_kernel, force_en_kernel = str_to_kernel_set(kernels, "mc", hm)
 
     kern_analytical = force_en_kernel(env1[0][0], env2[0][0], *args)
-    kern_analytical = kernel_analytical[d1-1]
+    kern_analytical = kern_analytical[d1-1]
 
     kern_finite_diff = 0
     if ('manybody' in kernels):
@@ -393,7 +394,7 @@ def test_force(kernels, diff_cutoff, d1, d2):
 
     args = from_mask_to_args(hyps, cutoffs, hm)
     kern_analytical = kernel(env1[0][0], env2[0][0], *args)
-    kern_analytical = kernel_analytical[d1-1, d2-1]
+    kern_analytical = kern_analytical[d1-1, d2-1]
 
     assert(isclose(kern_finite_diff, kern_analytical, rtol=tol))
 

--- a/tests/test_mc_sephyps.py
+++ b/tests/test_mc_sephyps.py
@@ -20,12 +20,11 @@ multi_cut = [False, True]
 
 @pytest.mark.parametrize('kernels', list_to_test)
 @pytest.mark.parametrize('multi_cutoff', multi_cut)
-def test_force_en_multi_vs_simple(kernels, multi_cutoff):
+@pytest.mark.parametrize('d1, d2', [[1,1], [1, 2]])
+def test_force_en_multi_vs_simple(kernels, multi_cutoff, d1, d2):
     """Check that the analytical kernel matches the one implemented
     in mc_simple.py"""
 
-    d1 = 1
-    d2 = 2
     tol = 1e-4
     cell = 1e7 * np.eye(3)
 
@@ -62,48 +61,48 @@ def test_force_en_multi_vs_simple(kernels, multi_cutoff):
     reference = funcs[0][i](env1, env2, *args0)
     result = funcs[1][i](env1, env2, *args1)
     print(kernels, i, reference, result)
-    assert(isclose(reference, result, rtol=tol))
+    assert(isclose(reference, result, rtol=tol).all())
     result = funcs[1][i](env1, env2, *args2)
     print(kernels, i, reference, result)
-    assert(isclose(reference, result, rtol=tol))
+    assert(isclose(reference, result, rtol=tol).all())
 
     i = 3
-    reference = funcs[0][i](env1, env2, d1, *args0)
-    result = funcs[1][i](env1, env2, d1, *args1)
+    reference = funcs[0][i](env1, env2, *args0)
+    result = funcs[1][i](env1, env2, *args1)
     print(kernels, i, reference, result)
-    assert(isclose(reference, result, rtol=tol))
-    result = funcs[1][i](env1, env2, d1, *args2)
+    assert(isclose(reference, result, rtol=tol).all())
+    result = funcs[1][i](env1, env2, *args2)
     print(kernels, i, reference, result)
-    assert(isclose(reference, result, rtol=tol))
+    assert(isclose(reference, result, rtol=tol).all())
 
     i = 0
-    reference = funcs[0][i](env1, env2, d1, d2, *args0)
-    result = funcs[1][i](env1, env2, d1, d2, *args1)
-    assert(isclose(reference, result, rtol=tol))
+    reference = funcs[0][i](env1, env2, *args0)
+    result = funcs[1][i](env1, env2, *args1)
+    assert(isclose(reference, result, rtol=tol).all())
     print(kernels, i, reference, result)
-    result = funcs[1][i](env1, env2, d1, d2, *args2)
-    assert(isclose(reference, result, rtol=tol))
+    result = funcs[1][i](env1, env2, *args2)
+    assert(isclose(reference, result, rtol=tol).all())
     print(kernels, i, reference, result)
 
     i = 1
-    reference = funcs[0][i](env1, env2, d1, d2, *args0)
-    result = funcs[1][i](env1, env2, d1, d2, *args1)
+    reference = funcs[0][i](env1, env2, *args0)
+    result = funcs[1][i](env1, env2, *args1)
     print(kernels, i, reference, result)
-    assert(isclose(reference[0], result[0], rtol=tol))
+    assert(isclose(reference[0], result[0], rtol=tol).all())
     assert(isclose(reference[1], result[1], rtol=tol).all())
 
-    result = funcs[1][i](env1, env2, d1, d2, *args2)
+    result = funcs[1][i](env1, env2, *args2)
     print(kernels, i, reference, result)
-    assert(isclose(reference[0], result[0], rtol=tol))
-    joint_grad = np.zeros(len(result[1])//2)
-    for i in range(joint_grad.shape[0]):
-        joint_grad[i] = result[1][i*2] + result[1][i*2+1]
-    assert(isclose(reference[1], joint_grad, rtol=tol).all())
+    assert(isclose(reference[0], result[0], rtol=tol).all())
+    for i in range(len(reference[1])):
+        joint_grad = result[1][i*2] + result[1][i*2+1]
+        assert(isclose(reference[1][i], joint_grad, rtol=tol).all())
 
 
 @pytest.mark.parametrize('kernels', list_to_test)
 @pytest.mark.parametrize('diff_cutoff', multi_cut)
-def test_check_sig_scale(kernels, diff_cutoff):
+@pytest.mark.parametrize('d1, d2', [[1,1], [1, 2]])
+def test_check_sig_scale(kernels, diff_cutoff, d1, d2):
     """Check whether the grouping is properly assign
     with four environments
 
@@ -118,8 +117,6 @@ def test_check_sig_scale(kernels, diff_cutoff):
       the reference
     """
 
-    d1 = 1
-    d2 = 2
     tol = 1e-4
     scale = 2
 
@@ -148,44 +145,39 @@ def test_check_sig_scale(kernels, diff_cutoff):
     reference = en_kernel(env1, env2, *args0)
     result = en_kernel(env1_t, env2_t, *args1)
     print(en_kernel.__name__, result, reference)
-    if (reference != 0):
-        assert isclose(result/reference, scale**2, rtol=tol)
+    assert isclose(result/reference, scale**2, rtol=tol).all()
 
-    reference = force_en_kernel(env1, env2, d1, *args0)
-    result = force_en_kernel(env1_t, env2_t, d1, *args1)
+    reference = force_en_kernel(env1, env2, *args0)
+    result = force_en_kernel(env1_t, env2_t, *args1)
     print(force_en_kernel.__name__, result, reference)
-    if (reference != 0):
-        assert isclose(result/reference, scale**2, rtol=tol)
+    assert isclose(result/reference, scale**2, rtol=tol).all()
 
-    reference = kernel(env1, env2, d1, d2, *args0)
-    result = kernel(env1_t, env2_t, d1, d2, *args1)
+    reference = kernel(env1, env2, *args0)
+    result = kernel(env1_t, env2_t, *args1)
     print(kernel.__name__, result, reference)
-    if (reference != 0):
-        assert isclose(result/reference, scale**2, rtol=tol)
+    assert isclose(result/reference, scale**2, rtol=tol).all()
 
-    reference = kg(env1, env2, d1, d2, *args0)
-    result = kg(env1_t, env2_t, d1, d2, *args1)
+    reference = kg(env1, env2, *args0)
+    result = kg(env1_t, env2_t, *args1)
     print(kg.__name__, result, reference)
-    if (reference[0] != 0):
-        assert isclose(result[0]/reference[0], scale**2, rtol=tol)
+    assert isclose(result[0]/reference[0], scale**2, rtol=tol).all()
     for idx in range(reference[1].shape[0]):
         # check sig0
-        if (reference[1][idx] != 0 and (idx % 4) == 0):
-            assert isclose(result[1][idx]/reference[1][idx], scale, rtol=tol)
+        if (idx % 4) == 0:
+            assert isclose(result[1][idx]/reference[1][idx], scale, rtol=tol).all()
         # check the rest, but skip sig 1
-        elif (reference[1][idx] != 0 and (idx % 4) != 1):
+        elif (idx % 4) != 1:
             assert isclose(result[1][idx]/reference[1]
-                           [idx], scale**2, rtol=tol)
+                           [idx], scale**2, rtol=tol).all()
 
 
 @pytest.mark.parametrize('kernels', list_to_test)
 @pytest.mark.parametrize('diff_cutoff', multi_cut)
-def test_force_bound_cutoff_compare(kernels, diff_cutoff):
+@pytest.mark.parametrize('d1, d2', [[1,1], [1, 2]])
+def test_force_bound_cutoff_compare(kernels, diff_cutoff, d1, d2):
     """Check that the analytical kernel matches the one implemented
     in mc_simple.py"""
 
-    d1 = 1
-    d2 = 2
     tol = 1e-4
     cell = 1e7 * np.eye(3)
     delta = 1e-8
@@ -201,36 +193,35 @@ def test_force_bound_cutoff_compare(kernels, diff_cutoff):
     env1 = env1[0][0]
     env2 = env2[0][0]
 
-    reference = kernel(env1, env2, d1, d2, *args, quadratic_cutoff_bound)
-    result = kernel(env1, env2, d1, d2, *args)
-    assert(isclose(reference, result, rtol=tol))
+    reference = kernel(env1, env2, *args, quadratic_cutoff_bound)
+    result = kernel(env1, env2, *args)
+    assert(isclose(reference, result, rtol=tol).all())
 
-    reference = kg(env1, env2, d1, d2, *args, quadratic_cutoff_bound)
-    result = kg(env1, env2, d1, d2, *args)
-    assert(isclose(reference[0], result[0], rtol=tol))
+    reference = kg(env1, env2, *args, quadratic_cutoff_bound)
+    result = kg(env1, env2, *args)
+    assert(isclose(reference[0], result[0], rtol=tol).all())
     assert(isclose(reference[1], result[1], rtol=tol).all())
 
     reference = en_kernel(env1, env2, *args, quadratic_cutoff_bound)
     result = en_kernel(env1, env2, *args)
-    assert(isclose(reference, result, rtol=tol))
+    assert(isclose(reference, result, rtol=tol).all())
 
     reference = force_en_kernel(
-        env1, env2, d1, *args, quadratic_cutoff_bound)
-    result = force_en_kernel(env1, env2, d1, *args)
-    assert(isclose(reference, result, rtol=tol))
+        env1, env2, *args, quadratic_cutoff_bound)
+    result = force_en_kernel(env1, env2, *args)
+    assert(isclose(reference, result, rtol=tol).all())
 
 
 @pytest.mark.parametrize('kernels', [['twobody', 'threebody']])
 @pytest.mark.parametrize('diff_cutoff', multi_cut)
-def test_constraint(kernels, diff_cutoff):
+@pytest.mark.parametrize('d1, d2', [[1,1], [1, 2]])
+def test_constraint(kernels, diff_cutoff, d1, d2):
     """Check that the analytical force/en kernel matches finite difference of
     energy kernel."""
 
     if ('manybody' in kernels):
         return
 
-    d1 = 1
-    d2 = 2
     cell = 1e7 * np.eye(3)
     delta = 1e-8
 
@@ -259,7 +250,8 @@ def test_constraint(kernels, diff_cutoff):
         calc2 = en3_kernel(env1[0][0], env2[0][0], *args0)
         kern_finite_diff += 9*(calc1 - calc2) / 3.0 / delta
 
-    kern_analytical = force_en_kernel(env1[0][0], env2[0][0], d1, *args0)
+    kern_analytical = force_en_kernel(env1[0][0], env2[0][0], *args0)
+    kern_analytical = kern_analytical[d1-1, d2-1]
 
     tol = 1e-4
     print(kern_finite_diff, kern_analytical)
@@ -268,15 +260,15 @@ def test_constraint(kernels, diff_cutoff):
 
 @pytest.mark.parametrize('kernels', list_to_test)
 @pytest.mark.parametrize('diff_cutoff', multi_cut)
-def test_force_en(kernels, diff_cutoff):
+@pytest.mark.parametrize('d1', [1, 2])
+def test_force_en(kernels, diff_cutoff, d1):
     """Check that the analytical force/en kernel matches finite difference of
     energy kernel."""
 
     delta = 1e-5
-    d1 = 1
-    d2 = 2
     cell = 1e7 * np.eye(3)
     np.random.seed(0)
+    d2 = 1
 
     cutoffs, hyps, hm = generate_diff_hm(kernels, diff_cutoff)
     args = from_mask_to_args(hyps, cutoffs, hm)
@@ -286,7 +278,8 @@ def test_force_en(kernels, diff_cutoff):
 
     _, __, en_kernel, force_en_kernel = str_to_kernel_set(kernels, "mc", hm)
 
-    kern_analytical = force_en_kernel(env1[0][0], env2[0][0], d1, *args)
+    kern_analytical = force_en_kernel(env1[0][0], env2[0][0], *args)
+    kern_analytical = kernel_analytical[d1-1]
 
     kern_finite_diff = 0
     if ('manybody' in kernels):
@@ -326,12 +319,11 @@ def test_force_en(kernels, diff_cutoff):
 
 @pytest.mark.parametrize('kernels', list_to_test)
 @pytest.mark.parametrize('diff_cutoff', multi_cut)
-def test_force(kernels, diff_cutoff):
+@pytest.mark.parametrize('d1, d2', [[1,1], [1, 2]])
+def test_force(kernels, diff_cutoff, d1, d2):
     """Check that the analytical force kernel matches finite difference of
     energy kernel."""
 
-    d1 = 1
-    d2 = 2
     tol = 1e-3
     cell = 1e7 * np.eye(3)
     delta = 1e-4
@@ -396,7 +388,8 @@ def test_force(kernels, diff_cutoff):
         kern_finite_diff += 9 * (calc1 + calc2 - calc3 - calc4) / (4*delta**2)
 
     args = from_mask_to_args(hyps, cutoffs, hm)
-    kern_analytical = kernel(env1[0][0], env2[0][0], d1, d2, *args)
+    kern_analytical = kernel(env1[0][0], env2[0][0], *args)
+    kern_analytical = kernel_analytical[d1-1, d2-1]
 
     assert(isclose(kern_finite_diff, kern_analytical, rtol=tol))
 
@@ -404,11 +397,10 @@ def test_force(kernels, diff_cutoff):
 @pytest.mark.parametrize('kernels', list_to_test)
 @pytest.mark.parametrize('diff_cutoff', multi_cut)
 @pytest.mark.parametrize('constraint', [True, False])
-def test_hyps_grad(kernels, diff_cutoff, constraint):
+@pytest.mark.parametrize('d1, d2', [[1,1], [1, 2]])
+def test_hyps_grad(kernels, diff_cutoff, constraint, d1, d2):
 
     delta = 1e-8
-    d1 = 1
-    d2 = 2
     tol = 1e-4
 
     np.random.seed(10)
@@ -422,9 +414,9 @@ def test_hyps_grad(kernels, diff_cutoff, constraint):
     env1 = env1[0][0]
     env2 = env2[0][0]
 
-    k, grad = kernel_grad(env1, env2, d1, d2, *args)
+    k, grad = kernel_grad(env1, env2, *args)
 
-    original = kernel(env1, env2, d1, d2, *args)
+    original = kernel(env1, env2, *args)
 
     nhyps = len(hyps)
     if hm['train_noise']:
@@ -440,13 +432,13 @@ def test_hyps_grad(kernels, diff_cutoff, constraint):
             hm['original_hyps'][newid] += delta
         newargs = from_mask_to_args(newhyps, cutoffs, hm)
 
-        hgrad = (kernel(env1, env2, d1, d2, *newargs) - original)/delta
+        hgrad = (kernel(env1, env2, *newargs) - original)/delta
         if 'map' in hm:
             print(i, "hgrad", hgrad, grad[hm['map'][i]])
-            assert(isclose(grad[hm['map'][i]], hgrad, rtol=tol))
+            assert(isclose(grad[hm['map'][i]][d1-1, d2-1], hgrad, rtol=tol))
         else:
             print(i, "hgrad", hgrad, grad[i])
-            assert(isclose(grad[i], hgrad, rtol=tol))
+            assert(isclose(grad[i][d1-1, d2-1], hgrad, rtol=tol))
 
 
 def generate_same_hm(kernels, multi_cutoff=False):

--- a/tests/test_mgp.py
+++ b/tests/test_mgp.py
@@ -212,7 +212,7 @@ def compare_triplet(mgp_model, gp_model, atom_env):
         for l in range(lengths.shape[0]):
             r1, r2, r12 = lengths[l, :]
             grid_env = get_triplet_env(r1, r2, r12, grid_env)
-            gp_pred = np.array([gp_model.predict(grid_env, d+1) for d in range(3)]).T
+            gp_pred = gp_model.predict(grid_env)
             gp_en, _ = gp_model.predict_local_energy_and_var(grid_env)
             gp_f.append(gp_pred[0])
             gp_e.append(gp_en)
@@ -288,7 +288,7 @@ def test_predict(all_gp, all_mgp, bodies, multihyps, map_force):
     assert Parameters.compare_dict(gp_model.hyps_mask, mgp_model.maps[kernel_name].hyps_mask)
 
     gp_pred_en, gp_pred_envar = gp_model.predict_local_energy_and_var(test_envi)
-    gp_pred = np.array([gp_model.predict(test_envi, d+1) for d in range(3)]).T
+    gp_pred = gp_model.predict(test_envi)
     mgp_pred = mgp_model.predict(test_envi, mean_only=True)
 
 


### PR DESCRIPTION
- compute 3x3 kernel for force-force and 3x1 for force-energy kernels.
- 2-4 times acceleration after merging the d1 and d2 looping into the njit function

following modules and interfaces are affected 
- gp_algebra: The way that matrices and vectors stack are changed.
- predict:  x,y,z are removed from the input arguments
- gp, mgp, ase calculator: x,y,z are removed from the input arguments

Existing problem:

2 body mgp would be slow down by 1.5-2 times because it computes 3xNxngrid vector instead of Nxngrid vector. But this would be solved once we have the two body mapping specific kernels.