### PR TITLE
[WIP] GPFA Modularization

### DIFF
--- a/flare/gp.py
+++ b/flare/gp.py
@@ -1014,7 +1014,8 @@ class GaussianProcess:
         """
         Return size of training data.
         """
-        return len(self.training_data)
+        return len(self.training_data) + len([len(struc) for struc in
+                                              self.training_structures])
 
     @property
     def par(self):

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -1009,13 +1009,12 @@ class GaussianProcess:
         data['envs_by_species'] = dict(Counter(present_species))
 
         return data
-    @property
+
     def __len__(self):
         """
-        Make neighbor Tuple-like to retain backwards compatibility.
+        Return size of training data.
         """
         return len(self.training_data)
-
 
     @property
     def par(self):

--- a/flare/gp_from_aimd.py
+++ b/flare/gp_from_aimd.py
@@ -424,6 +424,7 @@ class TrajectoryTrainer:
 
             if i < train_frame and not self.mgp and len(self.gp) <= \
                     self.max_model_size:
+
                 # Noise hyperparameter & relative std tolerance is not for mgp.
                 if self.mgp:
                     noise = 0

--- a/tests/test_gp_from_aimd.py
+++ b/tests/test_gp_from_aimd.py
@@ -53,19 +53,22 @@ def test_instantiation_of_trajectory_trainer(fake_gp):
     assert isinstance(a, TrajectoryTrainer)
 
     fake_gp.parallel = True
-    _ = TrajectoryTrainer([], fake_gp, n_cpus=2, calculate_energy=True)
+    _ = TrajectoryTrainer(active_frames=[], gp= fake_gp, n_cpus=2,
+                          calculate_energy=True)
     _ = TrajectoryTrainer([], fake_gp, n_cpus=2, calculate_energy=False)
 
     fake_gp.parallel = False
-    _ = TrajectoryTrainer([], fake_gp, n_cpus=2, calculate_energy=True)
-    _ = TrajectoryTrainer([], fake_gp, n_cpus=2, calculate_energy=False)
+    _ = TrajectoryTrainer(active_frames=[], gp=fake_gp, n_cpus=2,
+                          calculate_energy=True)
+    _ = TrajectoryTrainer(active_frames=[], gp=fake_gp, n_cpus=2,
+                          calculate_energy=False)
 
 
 def test_load_trained_gp_and_run(methanol_gp):
     with open('./test_files/methanol_frames.json', 'r') as f:
         frames = [Structure.from_dict(loads(s)) for s in f.readlines()]
 
-    tt = TrajectoryTrainer(frames,
+    tt = TrajectoryTrainer(active_frames=frames,
                            gp=methanol_gp,
                            active_rel_var_tol=0,
                            active_abs_var_tol=0,
@@ -89,7 +92,7 @@ def test_load_one_frame_and_run():
     with open('./test_files/methanol_frames.json', 'r') as f:
         frames = [Structure.from_dict(loads(s)) for s in f.readlines()]
 
-    tt = TrajectoryTrainer(frames,
+    tt = TrajectoryTrainer(active_frames=frames,
                            gp=the_gp, shuffle_active_frames=True,
                            print_as_xyz=True,
                            active_rel_var_tol=0,
@@ -120,7 +123,7 @@ def test_seed_and_run():
         forces = [np.array(d['forces']) for d in data_dicts]
         seeds = list(zip(envs, forces))
 
-    tt = TrajectoryTrainer(frames,
+    tt = TrajectoryTrainer(active_frames=frames,
                            gp=the_gp, shuffle_active_frames=True,
                            active_rel_var_tol=0,
                            active_abs_var_tol=0,
@@ -167,7 +170,7 @@ def test_pred_on_elements():
         seeds = list(zip(envs, forces))
 
     all_frames = deepcopy(frames)
-    tt = TrajectoryTrainer(frames,
+    tt = TrajectoryTrainer(active_frames=frames,
                            gp=the_gp, shuffle_active_frames=False,
                            active_rel_var_tol=0,
                            active_abs_var_tol=0,
@@ -182,7 +185,7 @@ def test_pred_on_elements():
                            written_model_format='json',
                            checkpoint_interval_atom=50,
                            passive_atoms_per_element={'H': 1},
-                           predict_atoms_per_element={'H': 0,'C': 1,'O': 0})
+                           predict_atoms_per_element={'H': 0, 'C': 1, 'O': 0})
     # Set to predict only on Carbon after training on H to ensure errors are
     #  high and that they get added to the gp
     tt.run()
@@ -224,8 +227,9 @@ def test_mgp_gpfa(all_mgp, all_gp):
     grid_params['threebody'] = grid_params_3b
     unique_species = gp_model.training_statistics['species']
 
-    mgp_model = MappedGaussianProcess(grid_params=grid_params, unique_species=unique_species, n_cpus=1,
-                map_force=False)
+    mgp_model = MappedGaussianProcess(grid_params=grid_params,
+                                      unique_species=unique_species, n_cpus=1,
+                                      map_force=False)
 
     mgp_model.build_map(gp_model)
 
@@ -237,7 +241,8 @@ def test_mgp_gpfa(all_mgp, all_gp):
 
     frames = [struc]
 
-    tt = TrajectoryTrainer(frames, mgp_model, active_rel_var_tol=0,
+    tt = TrajectoryTrainer(active_frames=frames, gp=mgp_model,
+                           active_rel_var_tol=0,
                            active_abs_var_tol=0, active_abs_error_tol=0)
     assert tt.mgp is True
     tt.run()

--- a/tests/test_gp_from_aimd.py
+++ b/tests/test_gp_from_aimd.py
@@ -48,7 +48,7 @@ def fake_gp():
 
 
 def test_instantiation_of_trajectory_trainer(fake_gp):
-    a = TrajectoryTrainer(frames=[], gp=fake_gp)
+    a = TrajectoryTrainer(active_frames=[], gp=fake_gp)
 
     assert isinstance(a, TrajectoryTrainer)
 
@@ -67,9 +67,9 @@ def test_load_trained_gp_and_run(methanol_gp):
 
     tt = TrajectoryTrainer(frames,
                            gp=methanol_gp,
-                           rel_std_tolerance=0,
-                           abs_std_tolerance=0,
-                           skip=15, train_checkpoint_interval=10)
+                           active_rel_var_tol=0,
+                           active_abs_var_tol=0,
+                           active_skip=15, checkpoint_interval_train=10)
 
     tt.run()
     for f in glob(f"gp_from_aimd*"):
@@ -90,11 +90,11 @@ def test_load_one_frame_and_run():
         frames = [Structure.from_dict(loads(s)) for s in f.readlines()]
 
     tt = TrajectoryTrainer(frames,
-                           gp=the_gp, shuffle_frames=True,
+                           gp=the_gp, shuffle_active_frames=True,
                            print_as_xyz=True,
-                           rel_std_tolerance=0,
-                           abs_std_tolerance=0,
-                           skip=15)
+                           active_rel_var_tol=0,
+                           active_abs_var_tol=0,
+                           active_skip=15)
 
     tt.run()
     for f in glob(f"gp_from_aimd*"):
@@ -121,17 +121,17 @@ def test_seed_and_run():
         seeds = list(zip(envs, forces))
 
     tt = TrajectoryTrainer(frames,
-                           gp=the_gp, shuffle_frames=True,
-                           rel_std_tolerance=0,
-                           abs_std_tolerance=0,
-                           skip=10,
-                           pre_train_seed_envs=seeds,
-                           pre_train_seed_frames=[frames[-1]],
+                           gp=the_gp, shuffle_active_frames=True,
+                           active_rel_var_tol=0,
+                           active_abs_var_tol=0,
+                           active_skip=10,
+                           passive_envs=seeds,
+                           passive_frames=[frames[-1]],
                            max_atoms_from_frame=4,
                            output_name='meth_test',
-                           model_format='pickle',
-                           train_checkpoint_interval=1,
-                           pre_train_atoms_per_element={'H': 1})
+                           written_model_format='pickle',
+                           checkpoint_interval_train=1,
+                           passive_atoms_per_element={'H': 1})
 
     tt.run()
 
@@ -168,20 +168,20 @@ def test_pred_on_elements():
 
     all_frames = deepcopy(frames)
     tt = TrajectoryTrainer(frames,
-                           gp=the_gp, shuffle_frames=False,
-                           rel_std_tolerance=0,
-                           abs_std_tolerance=0,
-                           abs_force_tolerance=.001,
-                           skip=5,
-                           min_atoms_per_train=100,
-                           pre_train_seed_envs=seeds,
-                           pre_train_seed_frames=[frames[-1]],
+                           gp=the_gp, shuffle_active_frames=False,
+                           active_rel_var_tol=0,
+                           active_abs_var_tol=0,
+                           active_abs_error_tol=.001,
+                           active_skip=5,
+                           min_atoms_added_per_train=100,
+                           passive_envs=seeds,
+                           passive_frames=[frames[-1]],
                            max_atoms_from_frame=4,
                            output_name='meth_test',
                            print_as_xyz=True,
-                           model_format='json',
-                           atom_checkpoint_interval=50,
-                           pre_train_atoms_per_element={'H': 1},
+                           written_model_format='json',
+                           checkpoint_interval_atom=50,
+                           passive_atoms_per_element={'H': 1},
                            predict_atoms_per_element={'H': 0,'C': 1,'O': 0})
     # Set to predict only on Carbon after training on H to ensure errors are
     #  high and that they get added to the gp
@@ -237,8 +237,8 @@ def test_mgp_gpfa(all_mgp, all_gp):
 
     frames = [struc]
 
-    tt = TrajectoryTrainer(frames, mgp_model, rel_std_tolerance=0,
-                           abs_std_tolerance=0, abs_force_tolerance=0)
+    tt = TrajectoryTrainer(frames, mgp_model, active_rel_var_tol=0,
+                           active_abs_var_tol=0, active_abs_error_tol=0)
     assert tt.mgp is True
     tt.run()
 


### PR DESCRIPTION
In response to user requests and feedback, I have re-written the arguments to `TrajectoryTrainer` to make their meaning more clear. I have also added an extra argument and tiny quality of life tweaks (such as a `__len__` method for GPs).

Given the way the curse of knowledge works (forgetting what it's like to not know), I particularly welcome insight from other users-- particularly those who do not use GPFA much -- to weigh in on if the new arguments are intuitively named and their function is clear.

**Changes**

- **Scripts will break. GPs  are now the first argument to TrajectoryTrainer, supplanting active learning frames as TrajectoryTrainer is meant to facilitate both passive and active learning equally well**.

-  Almost all arguments have been re-named and re-ordered in the `TrajectoryTrainer` module. They are now divided into `passive` and `active` learning arguments to refer to what was previously called the "seed" and "train" parts of the run, confusingly, given that "training" refers to hyperparameter optimization.
 
- `GaussianProcess` now has a `__len__` method which returns the number of atomic environments present.

- New design pattern for GPFA unit tests that would allow the tests to be ran from other directories; we could consider adding this pattern to other files.
