### PR TITLE
Give the option in otf to add all atoms above a specified threshold

### DIFF
--- a/flare/ase/otf.py
+++ b/flare/ase/otf.py
@@ -210,9 +210,6 @@ class ASE_OTF(OTF):
     def write_gp(self):
         self.flare_calc.write_model(self.flare_name)
 
-    def write_gp(self):
-        self.flare_calc.write_model(self.flare_name)
-
     def rescale_temperature(self, new_pos):
         # call OTF method
         super().rescale_temperature(new_pos)

--- a/flare/ase/otf.py
+++ b/flare/ase/otf.py
@@ -93,6 +93,7 @@ class ASE_OTF(OTF):
     def __init__(
         self,
         atoms,
+        calculator,
         timestep,
         number_of_steps,
         dft_calc,
@@ -103,6 +104,7 @@ class ASE_OTF(OTF):
     ):
 
         self.atoms = FLARE_Atoms.from_ase_atoms(atoms)
+        self.atoms.set_calculator(calculator)
         self.timestep = timestep
         self.md_engine = md_engine
         self.md_kwargs = md_kwargs

--- a/flare/ase/otf.py
+++ b/flare/ase/otf.py
@@ -94,18 +94,19 @@ class ASE_OTF(OTF):
     def __init__(
         self,
         atoms,
-        calculator,
         timestep,
         number_of_steps,
         dft_calc,
         md_engine,
         md_kwargs,
+        calculator=None,
         trajectory=None,
         **otf_kwargs
     ):
 
         self.atoms = FLARE_Atoms.from_ase_atoms(atoms)
-        self.atoms.set_calculator(calculator)
+        if calculator is not None:
+            self.atoms.set_calculator(calculator)
         self.timestep = timestep
         self.md_engine = md_engine
         self.md_kwargs = md_kwargs

--- a/flare/ase/otf.py
+++ b/flare/ase/otf.py
@@ -35,8 +35,9 @@ class ASE_OTF(OTF):
     On-the-fly training module using ASE MD engine, a subclass of OTF.
 
     Args:
-        atoms (ASE Atoms): the ASE Atoms object for the on-the-fly MD run,
-            with calculator set as FLARE_Calculator.
+        atoms (ASE Atoms): the ASE Atoms object for the on-the-fly MD run.
+        calculator: ASE calculator. Must have "get_uncertainties" method
+          implemented.
         timestep: the timestep in MD. Please use ASE units, e.g. if the
             timestep is 1 fs, then set `timestep = 1 * units.fs`
         number_of_steps (int): the total number of steps for MD.

--- a/flare/otf.py
+++ b/flare/otf.py
@@ -118,6 +118,8 @@ class OTF:
         max_atoms_added: int = 1,
         freeze_hyps: int = 10,
         min_steps_with_model: int = 0,
+        update_style: str = "add_n",
+        update_threshold: float = None,
         # dft args
         force_source: str = "qe",
         npool: int = None,
@@ -169,6 +171,8 @@ class OTF:
             self.init_atoms = [int(n) for n in range(self.noa)]
         else:
             self.init_atoms = init_atoms
+        self.update_style = update_style
+        self.update_threshold = update_threshold
 
         self.n_cpus = n_cpus  # set number of cpus and npool for DFT runs
         self.npool = npool
@@ -256,7 +260,9 @@ class OTF:
                     self.std_tolerance,
                     self.gp.force_noise,
                     self.structure,
-                    self.max_atoms_added,
+                    max_atoms_added=self.max_atoms_added,
+                    update_style=self.update_style,
+                    update_threshold=self.update_threshold
                 )
 
                 if (not std_in_bound) and (


### PR DESCRIPTION
## Summary

* New inputs to otf:

    * `update_style`: "add_n" is the default and adds the N highest-uncertainty atoms to the training set, as before; "threshold" adds all atoms above a given threshold.
    * `update_threshold`: sets the threshold for `update_style = "threshold"`, and can be different from the `std_tolerance_factor` that triggers DFT calls.