### PR TITLE
Add option for `force_only` & Add `set_atoms`

### DIFF
--- a/flare/ase/calculator.py
+++ b/flare/ase/calculator.py
@@ -97,6 +97,9 @@ class FLARE_Calculator(Calculator):
         self.results["stress"] = total_stress / volume
         self.results["energy"] = np.sum(self.results["local_energies"])
 
+    def set_atoms(self, atoms):
+        self.atoms = atoms
+
     def calculate_gp(self, atoms):
         # Compute energy, forces, and stresses and their uncertainties
         if self.par:

--- a/flare/ase/otf.py
+++ b/flare/ase/otf.py
@@ -247,6 +247,10 @@ class ASE_OTF(OTF):
                 ]
             )
 
+        if self.force_only:
+            dft_energy = None
+            flare_stress = None
+
         # update gp model
         self.gp.update_db(
             self.structure,

--- a/flare/ase/otf.py
+++ b/flare/ase/otf.py
@@ -197,8 +197,8 @@ class ASE_OTF(OTF):
         self.structure.prev_positions = np.copy(self.structure.positions)
 
         # Reset FLARE calculator.
-        self.flare_calc.reset()
         if self.dft_step:
+            self.flare_calc.reset()
             self.atoms.calc = self.flare_calc
 
         # Take MD step.

--- a/flare/otf.py
+++ b/flare/otf.py
@@ -41,6 +41,8 @@ class OTF:
         write_model (int, optional): If 0, write never. If 1, write at
             end of run. If 2, write after each training and end of run.
             If 3, write after each time atoms are added and end of run.
+        force_only (bool, optional): If True, only use forces for training. 
+            Default to False, use forces, energy and stress for training.
 
         std_tolerance_factor (float, optional): Threshold that determines
             when DFT is called. Specifies a multiple of the current noise
@@ -106,6 +108,7 @@ class OTF:
         calculate_energy: bool = False,
         calculate_efs: bool = False,
         write_model: int = 0,
+        force_only: bool = False,
         # otf args
         std_tolerance_factor: float = 1,
         skip: int = 0,
@@ -153,6 +156,7 @@ class OTF:
             self.local_energies = np.zeros(self.noa)
         else:
             self.local_energies = None
+        self.force_only = force_only
 
         # set otf
         self.std_tolerance = std_tolerance_factor
@@ -406,6 +410,10 @@ class OTF:
             dft_frcs (np.ndarray): DFT forces on all atoms in the structure.
         """
         self.output.add_atom_info(train_atoms, self.structure.stds)
+
+        if self.force_only:
+            dft_energy = None
+            dft_stress = None
 
         # update gp model
         self.gp.update_db(


### PR DESCRIPTION
1. Add an option `force_only` in otf, to allow training with only atomic forces. This is from the considerations below:
- **A minor point:** the calculation will be faster
- **In some situations the energies are not very useful:** for example, in the SiC system, for different stackings like 3C & 4H, the bulk energy difference is controversial, i.e. the dE is so small that different pp or different DFT codes sometimes give opposite ordering. At such cases, the inclusion of energy is a bit misleading.
- **One last but could be important:** since we've been using the zero mean, we have to consider the energy shift when including global energy as labels. I think at this moment we should use constant mean instead of zero mean for energy. It seems to me that this constant shift can be treated as a hyperparameter and can be trained, since it appears in the log likelihood, we should probably consider implementing this.

2. The issue #246 is addressed in development 44f8e9e, so now before calling `calculate`, the ase code will detect if the atomic positions are changed since last calculation, even if the `results` dict is not empty. 
- This change of code brought up a small bug for `otf`
- It is fixed by adding a function `set_atoms` in the calculator