### PR TITLE
Bugfix: opt_algorithm for #298, and write_model for #299

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -36,6 +36,10 @@ Before a pull request can be merged, the following items must be checked:
 - [ ] Type annotations are **highly** encouraged.
 - [ ] Tests have been added for any new functionality or bug fixes.
 - [ ] All existing tests pass.
+- [ ] The version number in `setup.py` is updated. We are using a version number format a.b.c
+    - If this PR fixes bugs, update version number to a.b.c+1
+    - If this PR adds new features, update version number to a.b+1.0
+    - If this PR includes significant changes in framework or interface, update version number to a+1.0.0
 
 Note that the CI system will run all the above checks. But it will be much more
 efficient if you already fix most errors prior to submitting the PR.

--- a/flare/ase/calculator.py
+++ b/flare/ase/calculator.py
@@ -100,9 +100,6 @@ class FLARE_Calculator(Calculator):
         self.results["stress"] = total_stress / volume
         self.results["energy"] = np.sum(self.results["local_energies"])
 
-    def set_atoms(self, atoms):
-        self.atoms = atoms
-
     def calculate_gp(self, atoms):
         # Compute energy, forces, and stresses and their uncertainties
         if self.par:

--- a/flare/ase/nosehoover.py
+++ b/flare/ase/nosehoover.py
@@ -77,7 +77,7 @@ class NoseHoover(MolecularDynamics):
         )
 
     def step(self):
-        """ Perform a MD step. """
+        """Perform a MD step."""
         masses = self.atoms.get_masses()
 
         modified_acc = (

--- a/flare/ase/otf.py
+++ b/flare/ase/otf.py
@@ -205,7 +205,7 @@ class ASE_OTF(OTF):
             self.flare_calc.reset()
             self.atoms.calc = self.flare_calc
 
-        # Take MD step.
+        # Take MD step. Inside the step() function, get_forces() is called
         self.md.step()
 
     def write_gp(self):

--- a/flare/dft_interface/vasp_util.py
+++ b/flare/dft_interface/vasp_util.py
@@ -6,10 +6,14 @@ from json import dump, load
 from subprocess import call
 from typing import List, Union
 
-from pymatgen.io.vasp.inputs import Poscar
-from pymatgen.io.vasp.outputs import Vasprun
-from pymatgen.io.vasp.sets import VaspInputSet
-from pymatgen.core.periodic_table import Element
+try:
+    from pymatgen.io.vasp.inputs import Poscar
+    from pymatgen.io.vasp.outputs import Vasprun
+    from pymatgen.io.vasp.sets import VaspInputSet
+    from pymatgen.core.periodic_table import Element
+    _pmg_present = True
+except:
+    _pmg_present = False
 
 from flare.struc import Structure
 from flare.utils.element_coder import NumpyEncoder
@@ -17,11 +21,11 @@ from flare.utils.element_coder import NumpyEncoder
 name = "VASP"
 
 
-def check_vasprun(vasprun: Union[str, Vasprun], vasprun_kwargs: dict = {}) -> Vasprun:
+def check_vasprun(vasprun, vasprun_kwargs: dict = {}):
     """
     Helper utility to take a vasprun file name or Vasprun object
     and return a vasprun object.
-    :param vasprun: vasprun filename or object
+    :param vasprun: Vasprun filename or object
     """
 
     if type(vasprun) == str:
@@ -167,7 +171,7 @@ def edit_dft_input_positions(output_name: str, structure: Structure):
     return output_name
 
 
-def parse_dft_forces(vasprun: Union[str, Vasprun]):
+def parse_dft_forces(vasprun):
     """
     Parses the DFT forces from the last ionic step of a VASP vasprun.xml file
     :param vasprun: pymatgen Vasprun object or vasprun filename
@@ -177,7 +181,7 @@ def parse_dft_forces(vasprun: Union[str, Vasprun]):
     return np.array(istep["forces"])
 
 
-def parse_dft_forces_and_energy(vasprun: Union[str, Vasprun]):
+def parse_dft_forces_and_energy(vasprun):
     """
     Parses the DFT forces and energy from a VASP vasprun.xml file
     :param vasprun: pymatgen Vasprun object or vasprun filename
@@ -188,7 +192,7 @@ def parse_dft_forces_and_energy(vasprun: Union[str, Vasprun]):
 
 
 def md_trajectory_from_vasprun(
-    vasprun: Union[str, Vasprun], ionic_step_skips=1, vasprun_kwargs: dict = {}
+    vasprun, ionic_step_skips=1, vasprun_kwargs: dict = {}
 ):
     """
     Returns a list of flare Structure objects decorated with forces, stress,

--- a/flare/gp.py
+++ b/flare/gp.py
@@ -1369,7 +1369,7 @@ class GaussianProcess:
             dictionary["name"] = "default_gp"
         if "per_atom_par" not in dictionary:
             dictionary["per_atom_par"] = True
-        if "optimization_algorithm" not in dictionary:
+        if "opt_algorithm" not in dictionary:
             dictionary["opt_algorithm"] = "L-BFGS-B"
         if "hyps_mask" not in dictionary:
             dictionary["hyps_mask"] = None

--- a/flare/lammps/lammps_calculator.py
+++ b/flare/lammps/lammps_calculator.py
@@ -133,7 +133,7 @@ Atoms
 
 
 def lammps_cell_text(structure):
-    """ Write cell from structure object."""
+    """Write cell from structure object."""
 
     cell_text = f"""
 0.0 {structure.cell[0, 0]}  xlo xhi

--- a/flare/otf_parser.py
+++ b/flare/otf_parser.py
@@ -9,7 +9,7 @@ from flare.gp import GaussianProcess
 
 class OtfAnalysis:
     """
-    Parse the OTF log file to get trajectory, training data, 
+    Parse the OTF log file to get trajectory, training data,
     thermostat, and build GP model.
 
     Args:
@@ -17,6 +17,7 @@ class OtfAnalysis:
         calculate_energy (bool): if the potential energy is computed and
             needs to be parsed, then set to True. Default False.
     """
+
     def __init__(self, filename, calculate_energy=False):
         self.filename = filename
 
@@ -74,7 +75,7 @@ class OtfAnalysis:
     ):
         """
         Build GP model from the training frames parsed from the log file.
-        The cell, hyps and gp can be reset with customized values. 
+        The cell, hyps and gp can be reset with customized values.
 
         Args:
             cell (np.ndarray): Default None to use the cell from the log file.
@@ -85,15 +86,15 @@ class OtfAnalysis:
             hyps (np.ndarray): Default None to use the hyperparameters from the
                 log file. Customized hyps can be input as an array.
             init_gp (GaussianProcess): Default to None to use no initial settings
-                or training data. an initial GP can be used, and then the 
-                frames parsed in the log file will add to the initial GP. Then the 
-                final GP uses the hyps and kernels of `init_gp`, and consists of 
+                or training data. an initial GP can be used, and then the
+                frames parsed in the log file will add to the initial GP. Then the
+                final GP uses the hyps and kernels of `init_gp`, and consists of
                 training data from `init_gp` and the data from the log file.
                 **NOTE**: if a log file from restarted OTF is parsed, then an initial
                 GP needs to be parsed from the prior log file as the `init_gp` of the
                 restarted log file.
             hyp_no (int): Default None to use the final optimized hyperparameters to
-                build GP. If not None, then use the hyps from the `hyp_no`th 
+                build GP. If not None, then use the hyps from the `hyp_no`th
                 optimization step.
             kwargs: if a new GP setting is needed without inputing `init_gp`, the GP
                 initial args can be input as kwargs.
@@ -242,19 +243,18 @@ class OtfAnalysis:
                 energy = 0
             else:
                 energy = self.energies[i]
- 
+
             cur_struc = struc.Structure(
-                cell=cell, 
-                species=species, 
+                cell=cell,
+                species=species,
                 positions=self.position_list[i],
                 forces=self.force_list[i],
                 stds=self.uncertainty_list[i],
             )
             cur_struc.energy = energy
-            #cur_struc.stress = self.stress_list[i]
+            # cur_struc.stress = self.stress_list[i]
             structures.append(cur_struc)
         return structures
-
 
     def to_xyz(self, xyz_file):
         """
@@ -263,9 +263,10 @@ class OtfAnalysis:
             xyz_file (str): the file name of the .xyz file to output
 
         Return:
-            A list of `ASE Atoms` objects. 
+            A list of `ASE Atoms` objects.
         """
         from ase.io import write
+
         struc_trj = self.output_md_structures()
         trj = []
         for s in struc_trj:
@@ -504,7 +505,7 @@ def extract_global_info(
             cell_list.append(vectors)
         if "Stress" in line:
             vectors = []
-            stress_line = block[ind + 2].replace('-',' -').split()
+            stress_line = block[ind + 2].replace("-", " -").split()
             vectors = [float(s) for s in stress_line]
             stress_list.append(vectors)
 
@@ -523,9 +524,9 @@ def get_thermostat(thermostat, kw, line):
     line = line.lower()
     if kw in line:
         try:
-            value = float(line.split()[-2]) # old style
+            value = float(line.split()[-2])  # old style
         except:
-            value = float(line.split()[-1]) # new style
+            value = float(line.split()[-1])  # new style
         if kw in thermostat:
             thermostat[kw].append(value)
         else:

--- a/flare/parameters.py
+++ b/flare/parameters.py
@@ -164,9 +164,7 @@ class Parameters:
             assert (
                 "species_mask" in param_dict
             ), "species_mask key missing in param_dict dictionary"
-            param_dict["species_mask"] = nparray(
-                param_dict["species_mask"], dtype=int
-            )
+            param_dict["species_mask"] = nparray(param_dict["species_mask"], dtype=int)
 
         # for each kernel, check whether it is defined
         # and the length of corresponding hyper-parameters

--- a/flare/predict.py
+++ b/flare/predict.py
@@ -302,7 +302,7 @@ def predict_on_structure_efs_par(
 
     # Just work in serial in the number of cpus is 1,
     # or the gp is not parallelized by atoms
-    if (n_cpus is 1) or (not gp.per_atom_par):
+    if (n_cpus == 1) or (not gp.per_atom_par):
         return predict_on_structure_efs(
             structure=structure,
             gp=gp,
@@ -505,7 +505,7 @@ def predict_on_structure_par_en(
     """
     # Work in serial if the number of cpus is 1
     # or the gp is not parallelized by atoms
-    if (n_cpus is 1) or (not gp.per_atom_par):
+    if (n_cpus == 1) or (not gp.per_atom_par):
         predict_on_structure_en(
             structure,
             gp,

--- a/flare/rbcm.py
+++ b/flare/rbcm.py
@@ -768,7 +768,7 @@ class RobustBayesianCommitteeMachine(GaussianProcess):
             self.sync_experts_data(i)
 
     def unsync_experts_data(self, expert_id: int):
-        """ Reset global variables. """
+        """Reset global variables."""
         if len(self.training_data) > expert_id:
             _global_training_data.pop(f"{self.name}_{expert_id}", None)
             _global_training_labels.pop(f"{self.name}_{expert_id}", None)
@@ -776,7 +776,7 @@ class RobustBayesianCommitteeMachine(GaussianProcess):
             _global_energy_labels.pop(f"{self.name}_{expert_id}", None)
 
     def sync_experts_data(self, expert_id: int):
-        """ Reset global variables. """
+        """Reset global variables."""
         if len(self.training_data) > expert_id:
             _global_training_data[f"{self.name}_{expert_id}"] = self.training_data[
                 expert_id
@@ -842,7 +842,7 @@ class RobustBayesianCommitteeMachine(GaussianProcess):
         self.n_envs_prev[expert_id] = len(self.training_data[expert_id])
 
     def redistribute_training_data(self, figure_name="default"):
-        """ redistribute data """
+        """redistribute data"""
 
         joint_data = []
         joint_structures = []
@@ -910,7 +910,7 @@ class RobustBayesianCommitteeMachine(GaussianProcess):
         return kmat
 
     def compute_join_dist_mat(self, list_expert_id):
-        """ Reset global variables. """
+        """Reset global variables."""
         joint_data = []
         joint_structures = []
         for i in list_expert_id:

--- a/flare/struc.py
+++ b/flare/struc.py
@@ -401,8 +401,7 @@ class Structure:
         properties = ["forces", "energy", "stress"]
         for p in properties:
             results[p] = getattr(self, p)
-        calculator = SinglePointCalculator(atoms, **results)
-        atoms.set_calculator(calculator)
+        atoms.calc = SinglePointCalculator(atoms, **results)
 
         return atoms
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<=1.20.3
 scipy
 memory_profiler
 numba

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ nbsphinx
 IPython
 pytest>=4.6
 pytest-mock
-pymatgen<=2022.0.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ nptyping
 nbsphinx
 IPython
 pytest>=4.6
+pytest-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-numpy<=1.20
+numpy
 scipy
 memory_profiler
 numba
 ase
-pymatgen<2021
+pymatgen
 nptyping
 nbsphinx
 IPython

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ scipy
 memory_profiler
 numba
 ase
-pymatgen
 nptyping
 nbsphinx
 IPython
 pytest>=4.6
 pytest-mock
+pymatgen<=2022.0.17

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r") as fh:
 setuptools.setup(
     name="mir-flare",
     packages=setuptools.find_packages(exclude=["tests"]),
-    version="0.1.8",
+    version="0.1.9",
     author="Materials Intelligence Research",
     author_email="mir@g.harvard.edu",
     description="Fast Learning of Atomistic Rare Events",

--- a/tests/fake_gp.py
+++ b/tests/fake_gp.py
@@ -10,7 +10,7 @@ from flare.utils.parameter_helper import ParameterHelper
 
 
 def get_random_structure(cell, unique_species, noa, set_seed: int = None):
-    """Create a random test structure """
+    """Create a random test structure"""
     if set_seed:
         np.random.seed(set_seed)
 

--- a/tests/test_ase_otf.py
+++ b/tests/test_ase_otf.py
@@ -48,7 +48,7 @@ def read_qe_results(self):
 
 md_list = [
     "VelocityVerlet",
-    "NVTBerendsen", 
+    "NVTBerendsen",
     "NPTBerendsen",
     "NPT",
     "Langevin",
@@ -77,7 +77,9 @@ def md_params():
         elif md_engine == "NPTBerendsen":
             md_dict[md_engine].update({"pressure": 0.0, "compressibility_au": 1.0})
         elif md_engine == "NPT":
-            md_dict[md_engine].update({"externalstress": 0, "ttime": 25, "pfactor": 1.0})
+            md_dict[md_engine].update(
+                {"externalstress": 0, "ttime": 25, "pfactor": 1.0}
+            )
         elif md_engine == "Langevin":
             md_dict[md_engine].update({"friction": 0.02})
         elif md_engine == "NoseHoover":
@@ -220,7 +222,7 @@ def test_otf_md(md_engine, md_params, super_cell, flare_calc, qe_calc, write_mod
     otf_traj = OtfAnalysis(output_name + ".out")
     comp1 = otf_traj.force_list[-2][1, 0]
     comp2 = otf_traj.force_list[-1][1, 0]
-    assert (comp1 != comp2)
+    assert comp1 != comp2
 
     for f in glob.glob("scf*.pw*"):
         os.remove(f)
@@ -264,7 +266,7 @@ def test_otf_parser(md_engine, write_model):
     # Check that the GP forces change.
     comp1 = otf_traj.force_list[-2][1, 0]
     comp2 = otf_traj.force_list[-1][1, 0]
-    assert (comp1 != comp2)
+    assert comp1 != comp2
 
-    for f in glob.glob(output_name + "*"): 
+    for f in glob.glob(output_name + "*"):
         os.remove(f)

--- a/tests/test_ase_otf.py
+++ b/tests/test_ase_otf.py
@@ -54,7 +54,7 @@ md_list = [
     "Langevin",
     "NoseHoover",
 ]
-number_of_steps = 3
+number_of_steps = 5
 
 
 @pytest.fixture(scope="module")
@@ -72,12 +72,16 @@ def md_params():
         else:
             md_dict[md_engine] = {"temperature": md_dict["temperature"]}
 
-    md_dict["NVTBerendsen"].update({"taut": 0.5e3 * units.fs})
-    md_dict["NPTBerendsen"].update({"pressure": 0.0,
-                                    "compressibility_au": 1.0})
-    md_dict["NPT"].update({"externalstress": 0, "ttime": 25, "pfactor": 1.0})
-    md_dict["Langevin"].update({"friction": 0.02})
-    md_dict["NoseHoover"].update({"nvt_q": 334.0})
+        if md_engine == "NVTBerendsen":
+            md_dict[md_engine].update({"taut": 0.5e3 * units.fs})
+        elif md_engine == "NPTBerendsen":
+            md_dict[md_engine].update({"pressure": 0.0, "compressibility_au": 1.0})
+        elif md_engine == "NPT":
+            md_dict[md_engine].update({"externalstress": 0, "ttime": 25, "pfactor": 1.0})
+        elif md_engine == "Langevin":
+            md_dict[md_engine].update({"friction": 0.02})
+        elif md_engine == "NoseHoover":
+            md_dict[md_engine].update({"nvt_q": 334.0})
 
     yield md_dict
     del md_dict
@@ -169,18 +173,21 @@ def qe_calc():
 
 
 @pytest.mark.parametrize("md_engine", md_list)
-def test_otf_md(md_engine, md_params, super_cell, flare_calc, qe_calc):
+@pytest.mark.parametrize("write_model", [1, 2, 3])
+def test_otf_md(md_engine, md_params, super_cell, flare_calc, qe_calc, write_model):
     np.random.seed(12345)
 
     flare_calculator = flare_calc[md_engine]
+    output_name = f"{md_engine}_{write_model}"
+
     # set up OTF MD engine
     otf_params = {
         "init_atoms": [0, 1, 2, 3],
-        "output_name": md_engine,
+        "output_name": output_name,
         "std_tolerance_factor": 1.0,
         "max_atoms_added": len(super_cell.positions),
-        "freeze_hyps": 10,
-        "write_model": 1,
+        "freeze_hyps": write_model,
+        "write_model": 3,
     }
     #                  'use_mapping': flare_calculator.use_mapping}
 
@@ -200,7 +207,7 @@ def test_otf_md(md_engine, md_params, super_cell, flare_calc, qe_calc):
         dft_calc=qe_calc,
         md_engine=md_engine,
         md_kwargs=md_kwargs,
-        trajectory=md_engine + "_otf.traj",
+        trajectory=f"{output_name}_otf.traj",
         **otf_params,
     )
 
@@ -210,9 +217,8 @@ def test_otf_md(md_engine, md_params, super_cell, flare_calc, qe_calc):
     test_otf.run()
 
     # Check that the GP forces change.
-    output_name = f"{md_engine}.out"
-    otf_traj = OtfAnalysis(output_name)
-    comp1 = otf_traj.force_list[0][1, 0]
+    otf_traj = OtfAnalysis(output_name + ".out")
+    comp1 = otf_traj.force_list[-2][1, 0]
     comp2 = otf_traj.force_list[-1][1, 0]
     assert (comp1 != comp2)
 
@@ -234,28 +240,31 @@ def test_otf_md(md_engine, md_params, super_cell, flare_calc, qe_calc):
 
 
 @pytest.mark.parametrize("md_engine", md_list)
-def test_load_checkpoint(md_engine):
-    new_otf = ASE_OTF.from_checkpoint(md_engine + "_checkpt.json")
+@pytest.mark.parametrize("write_model", [1, 2, 3])
+def test_load_checkpoint(md_engine, write_model):
+    output_name = f"{md_engine}_{write_model}"
+    new_otf = ASE_OTF.from_checkpoint(output_name + "_checkpt.json")
     assert new_otf.curr_step == number_of_steps
     new_otf.number_of_steps = new_otf.number_of_steps + 3
     new_otf.run()
 
 
 @pytest.mark.parametrize("md_engine", md_list)
-def test_otf_parser(md_engine):
-    output_name = f"{md_engine}.out"
-    otf_traj = OtfAnalysis(output_name)
+@pytest.mark.parametrize("write_model", [1, 2, 3])
+def test_otf_parser(md_engine, write_model):
+    output_name = f"{md_engine}_{write_model}"
+    otf_traj = OtfAnalysis(output_name + ".out")
     try:
         replicated_gp = otf_traj.make_gp()
     except:
-        init_flare = FLARE_Calculator.from_file(md_engine + "_flare.json")
+        init_flare = FLARE_Calculator.from_file(output_name + "_flare.json")
         replicated_gp = otf_traj.make_gp(init_gp=init_flare.gp_model)
 
     print("ase otf traj parsed")
     # Check that the GP forces change.
-    comp1 = otf_traj.force_list[0][1, 0]
+    comp1 = otf_traj.force_list[-2][1, 0]
     comp2 = otf_traj.force_list[-1][1, 0]
     assert (comp1 != comp2)
 
-    for f in glob.glob(md_engine + "*"): 
+    for f in glob.glob(output_name + "*"): 
         os.remove(f)

--- a/tests/test_ase_otf.py
+++ b/tests/test_ase_otf.py
@@ -188,8 +188,8 @@ def test_otf_md(md_engine, md_params, super_cell, flare_calc, qe_calc, write_mod
         "output_name": output_name,
         "std_tolerance_factor": 1.0,
         "max_atoms_added": len(super_cell.positions),
-        "freeze_hyps": write_model,
-        "write_model": 3,
+        "freeze_hyps": 10,
+        "write_model": write_model,
     }
     #                  'use_mapping': flare_calculator.use_mapping}
 

--- a/tests/test_flare_io.py
+++ b/tests/test_flare_io.py
@@ -1,12 +1,8 @@
 import pytest
+pmgout = pytest.importorskip("pymatgen.io.vasp.outputs")
+Vasprun = pmgout.Vasprun
 import os
 import numpy as np
-try:
-    from pymatgen.io.vasp.outputs import Vasprun
-    _pmg_present = True
-except:
-    _pmg_present = False
-
 from flare.struc import Structure, get_unique_species
 from flare.dft_interface.vasp_util import md_trajectory_from_vasprun
 from flare.utils.flare_io import md_trajectory_to_file, md_trajectory_from_file
@@ -15,8 +11,6 @@ pytestmark = pytest.mark.filterwarnings(
     "ignore::UserWarning", "ignore::pymatgen.io.vasp.outputs.UnconvergedVASPWarning"
 )
 
-
-@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 def test_read_write_trajectory():
     structures = md_trajectory_from_vasprun("test_files/test_vasprun.xml")
     fname = "tst_traj.json"

--- a/tests/test_flare_io.py
+++ b/tests/test_flare_io.py
@@ -1,7 +1,12 @@
 import pytest
 import os
 import numpy as np
-from pymatgen.io.vasp.outputs import Vasprun
+try:
+    from pymatgen.io.vasp.outputs import Vasprun
+    _pmg_present = True
+except:
+    _pmg_present = False
+
 from flare.struc import Structure, get_unique_species
 from flare.dft_interface.vasp_util import md_trajectory_from_vasprun
 from flare.utils.flare_io import md_trajectory_to_file, md_trajectory_from_file
@@ -11,6 +16,7 @@ pytestmark = pytest.mark.filterwarnings(
 )
 
 
+@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 def test_read_write_trajectory():
     structures = md_trajectory_from_vasprun("test_files/test_vasprun.xml")
     fname = "tst_traj.json"

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -129,6 +129,9 @@ class TestInitialization:
             GaussianProcess(parallel=parallel)
         for per_atom_par in [True, False]:
             GaussianProcess(per_atom_par=per_atom_par)
+        for opt_algorithm in ["L-BFGS-B", "BFGS"]:
+            gp = GaussianProcess(opt_algorithm=opt_algorithm)
+            assert opt_algorithm == gp.opt_algorithm
 
 
 class TestDataUpdating:

--- a/tests/test_grid_kernel.py
+++ b/tests/test_grid_kernel.py
@@ -117,9 +117,11 @@ def parameter():
 
         delta = 1e-8
         cutoffs, hyps1, hyps2, hm1, hm2 = generate_same_hm(kernels, multi_cutoff=False)
-        (cutoffs, hyps2, hm2,) = generate_diff_hm(
-            kernels, diff_cutoff=False, constraint=False
-        )
+        (
+            cutoffs,
+            hyps2,
+            hm2,
+        ) = generate_diff_hm(kernels, diff_cutoff=False, constraint=False)
 
         cell = 1e7 * np.eye(3)
         env1 = generate_mb_envs(hm1["cutoffs"], cell, delta, 1)

--- a/tests/test_mgp.py
+++ b/tests/test_mgp.py
@@ -293,18 +293,18 @@ def test_predict(all_gp, all_mgp, bodies, multihyps):
         kernel_name = "threebody"
         # compare_triplet(mgp_model.maps['threebody'], gp_model, test_envi)
 
-    mgp_f, mgp_e_var, mgp_s, mgp_e  = mgp_model.predict(test_envi)
+    mgp_f, mgp_e_var, mgp_s, mgp_e = mgp_model.predict(test_envi)
 
     assert Parameters.compare_dict(
         gp_model.hyps_mask, mgp_model.maps[kernel_name].hyps_mask
     )
 
-    if multihyps: 
+    if multihyps:
         gp_e, gp_e_var = gp_model.predict_local_energy_and_var(test_envi)
         gp_f, gp_f_var = gp_model.predict_force_xyz(test_envi)
     else:
         gp_e, gp_f, gp_s, gp_e_var, _, _ = gp_model.predict_efs(test_envi)
-        gp_s = - gp_s[[0, 3, 5, 4, 2, 1]]
+        gp_s = -gp_s[[0, 3, 5, 4, 2, 1]]
 
         # check stress
         assert np.allclose(mgp_s, gp_s, rtol=1e-2)
@@ -317,9 +317,7 @@ def test_predict(all_gp, all_mgp, bodies, multihyps):
 
     # check forces
     print("isclose?", mgp_f - gp_f, gp_f)
-    assert np.allclose(
-        mgp_f, gp_f, atol=1e-3
-    ), f"{bodies} body force mapping is wrong"
+    assert np.allclose(mgp_f, gp_f, atol=1e-3), f"{bodies} body force mapping is wrong"
 
     if mgp_model.var_map == "simple":
         print(bodies, multihyps)

--- a/tests/test_rbcm.py
+++ b/tests/test_rbcm.py
@@ -61,7 +61,8 @@ def test_prediction():
     """
     prior_var = 0.1
     rbcm = RobustBayesianCommitteeMachine(
-        ndata_per_expert=100, prior_variance=prior_var,
+        ndata_per_expert=100,
+        prior_variance=prior_var,
     )
     gp = GaussianProcess()
 

--- a/tests/test_struc.py
+++ b/tests/test_struc.py
@@ -47,7 +47,7 @@ def test_prev_positions_arg():
 
 
 def test_raw_to_relative():
-    """ Test that Cartesian and relative coordinates are equal. """
+    """Test that Cartesian and relative coordinates are equal."""
 
     cell = np.random.rand(3, 3)
     noa = 10

--- a/tests/test_struc.py
+++ b/tests/test_struc.py
@@ -6,14 +6,6 @@ from tests.test_gp import get_random_structure
 from flare.struc import Structure
 from json import loads, dumps
 from flare.utils.element_coder import Z_to_element, NumpyEncoder
-
-try:
-    import pymatgen.core.structure as pmgstruc
-
-    _test_pmg = True
-except ImportError:
-    _test_pmg = False
-
 from .test_gp import dumpcompare
 
 
@@ -176,8 +168,8 @@ def test_struc_to_ase():
     assert np.all(new_atoms.get_stress() == uc.stress)
 
 
-@pytest.mark.skipif(not _test_pmg, reason="Pymatgen not present in available packages.")
 def test_from_pmg_structure():
+    pmgstruc = pytest.importorskip("pymatgen.core.structure")
 
     pmg_struc = pmgstruc.Structure(
         lattice=np.eye(3),
@@ -220,8 +212,8 @@ def test_from_pmg_structure():
     assert np.equal(new_struc.forces, np.array([1.0, 1.0, 1.0])).all()
 
 
-@pytest.mark.skipif(not _test_pmg, reason="Pymatgen not present in available packages.")
 def test_to_pmg_structure(varied_test_struc):
+    pmgstruc = pytest.importorskip("pymatgen.core.structure")
 
     new_struc = Structure.to_pmg_structure(varied_test_struc)
     assert len(varied_test_struc) == len(varied_test_struc)
@@ -263,6 +255,8 @@ def test_to_xyz(varied_test_struc):
 
 
 def test_file_load():
+    pmgstruc = pytest.importorskip("pymatgen.core.structure")
+
     struct1, forces = get_random_structure(cell=np.eye(3), unique_species=[1, 2], noa=2)
     struct2, forces = get_random_structure(cell=np.eye(3), unique_species=[1, 2], noa=2)
 
@@ -303,6 +297,8 @@ def test_is_valid():
     tolerance
     :return:
     """
+    pmgstruc = pytest.importorskip("pymatgen.core.structure")
+
     test_struc = Structure(
         cell=np.eye(3), species=["H"], positions=np.array([[0, 0, 0]])
     )

--- a/tests/test_vasp_util.py
+++ b/tests/test_vasp_util.py
@@ -2,8 +2,13 @@ import pytest
 import os
 import sys
 import numpy as np
-from pymatgen.io.vasp.inputs import Poscar
-from pymatgen.io.vasp.outputs import Vasprun
+try:
+    from pymatgen.io.vasp.inputs import Poscar
+    from pymatgen.io.vasp.outputs import Vasprun
+    _pmg_present = True
+except:
+    _pmg_present = False
+
 from flare.struc import Structure, get_unique_species
 from flare.dft_interface.vasp_util import (
     parse_dft_forces,
@@ -25,12 +30,13 @@ pytestmark = pytest.mark.filterwarnings(
 TEST_DIR = os.path.dirname(__file__)
 TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
-
+@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 def cleanup_vasp_run():
     os.system("rm POSCAR")
     os.system("rm vasprun.xml")
 
 
+@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 def test_check_vasprun():
     fname = "./test_files/test_vasprun.xml"
     vr = Vasprun(fname)
@@ -45,6 +51,7 @@ def test_check_vasprun():
 # ------------------------------------------------------
 
 
+@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 @pytest.mark.parametrize("poscar", ["./test_files/test_POSCAR"])
 def test_structure_parsing(poscar):
     structure = dft_input_to_structure(poscar)
@@ -56,11 +63,13 @@ def test_structure_parsing(poscar):
     assert np.isclose(structure.positions, pmg_struct.cart_coords).all()
 
 
+@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 @pytest.mark.parametrize("poscar", ["./test_files/test_POSCAR"])
 def test_input_to_structure(poscar):
     assert isinstance(dft_input_to_structure(poscar), Structure)
 
 
+@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 @pytest.mark.parametrize(
     "cmd, poscar", [("python ./test_files/dummy_vasp.py", "./test_files/test_POSCAR")]
 )
@@ -94,6 +103,7 @@ def test_vasp_calling(cmd, poscar):
     cleanup_vasp_run()
 
 
+@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 @pytest.mark.parametrize(
     "cmd, poscar",
     [("python ./test_files/dummy_vasp.py test_fail", "./test_files/test_POSCAR")],
@@ -104,6 +114,7 @@ def test_vasp_calling_fail(cmd, poscar):
         _ = run_dft(".", cmd, structure=structure, en=False)
 
 
+@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 def test_vasp_input_edit():
     os.system("cp test_files/test_POSCAR ./POSCAR")
     structure = dft_input_to_structure("./test_files/test_POSCAR")
@@ -123,6 +134,7 @@ def test_vasp_input_edit():
     os.system("rm ./POSCAR.bak")
 
 
+@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 @pytest.mark.skipif(
     not os.environ.get("VASP_COMMAND", False),
     reason=(
@@ -164,6 +176,7 @@ def test_run_dft_par():
 # ------------------------------------------------------
 
 
+@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 def test_md_trajectory():
     structures = md_trajectory_from_vasprun("test_files/test_vasprun.xml")
     assert len(structures) == 2

--- a/tests/test_vasp_util.py
+++ b/tests/test_vasp_util.py
@@ -1,14 +1,11 @@
 import pytest
+pmgin = pytest.importorskip("pymatgen.io.vasp.inputs")
+pmgout = pytest.importorskip("pymatgen.io.vasp.outputs")
+Poscar = pmgin.Poscar
+Vasprun = pmgout.Vasprun
 import os
 import sys
 import numpy as np
-try:
-    from pymatgen.io.vasp.inputs import Poscar
-    from pymatgen.io.vasp.outputs import Vasprun
-    _pmg_present = True
-except:
-    _pmg_present = False
-
 from flare.struc import Structure, get_unique_species
 from flare.dft_interface.vasp_util import (
     parse_dft_forces,
@@ -30,13 +27,11 @@ pytestmark = pytest.mark.filterwarnings(
 TEST_DIR = os.path.dirname(__file__)
 TEST_FILE_DIR = os.path.join(TEST_DIR, "test_files")
 
-@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 def cleanup_vasp_run():
     os.system("rm POSCAR")
     os.system("rm vasprun.xml")
 
 
-@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 def test_check_vasprun():
     fname = "./test_files/test_vasprun.xml"
     vr = Vasprun(fname)
@@ -51,7 +46,6 @@ def test_check_vasprun():
 # ------------------------------------------------------
 
 
-@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 @pytest.mark.parametrize("poscar", ["./test_files/test_POSCAR"])
 def test_structure_parsing(poscar):
     structure = dft_input_to_structure(poscar)
@@ -63,13 +57,11 @@ def test_structure_parsing(poscar):
     assert np.isclose(structure.positions, pmg_struct.cart_coords).all()
 
 
-@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 @pytest.mark.parametrize("poscar", ["./test_files/test_POSCAR"])
 def test_input_to_structure(poscar):
     assert isinstance(dft_input_to_structure(poscar), Structure)
 
 
-@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 @pytest.mark.parametrize(
     "cmd, poscar", [("python ./test_files/dummy_vasp.py", "./test_files/test_POSCAR")]
 )
@@ -103,7 +95,6 @@ def test_vasp_calling(cmd, poscar):
     cleanup_vasp_run()
 
 
-@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 @pytest.mark.parametrize(
     "cmd, poscar",
     [("python ./test_files/dummy_vasp.py test_fail", "./test_files/test_POSCAR")],
@@ -114,7 +105,6 @@ def test_vasp_calling_fail(cmd, poscar):
         _ = run_dft(".", cmd, structure=structure, en=False)
 
 
-@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 def test_vasp_input_edit():
     os.system("cp test_files/test_POSCAR ./POSCAR")
     structure = dft_input_to_structure("./test_files/test_POSCAR")
@@ -134,7 +124,6 @@ def test_vasp_input_edit():
     os.system("rm ./POSCAR.bak")
 
 
-@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 @pytest.mark.skipif(
     not os.environ.get("VASP_COMMAND", False),
     reason=(
@@ -176,7 +165,6 @@ def test_run_dft_par():
 # ------------------------------------------------------
 
 
-@pytest.mark.skipif(not _pmg_present, reason=("pymatgen not found "))
 def test_md_trajectory():
     structures = md_trajectory_from_vasprun("test_files/test_vasprun.xml")
     assert len(structures) == 2


### PR DESCRIPTION
## Summary

Include a summary of major changes in bullet points:

* Fix #298 
* Fix #299 by removing `set_atoms` in `FLARE_Calculator`, because in `ase/otf.py: as_dict`, setting calculator by `self.atoms.calc = flare_calc` assigns the atoms to the calculator, without changing the `results` dict, and this method is no longer needed in the current ASE version.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [Black](https://pypi.org/project/black/) on your local machine.
- [x] Docstrings have been added in the [Sphinx docstring format](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html).
- [x] Type annotations are **highly** encouraged.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All existing tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.
