### PR TITLE
Steven/update/stress struc

### DIFF
--- a/flare/struc.py
+++ b/flare/struc.py
@@ -51,6 +51,12 @@ class Structure:
     :type species_labels: List[str]
     :param stds: Uncertainty associated with forces
     :type stds: np.ndarray
+    :param forces: Forces associated with each atom in structure.
+    :type forces: np.ndarray
+    :param energy: Energy associated with structure.
+    :type energy: float
+    :param stress: Stress tensor associated with structure.
+    :type stress: np.ndarray
     """
 
     def __init__(
@@ -61,10 +67,10 @@ class Structure:
         mass_dict: dict = None,
         prev_positions: "ndarray" = None,
         species_labels: List[str] = None,
-        forces=None,
+        forces: "ndarray" = None,
         stds=None,
         energy: float = None,
-        stress=None,
+        stress: "ndarray" = None,
     ):
 
         # Define cell (each row is a Bravais lattice vector).

--- a/flare/struc.py
+++ b/flare/struc.py
@@ -337,6 +337,7 @@ class Structure:
             mass_dict=dictionary.get("mass_dict"),
             species_labels=dictionary.get("species_labels"),
             energy=dictionary.get("energy", None),
+            stress=dictionary.get("stress", None),
         )
 
         struc.stds = np.array(dictionary.get("stds"))

--- a/flare/struc.py
+++ b/flare/struc.py
@@ -64,6 +64,7 @@ class Structure:
         forces=None,
         stds=None,
         energy: float = None,
+        stress=None,
     ):
 
         # Define cell (each row is a Bravais lattice vector).
@@ -110,7 +111,7 @@ class Structure:
         self.local_energy_stds = None
         self.partial_stresses = None
         self.partial_stress_stds = None
-        self.stress = None
+        self.stress = stress
         self.stress_stds = None
 
         # Potential energy attribute needed to mirror ASE atoms object.
@@ -337,6 +338,7 @@ class Structure:
             mass_dict=dictionary.get("mass_dict"),
             species_labels=dictionary.get("species_labels"),
             energy=dictionary.get("energy", None),
+            stress=dictionary.get("stress", None),
         )
 
         struc.stds = np.array(dictionary.get("stds"))

--- a/flare/struc.py
+++ b/flare/struc.py
@@ -337,7 +337,6 @@ class Structure:
             mass_dict=dictionary.get("mass_dict"),
             species_labels=dictionary.get("species_labels"),
             energy=dictionary.get("energy", None),
-            stress=dictionary.get("stress", None),
         )
 
         struc.stds = np.array(dictionary.get("stds"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.20
+numpy>=1.20.1
 scipy
 memory_profiler
 numba

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.16.0
+numpy>=1.20
 scipy
 memory_profiler
 numba

--- a/tests/test_struc.py
+++ b/tests/test_struc.py
@@ -94,6 +94,8 @@ def varied_test_struc():
         positions=np.array([np.random.uniform(-1, 1, 3) for i in range(10)]),
     )
     struc.forces = np.array([np.random.uniform(-1, 1, 3) for _ in range(10)])
+    struc.stress = np.random.uniform(-1, 1, 9).reshape((3, 3))
+    struc.energy = np.random.uniform(-1, 1, 1)
     return struc
 
 
@@ -109,7 +111,8 @@ def test_to_from_methods(varied_test_struc):
 
     assert isinstance(test_dict, dict)
     assert (test_dict["forces"] == varied_test_struc.forces).all()
-
+    assert test_dict["energy"] == varied_test_struc.energy
+    assert (test_dict["stress"] == varied_test_struc.stress).all()
     new_struc_1 = Structure.from_dict(test_dict)
     new_struc_2 = Structure.from_dict(loads(varied_test_struc.as_str()))
 


### PR DESCRIPTION
## Summary

Stress is now included as an argument to the `Structure` object, so structures can be instantiated with the stress property.
Unit tests have been updated so that serialization / deserialization into JSON includes checking for this field.


- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [Black](https://pypi.org/project/black/) on your local machine.
- [x] Docstrings have been added in the [Sphinx docstring format](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html).
- [x] Type annotations are **highly** encouraged.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.
