### PR TITLE
add checks for ase calculators with no stress tensor property impleme…

### DIFF
--- a/flare/io/output.py
+++ b/flare/io/output.py
@@ -280,18 +280,18 @@ class Output:
         # Check if we need to report the stress and pressure tensors
         try:
             if type(structure.stress) == np.ndarray:
-                periodic = True
+                stress_exist = True
         except PropertyNotImplementedError:
-            periodic = False
+            stress_exist = False
 
         # Report cell if stress attribute is present.
-        if periodic and structure.stress is not None:
+        if stress_exist and structure.stress is not None:
             string += "Periodic cell (A): \n"
             string += str(np.array(structure.cell)) + "\n\n"
 
         # Report stress tensor.
         pressure = None
-        if periodic and structure.stress is not None:
+        if stress_exist and structure.stress is not None:
             stress_tensor = structure.stress * eva_to_gpa  # Convert to GPa
             s8 = " " * 8
             string += "Stress tensor (GPa):\n"
@@ -315,7 +315,7 @@ class Output:
             pressure = (stress_tensor[0] + stress_tensor[1] + stress_tensor[2]) / 3
 
         # Report stress tensor uncertainties.
-        if periodic and structure.stress_stds is not None:
+        if stress_exist and structure.stress_stds is not None:
             stress_stds = structure.stress_stds * eva_to_gpa  # Convert to GPa
             string += "Stress tensor uncertainties (GPa):\n"
             for p in range(6):

--- a/flare/learners/otf.py
+++ b/flare/learners/otf.py
@@ -29,6 +29,7 @@ from flare.md.lammps import LAMMPS_MD, check_sgp_match
 from flare.md.fake import FakeMD
 from ase import units
 from ase.io import read, write
+from ase.calculators.calculator import PropertyNotImplementedError
 
 from flare.io.output import Output, compute_mae
 from flare.learners.utils import is_std_in_bound, get_env_indices
@@ -462,7 +463,13 @@ class OTF:
         # call dft and update positions
         self.run_dft()
         dft_frcs = deepcopy(self.atoms.forces)
-        dft_stress = deepcopy(self.atoms.stress)
+
+        # some ase calculators don't have the stress property implemented
+        try:
+            dft_stress = deepcopy(self.atoms.stress)
+        except PropertyNotImplementedError:
+            dft_stress = None
+
         dft_energy = self.atoms.potential_energy
 
         self.update_temperature()


### PR DESCRIPTION
## Summary

* Add fixes for when stress is still calculated despite user indication that `stress_training = False`
* Import PropertyNotImplementedError from ase for readability