### PR TITLE
Add optional calculator input to ase otf constructor

### DIFF
--- a/flare/ase/otf.py
+++ b/flare/ase/otf.py
@@ -210,9 +210,6 @@ class ASE_OTF(OTF):
     def write_gp(self):
         self.flare_calc.write_model(self.flare_name)
 
-    def write_gp(self):
-        self.flare_calc.write_model(self.flare_name)
-
     def rescale_temperature(self, new_pos):
         # call OTF method
         super().rescale_temperature(new_pos)

--- a/flare/ase/otf.py
+++ b/flare/ase/otf.py
@@ -93,6 +93,7 @@ class ASE_OTF(OTF):
     def __init__(
         self,
         atoms,
+        calculator,
         timestep,
         number_of_steps,
         dft_calc,
@@ -103,6 +104,7 @@ class ASE_OTF(OTF):
     ):
 
         self.atoms = FLARE_Atoms.from_ase_atoms(atoms)
+        self.atoms.set_calculator(calculator)
         self.timestep = timestep
         self.md_engine = md_engine
         self.md_kwargs = md_kwargs

--- a/flare/ase/otf.py
+++ b/flare/ase/otf.py
@@ -94,18 +94,19 @@ class ASE_OTF(OTF):
     def __init__(
         self,
         atoms,
-        calculator,
         timestep,
         number_of_steps,
         dft_calc,
         md_engine,
         md_kwargs,
+        calculator=None,
         trajectory=None,
         **otf_kwargs
     ):
 
         self.atoms = FLARE_Atoms.from_ase_atoms(atoms)
-        self.atoms.set_calculator(calculator)
+        if calculator is not None:
+            self.atoms.set_calculator(calculator)
         self.timestep = timestep
         self.md_engine = md_engine
         self.md_kwargs = md_kwargs

--- a/flare/ase/otf.py
+++ b/flare/ase/otf.py
@@ -35,8 +35,9 @@ class ASE_OTF(OTF):
     On-the-fly training module using ASE MD engine, a subclass of OTF.
 
     Args:
-        atoms (ASE Atoms): the ASE Atoms object for the on-the-fly MD run,
-            with calculator set as FLARE_Calculator.
+        atoms (ASE Atoms): the ASE Atoms object for the on-the-fly MD run.
+        calculator: ASE calculator. Must have "get_uncertainties" method
+          implemented.
         timestep: the timestep in MD. Please use ASE units, e.g. if the
             timestep is 1 fs, then set `timestep = 1 * units.fs`
         number_of_steps (int): the total number of steps for MD.


### PR DESCRIPTION
## Summary

* Allows an ase calculator to be given as input to the ase otf constructor. This makes it possible to avoid a deepcopy in the `from_ase_atoms` method, which is needed for non-picklable C++ calculators
* Removes a duplicate method in ase otf