### PR TITLE
Steven/bugfix/parameterhelper

### DIFF
--- a/flare/gp.py
+++ b/flare/gp.py
@@ -1014,7 +1014,8 @@ class GaussianProcess:
         """
         Return size of training data.
         """
-        return len(self.training_data)
+        return len(self.training_data) + len([len(struc) for struc in
+                                              self.training_structures])
 
     @property
     def par(self):

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -1026,9 +1026,9 @@ class GaussianProcess:
         return self.parallel
 
     def __del__(self):
-        if (self is None):
+        if self is None:
             return
-        if (self.name in _global_training_labels):
+        if self.name in _global_training_labels:
             _global_training_labels.pop(self.name, None)
             _global_training_data.pop(self.name, None)
 

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -1009,13 +1009,12 @@ class GaussianProcess:
         data['envs_by_species'] = dict(Counter(present_species))
 
         return data
-    @property
+
     def __len__(self):
         """
-        Make neighbor Tuple-like to retain backwards compatibility.
+        Return size of training data.
         """
         return len(self.training_data)
-
 
     @property
     def par(self):

--- a/flare/gp_from_aimd.py
+++ b/flare/gp_from_aimd.py
@@ -424,6 +424,7 @@ class TrajectoryTrainer:
 
             if i < train_frame and not self.mgp and len(self.gp) <= \
                     self.max_model_size:
+
                 # Noise hyperparameter & relative std tolerance is not for mgp.
                 if self.mgp:
                     noise = 0

--- a/flare/gp_from_aimd.py
+++ b/flare/gp_from_aimd.py
@@ -59,39 +59,39 @@ from flare.parameters import Parameters
 
 class TrajectoryTrainer:
 
-    def __init__(self, gp: Union[GaussianProcess, MappedGaussianProcess],
+    def __init__(self,
+                 gp: Union[GaussianProcess, MappedGaussianProcess],
+                 # Data to be used to augment and/or validate the GP
                  active_frames: List[Structure] = None,
                  passive_frames: List[Structure] = None,
                  passive_envs: List[Tuple[AtomicEnvironment,
                                           'np.array']] = None,
-
+                 # Active learning arguments
                  active_rel_var_tol: float = 4,
                  active_abs_var_tol: float = 1,
                  active_abs_error_tol: float = 0,
                  active_error_tol_cutoff: float = inf,
                  active_max_trains: int = np.inf,
                  active_max_element_from_frame: dict = None,
-
-                 checkpoint_interval_train: int = 1,
-                 checkpoint_interval_atom: int = 100,
-
                  predict_atoms_per_element: dict = None,
-
-                 max_atoms_from_frame: int = np.inf,
-                 min_atoms_added_per_train: int = 1,
-                 max_model_size: int = np.inf,
-
+                 active_skip: int = 1,
+                 active_frame_shuffle: bool = False,
+                 validate_ratio: float = 0.0,
+                 # Passive learning arguments
                  passive_on_active_skips: int = -1,
                  passive_train_max_iter: int = 50,
                  passive_atoms_per_element: dict = None,
-
-                 active_skip: int = 1,
-                 shuffle_active_frames: bool = False,
-
+                 # Model checkpoint writing arguments
+                 checkpoint_interval_train: int = 1,
+                 checkpoint_interval_atom: int = 100,
+                 # Args to control rate of GP growth
+                 max_atoms_from_frame: int = np.inf,
+                 min_atoms_added_per_train: int = 1,
+                 max_model_size: int = np.inf,
+                 # Misc settings
                  n_cpus: int = 1,
-                 validate_ratio: float = 0.0,
                  calculate_energy: bool = False,
-
+                 # Output args
                  output_name: str = 'gp_from_aimd',
                  print_as_xyz: bool = False,
                  verbose: str = "INFO",
@@ -136,7 +136,7 @@ class TrajectoryTrainer:
         :param active_max_trains: Stop training GP after this many calls to train
         :param n_cpus: Number of CPUs to parallelize over for parallelization
                 over atoms
-        :param shuffle_active_frames: Randomize order of frames for better training
+        :param active_frame_shuffle: Randomize order of frames for better training
         :param verbose: same as logging level, "WARNING", "INFO", "DEBUG"
         :param passive_on_active_skips: Train model on every n frames before running
         :param passive_frames: Frames to train on before running
@@ -161,7 +161,7 @@ class TrajectoryTrainer:
 
         # Set up parameters
         self.frames = active_frames
-        if shuffle_active_frames:
+        if active_frame_shuffle:
             np.random.shuffle(active_frames)
 
         # GP Training and Execution parameters

--- a/flare/gp_from_aimd.py
+++ b/flare/gp_from_aimd.py
@@ -239,7 +239,8 @@ class TrajectoryTrainer:
         self.train_count = 0
         self.start_time = time.time()
 
-    def passive_run(self):
+    def passive_run(self, frames: List[Structure],
+                          envs: List[Tuple[AtomicEnvironment,'np.ndarray']]):
         """
         Various tasks to set up the AIMD training before commencing
         the run through the AIMD trajectory.
@@ -341,7 +342,8 @@ class TrajectoryTrainer:
             self.gp.write_model(f'{self.output_name}_prerun',
                                 self.model_format)
 
-    def run(self, perform_passive_run: bool = True):
+    def active_run(self, perform_passive_run: bool = True,
+                            passive_kwargs: dict = {}):
         """
         Loop through frames and record the error between
         the GP predictions and the ground-truth forces. Train the GP and update
@@ -356,7 +358,7 @@ class TrajectoryTrainer:
         logger.debug("Commencing run with pre-run...")
         if not self.mgp:
             if perform_passive_run:
-                self.passive_run()
+                self.passive_run(**passive_kwargs)
             elif len(self.gp) == 0:
                 logger.warning("You are attempting to train a model with no "
                               "data in your Gausian Process; it is "
@@ -590,18 +592,6 @@ class TrajectoryTrainer:
                                self.gp.likelihood_gradient,
                                hyps_mask=self.gp.hyps_mask)
         self.train_count += 1
-
-    @staticmethod
-    def backward_arguments(kwargs:dict,
-                           tt_dict:dict):
-
-        deprecated_arguments = {'rel_std_tolerance': 'active_rel_var_tol',
-                                'abs_std_tolerance': 'active_abs_var_tol',
-                                'abs_force_tolerance':'active_abs_error_tol',
-                                'max_force_error':'active_error_tol_cutoff',
-                                'parallel':None,
-                                'skip':'active_skip',
-                                'pre_train_max_iter': 'passive_train_max_iter'}
 
 
 

--- a/flare/gp_from_aimd.py
+++ b/flare/gp_from_aimd.py
@@ -591,6 +591,19 @@ class TrajectoryTrainer:
                                hyps_mask=self.gp.hyps_mask)
         self.train_count += 1
 
+    @staticmethod
+    def backward_arguments(kwargs:dict,
+                           tt_dict:dict):
+
+        deprecated_arguments = {'rel_std_tolerance': 'active_rel_var_tol',
+                                'abs_std_tolerance': 'active_abs_var_tol',
+                                'abs_force_tolerance':'active_abs_error_tol',
+                                'max_force_error':'active_error_tol_cutoff',
+                                'parallel':None,
+                                'skip':'active_skip',
+                                'pre_train_max_iter': 'passive_train_max_iter'}
+
+
 
 def parse_trajectory_trainer_output(file: str, return_gp_data: bool = False) \
         -> Union[List[dict], Tuple[List[dict], dict]]:

--- a/flare/parameters.py
+++ b/flare/parameters.py
@@ -152,7 +152,7 @@ class Parameters():
 
         assert isinstance(param_dict, dict)
         assert isinstance(cutoffs, dict)
-        assert isinstance(kernels, (list))
+        assert isinstance(kernels, list)
 
         param_dict['cutoffs'] = cutoffs
 
@@ -179,7 +179,7 @@ class Parameters():
                 assert n > 0, f"{kernel} has n 0"
 
                 # check all corresponding keys exist
-                assert kernel in cutoffs
+                assert kernel in cutoffs.keys()
                 assert kernel+"_start" in param_dict
 
                 # check the partition of hyperparameters are not used

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -97,6 +97,31 @@ def validation_env() -> AtomicEnvironment:
 #                   test GP methods
 # ------------------------------------------------------
 
+
+class TestInitialization():
+
+    def test_simple_initialization(self):
+        GaussianProcess()
+
+    def test_permuted_initalization(self):
+        """
+        Run through some common permutations of input sequences
+        to ensure that the GP correctly initializes.
+        """
+        for kernel_list in [['2'], ['3'], ['2', '3'],
+                            ['3', '2', 'mb']]:
+            GaussianProcess(kernels=kernel_list)
+        full_kernel_list = ['2', '3']
+        for component in ['sc', 'mc']:
+            GaussianProcess(kernels=full_kernel_list,
+                            component=component)
+        for parallel in [True, False]:
+            GaussianProcess(parallel=parallel)
+        for per_atom_par in [True, False]:
+            GaussianProcess(per_atom_par=per_atom_par)
+
+
+
 class TestDataUpdating():
 
     @pytest.mark.parametrize('multihyps', multihyps_list)

--- a/tests/test_gp_from_aimd.py
+++ b/tests/test_gp_from_aimd.py
@@ -93,7 +93,7 @@ def test_load_one_frame_and_run():
         frames = [Structure.from_dict(loads(s)) for s in f.readlines()]
 
     tt = TrajectoryTrainer(active_frames=frames,
-                           gp=the_gp, shuffle_active_frames=True,
+                           gp=the_gp, active_frame_shuffle=True,
                            print_as_xyz=True,
                            active_rel_var_tol=0,
                            active_abs_var_tol=0,
@@ -124,7 +124,7 @@ def test_seed_and_run():
         seeds = list(zip(envs, forces))
 
     tt = TrajectoryTrainer(active_frames=frames,
-                           gp=the_gp, shuffle_active_frames=True,
+                           gp=the_gp, active_frame_shuffle=True,
                            active_rel_var_tol=0,
                            active_abs_var_tol=0,
                            active_skip=10,
@@ -171,7 +171,7 @@ def test_pred_on_elements():
 
     all_frames = deepcopy(frames)
     tt = TrajectoryTrainer(active_frames=frames,
-                           gp=the_gp, shuffle_active_frames=False,
+                           gp=the_gp, active_frame_shuffle=False,
                            active_rel_var_tol=0,
                            active_abs_var_tol=0,
                            active_abs_error_tol=.001,

--- a/tests/test_gp_from_aimd.py
+++ b/tests/test_gp_from_aimd.py
@@ -53,19 +53,22 @@ def test_instantiation_of_trajectory_trainer(fake_gp):
     assert isinstance(a, TrajectoryTrainer)
 
     fake_gp.parallel = True
-    _ = TrajectoryTrainer([], fake_gp, n_cpus=2, calculate_energy=True)
+    _ = TrajectoryTrainer(active_frames=[], gp= fake_gp, n_cpus=2,
+                          calculate_energy=True)
     _ = TrajectoryTrainer([], fake_gp, n_cpus=2, calculate_energy=False)
 
     fake_gp.parallel = False
-    _ = TrajectoryTrainer([], fake_gp, n_cpus=2, calculate_energy=True)
-    _ = TrajectoryTrainer([], fake_gp, n_cpus=2, calculate_energy=False)
+    _ = TrajectoryTrainer(active_frames=[], gp=fake_gp, n_cpus=2,
+                          calculate_energy=True)
+    _ = TrajectoryTrainer(active_frames=[], gp=fake_gp, n_cpus=2,
+                          calculate_energy=False)
 
 
 def test_load_trained_gp_and_run(methanol_gp):
     with open('./test_files/methanol_frames.json', 'r') as f:
         frames = [Structure.from_dict(loads(s)) for s in f.readlines()]
 
-    tt = TrajectoryTrainer(frames,
+    tt = TrajectoryTrainer(active_frames=frames,
                            gp=methanol_gp,
                            active_rel_var_tol=0,
                            active_abs_var_tol=0,
@@ -89,7 +92,7 @@ def test_load_one_frame_and_run():
     with open('./test_files/methanol_frames.json', 'r') as f:
         frames = [Structure.from_dict(loads(s)) for s in f.readlines()]
 
-    tt = TrajectoryTrainer(frames,
+    tt = TrajectoryTrainer(active_frames=frames,
                            gp=the_gp, shuffle_active_frames=True,
                            print_as_xyz=True,
                            active_rel_var_tol=0,
@@ -120,7 +123,7 @@ def test_seed_and_run():
         forces = [np.array(d['forces']) for d in data_dicts]
         seeds = list(zip(envs, forces))
 
-    tt = TrajectoryTrainer(frames,
+    tt = TrajectoryTrainer(active_frames=frames,
                            gp=the_gp, shuffle_active_frames=True,
                            active_rel_var_tol=0,
                            active_abs_var_tol=0,
@@ -167,7 +170,7 @@ def test_pred_on_elements():
         seeds = list(zip(envs, forces))
 
     all_frames = deepcopy(frames)
-    tt = TrajectoryTrainer(frames,
+    tt = TrajectoryTrainer(active_frames=frames,
                            gp=the_gp, shuffle_active_frames=False,
                            active_rel_var_tol=0,
                            active_abs_var_tol=0,
@@ -182,7 +185,7 @@ def test_pred_on_elements():
                            written_model_format='json',
                            checkpoint_interval_atom=50,
                            passive_atoms_per_element={'H': 1},
-                           predict_atoms_per_element={'H': 0,'C': 1,'O': 0})
+                           predict_atoms_per_element={'H': 0, 'C': 1, 'O': 0})
     # Set to predict only on Carbon after training on H to ensure errors are
     #  high and that they get added to the gp
     tt.run()
@@ -224,8 +227,9 @@ def test_mgp_gpfa(all_mgp, all_gp):
     grid_params['threebody'] = grid_params_3b
     unique_species = gp_model.training_statistics['species']
 
-    mgp_model = MappedGaussianProcess(grid_params=grid_params, unique_species=unique_species, n_cpus=1,
-                map_force=False)
+    mgp_model = MappedGaussianProcess(grid_params=grid_params,
+                                      unique_species=unique_species, n_cpus=1,
+                                      map_force=False)
 
     mgp_model.build_map(gp_model)
 
@@ -237,7 +241,8 @@ def test_mgp_gpfa(all_mgp, all_gp):
 
     frames = [struc]
 
-    tt = TrajectoryTrainer(frames, mgp_model, active_rel_var_tol=0,
+    tt = TrajectoryTrainer(active_frames=frames, gp=mgp_model,
+                           active_rel_var_tol=0,
                            active_abs_var_tol=0, active_abs_error_tol=0)
     assert tt.mgp is True
     tt.run()

--- a/tests/test_gp_from_aimd.py
+++ b/tests/test_gp_from_aimd.py
@@ -48,7 +48,7 @@ def fake_gp():
 
 
 def test_instantiation_of_trajectory_trainer(fake_gp):
-    a = TrajectoryTrainer(frames=[], gp=fake_gp)
+    a = TrajectoryTrainer(active_frames=[], gp=fake_gp)
 
     assert isinstance(a, TrajectoryTrainer)
 
@@ -67,9 +67,9 @@ def test_load_trained_gp_and_run(methanol_gp):
 
     tt = TrajectoryTrainer(frames,
                            gp=methanol_gp,
-                           rel_std_tolerance=0,
-                           abs_std_tolerance=0,
-                           skip=15, train_checkpoint_interval=10)
+                           active_rel_var_tol=0,
+                           active_abs_var_tol=0,
+                           active_skip=15, checkpoint_interval_train=10)
 
     tt.run()
     for f in glob(f"gp_from_aimd*"):
@@ -90,11 +90,11 @@ def test_load_one_frame_and_run():
         frames = [Structure.from_dict(loads(s)) for s in f.readlines()]
 
     tt = TrajectoryTrainer(frames,
-                           gp=the_gp, shuffle_frames=True,
+                           gp=the_gp, shuffle_active_frames=True,
                            print_as_xyz=True,
-                           rel_std_tolerance=0,
-                           abs_std_tolerance=0,
-                           skip=15)
+                           active_rel_var_tol=0,
+                           active_abs_var_tol=0,
+                           active_skip=15)
 
     tt.run()
     for f in glob(f"gp_from_aimd*"):
@@ -121,17 +121,17 @@ def test_seed_and_run():
         seeds = list(zip(envs, forces))
 
     tt = TrajectoryTrainer(frames,
-                           gp=the_gp, shuffle_frames=True,
-                           rel_std_tolerance=0,
-                           abs_std_tolerance=0,
-                           skip=10,
-                           pre_train_seed_envs=seeds,
-                           pre_train_seed_frames=[frames[-1]],
+                           gp=the_gp, shuffle_active_frames=True,
+                           active_rel_var_tol=0,
+                           active_abs_var_tol=0,
+                           active_skip=10,
+                           passive_envs=seeds,
+                           passive_frames=[frames[-1]],
                            max_atoms_from_frame=4,
                            output_name='meth_test',
-                           model_format='pickle',
-                           train_checkpoint_interval=1,
-                           pre_train_atoms_per_element={'H': 1})
+                           written_model_format='pickle',
+                           checkpoint_interval_train=1,
+                           passive_atoms_per_element={'H': 1})
 
     tt.run()
 
@@ -168,20 +168,20 @@ def test_pred_on_elements():
 
     all_frames = deepcopy(frames)
     tt = TrajectoryTrainer(frames,
-                           gp=the_gp, shuffle_frames=False,
-                           rel_std_tolerance=0,
-                           abs_std_tolerance=0,
-                           abs_force_tolerance=.001,
-                           skip=5,
-                           min_atoms_per_train=100,
-                           pre_train_seed_envs=seeds,
-                           pre_train_seed_frames=[frames[-1]],
+                           gp=the_gp, shuffle_active_frames=False,
+                           active_rel_var_tol=0,
+                           active_abs_var_tol=0,
+                           active_abs_error_tol=.001,
+                           active_skip=5,
+                           min_atoms_added_per_train=100,
+                           passive_envs=seeds,
+                           passive_frames=[frames[-1]],
                            max_atoms_from_frame=4,
                            output_name='meth_test',
                            print_as_xyz=True,
-                           model_format='json',
-                           atom_checkpoint_interval=50,
-                           pre_train_atoms_per_element={'H': 1},
+                           written_model_format='json',
+                           checkpoint_interval_atom=50,
+                           passive_atoms_per_element={'H': 1},
                            predict_atoms_per_element={'H': 0,'C': 1,'O': 0})
     # Set to predict only on Carbon after training on H to ensure errors are
     #  high and that they get added to the gp
@@ -237,8 +237,8 @@ def test_mgp_gpfa(all_mgp, all_gp):
 
     frames = [struc]
 
-    tt = TrajectoryTrainer(frames, mgp_model, rel_std_tolerance=0,
-                           abs_std_tolerance=0, abs_force_tolerance=0)
+    tt = TrajectoryTrainer(frames, mgp_model, active_rel_var_tol=0,
+                           active_abs_var_tol=0, active_abs_error_tol=0)
     assert tt.mgp is True
     tt.run()
 

--- a/tests/test_gp_from_aimd.py
+++ b/tests/test_gp_from_aimd.py
@@ -78,7 +78,7 @@ def test_load_trained_gp_and_run(methanol_gp):
                            active_abs_var_tol=0,
                            active_skip=15, checkpoint_interval_train=10)
 
-    tt.run()
+    tt.active_run()
     for f in glob(f"gp_from_aimd*"):
         remove(f)
 
@@ -103,7 +103,7 @@ def test_load_one_frame_and_run():
                            active_abs_var_tol=0,
                            active_skip=15)
 
-    tt.run()
+    tt.active_run()
     for f in glob(f"gp_from_aimd*"):
         remove(f)
 
@@ -140,7 +140,7 @@ def test_seed_and_run():
                            checkpoint_interval_train=1,
                            passive_atoms_per_element={'H': 1})
 
-    tt.run()
+    tt.active_run()
 
     with open('meth_test_model.pickle', 'rb') as f:
         new_gp = pickle.load(f)
@@ -192,7 +192,7 @@ def test_pred_on_elements():
                            predict_atoms_per_element={'H': 0, 'C': 1, 'O': 0})
     # Set to predict only on Carbon after training on H to ensure errors are
     #  high and that they get added to the gp
-    tt.run()
+    tt.active_run()
 
     # Ensure forces weren't written directly to structure
     for i in range(len(all_frames)):
@@ -248,7 +248,7 @@ def test_mgp_gpfa():
                            active_rel_var_tol=0,
                            active_abs_var_tol=0, active_abs_error_tol=0)
     assert tt.mgp is True
-    tt.run()
+    tt.active_run()
 
 
 def test_parse_gpfa_output():


### PR DESCRIPTION
When kernels are specified as ['2','3'], etc, to the GP, the cutoffs must be supplied in the exact same way (e.g. 'twobody', 'threebody' will be checked for). 

Now, the kernel string names are 'standardized' as 'twobody', 'threebody', etc. This bug also afflicted GPs instantiated with no argument supplied, so I added a few unit tests to test the initialization of GPs. The GP now, by default, is a 2+3 body model with a 7 A 2 body cutoff and 3.5 A 3-body cutoff. The user is warned appropriately.

@nw13slx review requested only for FYI.