### PR TITLE
GPFA now can include energies

### DIFF
--- a/tests/test_gp_from_aimd.py
+++ b/tests/test_gp_from_aimd.py
@@ -445,7 +445,11 @@ def test_active_learning_simple_run():
 
     frames = Structure.from_file(path.join(TEST_FILE_DIR, "methanol_frames.json"))
 
-    tt = TrajectoryTrainer(gp=the_gp)
+    # Assign fake energies to structures
+    for frame in frames:
+        frame.energy = np.random.random()
+
+    tt = TrajectoryTrainer(gp=the_gp, include_energies=True)
 
     tt.run_passive_learning(
         frames=frames[:1],
@@ -454,6 +458,7 @@ def test_active_learning_simple_run():
         post_build_matrices=True,
     )
 
+    assert len(the_gp.training_structures) == 1
     prev_gp_len = len(the_gp)
     prev_gp_stats = the_gp.training_statistics
     tt.run_active_learning(
@@ -461,7 +466,10 @@ def test_active_learning_simple_run():
     )
     assert len(the_gp) == prev_gp_len
     # Try on a frame where the Carbon atom is guaranteed to trip the
-    # abs. force tolerance contition
+    # abs. force tolerance contition.
+    # Turn off include energies so that the number of training structures
+    # does not change.
+    tt.include_energies = False
     tt.run_active_learning(
         frames[1:2],
         rel_std_tolerance=0,
@@ -471,6 +479,7 @@ def test_active_learning_simple_run():
         max_model_elts={"C": 2},
     )
     assert len(the_gp) == prev_gp_len + 1
+    assert len(the_gp.training_structures) == 1
     prev_carbon_atoms = prev_gp_stats["envs_by_species"]["C"]
     assert the_gp.training_statistics["envs_by_species"]["C"] == prev_carbon_atoms + 1
 

--- a/tests/test_gp_from_aimd.py
+++ b/tests/test_gp_from_aimd.py
@@ -466,7 +466,7 @@ def test_active_learning_simple_run():
     )
     assert len(the_gp) == prev_gp_len
     # Try on a frame where the Carbon atom is guaranteed to trip the
-    # abs. force tolerance contition.
+    # abs. force tolerance condition.
     # Turn off include energies so that the number of training structures
     # does not change.
     tt.include_energies = False


### PR DESCRIPTION
Adapted from the Pymatgen PR template.
## Summary

`TrajectoryTrainer` now has an `include_energies` argument which adds in structures labeled by energy during the active learning and passive learning training loops whenever frames are added.

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [Black](https://pypi.org/project/black/) on your local machine.
- [x] Docstrings have been added in the [Sphinx docstring format](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html).
- [x] Type annotations are **highly** encouraged.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.
