### PR TITLE
Compilers and libraries from conda instead of module load

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,12 @@ add_dependencies(flare eigen_project)
 # Link to json.
 target_link_libraries(flare PUBLIC nlohmann_json::nlohmann_json)
 
+# Add conda include directories
+if (DEFINED ENV{CONDA_PREFIX})
+  message(STATUS "Adding conda include directories.")
+  include_directories($ENV{CONDA_PREFIX}/include)
+endif()
+
 # Link to OpenMP.
 if (DEFINED ENV{OMP_LOC})
     target_link_libraries(flare PUBLIC $ENV{OMP_LOC})

--- a/README.md
+++ b/README.md
@@ -53,33 +53,17 @@ All the tutorials take a few minutes to run on a normal desktop computer or lapt
 
 ## Installation
 ### Pip installation
-If you're installing on a compute cluster, make sure to load the following modules first:
-```
-module load cmake/3.17.3-fasrc01 python/3.6.3-fasrc01 gcc/9.3.0-fasrc01
-```
-
-FLARE can be installed in two different ways.
-1. Download and install automatically:
-    ```
-    pip install mir-flare
-    ```
-2. Download this repository and install (required for unit tests):
-    ```
-    git clone https://github.com/mir-group/flare
-    cd flare
-    pip install .
-    ```
-    
+Please check the [installation guide here](https://mir-group.github.io/flare/installation/install.html).
 This will take a few minutes on a normal desktop computer or laptop.
 
 ### Developer's installation guide
-For developers, please check the [installation guide](https://mir-group.github.io/flare_pp/installation.html).
+For developers, please check the [installation guide](https://mir-group.github.io/flare/installation/install.html#developer-s-installation-guide).
 
 ### Compiling LAMMPS
 See [documentation on compiling LAMMPS with FLARE](https://mir-group.github.io/flare/installation/lammps.html)
 
 ### Trouble shooting
-If you have problem compiling and installing the code, please check the [FAQs](https://mir-group.github.io/flare_pp/faqs.html) to see if your problem is covered. Otherwise, please open an issue or contact us.
+If you have problem compiling and installing the code, please check the [FAQs](https://mir-group.github.io/flare/installation/install.html#trouble-shooting) to see if your problem is covered. Otherwise, please open an issue or contact us.
 
 ## System requirements
 ### Software dependencies

--- a/docs/source/installation/install.rst
+++ b/docs/source/installation/install.rst
@@ -5,29 +5,41 @@ Installation of FLARE
 Requirements
 ************
 
-If you're installing on a compute cluster, make sure to load the following modules first:
+1. Create a new conda environment to install flare
 
 .. code-block:: bash
 
-    module load cmake/3.17.3-fasrc01 python/3.6.3-fasrc01 gcc/9.3.0-fasrc01
+    conda create --name flare python=3.8
+    conda activate flare
 
-**********************
-Installation using pip
-**********************
+2. Use conda to install compilers and dependencies for flare
 
-Pip can automatically fetch the source code from PyPI_ and install.
-
-.. code-block:: bash
-
-  $ pip install mir-flare
-
-For non-admin users
-
-.. code-block:: bash
-
-  $ pip install --upgrade --user mir-flare
+* Option 1: If you want to install flare with mkl
     
-.. _PyPI: https://pypi.org/project/mir-flare/
+.. code-block:: bash
+
+    conda install -y gcc gxx cmake mkl-devel mkl-service openmp -c conda-forge
+    
+* Option 2: If you want to install flare with openblas + lapacke
+    
+.. code-block:: bash
+
+    conda install -y gcc gxx cmake openmp liblapacke openblas -c conda-forge
+
+* Option 3: You can load modules if your machine have already installed them
+
+.. code-block:: bash
+
+    module load cmake/3.17.3 gcc/9.3.0 intel-mkl/2017.2.174
+
+3. Download flare code from github repo and pip install 
+
+.. code-block:: bash
+
+    git clone -b development https://github.com/mir-group/flare.git
+    cd flare
+    pip install .
+
 
 ******************************
 Developer's installation guide
@@ -58,6 +70,42 @@ Finally, add the path of ``flare`` to ``PYTHONPATH``, such that you can ``import
     export PYTHONPATH=${PYTHONPATH}:<current_dir>
 
 An alternative way is setting ``sys.path.append(<flare path>)`` in your python script.
+
+
+***********************
+Test FLARE installation
+***********************
+
+After the installation is done, you can leave the current folder and in the python console, try
+
+.. code-block:: ipython
+
+    >>> import flare
+    >>> flare.__file__
+    '/xxx/.conda/envs/flare/lib/python3.8/site-packages/flare/__init__.py'
+    >>> import flare.bffs.sgp
+
+You can also check that the flare C++ library is linked to mkl (or openblas and lapacke) and openmp by
+
+.. code-block:: bash
+
+    ldd /xxx/.conda/envs/flare/lib/python3.8/site-packages/flare/bffs/sgp/_C_flare.*.so
+
+where it is expected to show libmkl (or libopenblas), libgomp etc.
+
+****************
+Trouble shooting
+****************
+
+* If it fails to build mir-flare during pip install, check whether you have done `conda install cxx-compiler`, then it sometimes does not find the correct g++, i.e. `which gcc` gives the conda’s gcc, while `which g++` still gives the local one. In such case, try `conda uninstall cxx-compiler gxx`, and then redo `conda install gxx -c conda-forge`
+
+* If you get the error that `mkl.h` is not found during pip install, first check `conda list` that `mkl-include` is installed in the current environment. You can also use your own mkl headers by setting environment variable `MKL_INCLUDE` to the directory
+
+* If you manage to install flare, but get warning when `import flare.bffs.sgp`, then please check
+
+    * `which pip` should show that `pip` is in the `.conda/envs/flare/bin/` directory, instead of others
+
+    * the `ldd` command above should show the linked libraries in the `.conda/envs/flare` directory
 
 
 *****************************************

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy >=1.18, <=1.20.3
+numpy >=1.18
 scipy
 memory_profiler
 numba

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy >=1.18
+numpy >=1.18, <1.23
 scipy
 memory_profiler
 numba


### PR DESCRIPTION
This PR allows to installing flare without loading any modules, thus avoid the case where users have different module version on different clusters that might cause various compatibility issues. 

Three small changes are made in this PR:
- Add python 3.8 to the cmake file
- Add Conda's `include` folder into the search directories in cmake, such that the header files (e.g. `mkl.h`) installed by conda can be found. 
- Increase numpy version upper bound to 1.22 (1.23 has compatibility issue with numba)

---
The compiler tools and libraries required by the flare c++ code are installed by conda, instead of loading from modules. The new installation recipe is as below:

1. Create a new conda env with python<=3.8
```bash
conda create --name flare python=3.8
conda activate flare
```

2. Install compilers and libraries
    - Option 1: If you want to install flare with mkl
    ```bash
    conda install -y gcc gxx cmake mkl-devel mkl-service openmp -c conda-forge
    ```
    - Option 2: If you want to install flare with openblas + lapacke
    ```bash
    conda install -y gcc gxx cmake openmp liblapacke openblas -c conda-forge
    ```

3. Install flare
```bash
git clone -b development https://github.com/mir-group/flare.git
cd flare
pip install .
```