### PR TITLE
Fix pickling errors of CP2K within OTF training 

### DIFF
--- a/.github/workflows/flare.yml
+++ b/.github/workflows/flare.yml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         omp: [OFF, ON]
         lapack: [OFF, ON]
-    name: "(OpenMP, Lapack) ="
+        python-version: ["3.7", "3.8"]
+    name: "(OpenMP, Lapack, Python) ="
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -30,6 +31,10 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install Sphinx and Breathe
       run: |
@@ -90,7 +95,7 @@ jobs:
     - name: Install LAMMPS
       run: |
         git clone --depth 1 https://github.com/lammps/lammps.git lammps
-        
+
         cd lammps/src
         cp pair_hybrid.* pair_lj_cut.* ..
         rm pair_*.cpp pair_*.h
@@ -103,7 +108,7 @@ jobs:
         rm KOKKOS/pair_*.*
         mv pair_kokkos.* KOKKOS/
         cd ../..
-       
+
         cd lammps_plugins
         ./install.sh $(pwd)/../lammps
         cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,34 +84,12 @@ include_directories(${SOURCE_DIR})
 
 # pybind11
 ###############################################################################
-ExternalProject_Add(
-    pybind11_project
-    SOURCE_DIR "${CMAKE_BINARY_DIR}/External/pybind11"
-    URL "https://github.com/pybind/pybind11/archive/v2.3.0.tar.gz"
-    URL_HASH MD5=e2120c5b0e3c20a93f2dfcdc55026ba8
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
+FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11
 )
-if (NOT FLARE_PYTHON_VERSION)
-    set(Python_ADDITIONAL_VERSIONS 3.8 3.7 3.6 3.5)
-endif()
-find_package(PythonLibsNew ${FLARE_PYTHON_VERSION} REQUIRED)
-
-add_library(pybind11 INTERFACE)
-ExternalProject_Get_Property(pybind11_project SOURCE_DIR)
-target_include_directories(pybind11 SYSTEM INTERFACE ${SOURCE_DIR}/include)
-target_include_directories(pybind11 SYSTEM INTERFACE ${PYTHON_INCLUDE_DIRS})
-
-if(APPLE)
-      TARGET_LINK_LIBRARIES(pybind11 INTERFACE "-undefined dynamic_lookup")
-      message(STATUS "Building in conda environment on MAC")
-else()
-      target_link_libraries(pybind11 INTERFACE ${PYTHON_LIBRARIES})
-endif()
-
-# Greatly reduces the code bloat
-target_compile_options(pybind11 INTERFACE "-fvisibility=hidden")
+FetchContent_MakeAvailable(pybind11)
 ###############################################################################
 
 # Specify source files.
@@ -204,11 +182,8 @@ else()
 endif()
 
 # Create pybind module.
-add_library(flare_module SHARED ${PYBIND_SOURCES})
-target_link_libraries(flare_module PUBLIC flare pybind11)
-set_target_properties(flare_module PROPERTIES PREFIX "${PYTHON_MODULE_PREFIX}"
-                                              SUFFIX "${PYTHON_MODULE_EXTENSION}")
-add_dependencies(flare_module pybind11_project)
+pybind11_add_module(flare_module ${PYBIND_SOURCES})
+target_link_libraries(flare_module PUBLIC flare)
 set_target_properties(flare_module PROPERTIES OUTPUT_NAME "_C_flare")
 
 # Add test directory.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://github.com/mir-group/flare/actions/workflows/main.yml/badge.svg)](https://github.com/mir-group/flare/actions) [![documentation](https://readthedocs.org/projects/flare/badge/?version=latest)](https://readthedocs.org/projects/flare) [![pypi](https://img.shields.io/pypi/v/mir-flare)](https://pypi.org/project/mir-flare/) [![activity](https://img.shields.io/github/commit-activity/m/mir-group/flare)](https://github.com/mir-group/flare/commits/master) [![codecov](https://codecov.io/gh/mir-group/flare/branch/master/graph/badge.svg)](https://codecov.io/gh/mir-group/flare)
+[![Build Status](https://github.com/mir-group/flare/actions/workflows/flare.yml/badge.svg)](https://github.com/mir-group/flare/actions) [![pypi](https://img.shields.io/pypi/v/mir-flare)](https://pypi.org/project/mir-flare/) [![activity](https://img.shields.io/github/commit-activity/m/mir-group/flare)](https://github.com/mir-group/flare/commits/master) [![codecov](https://codecov.io/gh/mir-group/flare/branch/master/graph/badge.svg)](https://codecov.io/gh/mir-group/flare)
+
+***NOTE: This is the latest release [1.3.3](https://github.com/mir-group/flare/releases/tag/1.3.3) which includes significant changes compared to the previous version [0.2.4](https://github.com/mir-group/flare/releases/tag/0.2.4). Please check the updated tutorials and documentations from the links below.***
 
 # FLARE: Fast Learning of Atomistic Rare Events
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,6 +55,8 @@ extensions = [
 breathe_projects = {"flare_pp": "xml"}
 breathe_default_project = "flare_pp"
 breathe_default_members = ("members", "undoc-members")
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
 napoleon_use_param = False
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/flare/learners/learners.rst
+++ b/docs/source/flare/learners/learners.rst
@@ -5,5 +5,6 @@ Bayesian Active Learning
    :maxdepth: 2
 
    otf
+   lmpotf
    gp_from_aimd
    utils

--- a/docs/source/flare/learners/lmpotf.rst
+++ b/docs/source/flare/learners/lmpotf.rst
@@ -1,0 +1,5 @@
+On-the-Fly Training in LAMMPS
+=============================
+
+.. automodule:: flare.learners.lmpotf
+    :members:

--- a/flare/learners/lmpotf.py
+++ b/flare/learners/lmpotf.py
@@ -1,0 +1,302 @@
+from lammps import lammps
+import ase, os, numpy as np, sys
+from typing import Union, Optional, Callable, Any, List
+from flare.bffs.sgp._C_flare import Structure, SparseGP
+from flare.bffs.sgp.sparse_gp import optimize_hyperparameters
+import logging
+import time
+
+
+def transform_stress(stress: List[List[float]]) -> List[List[float]]:
+    return -np.array(
+        [
+            stress[(0, 0)],
+            stress[(0, 1)],
+            stress[(0, 2)],
+            stress[(1, 1)],
+            stress[(1, 2)],
+            stress[(2, 2)],
+        ]
+    )
+
+
+class LMPOTF:
+    """
+    Module for performing On-The-Fly (OTF) training, also known as active learning,
+    entirely within LAMMPS.
+
+    Parameters
+    ----------
+    sparse_gp
+        The :cpp:class:`SparseGP` object to train.
+    descriptors
+        A list of descriptor objects, or a single descriptor (most common), e.g. :cpp:class:`B2`.
+    rcut
+        The interaction cut-off radius.
+    type2number
+        The atomic numbers of all LAMMPS types.
+    dftcalc
+        An ASE calculator, e.g. Espresso.
+    energy_correction
+        Per-type corrections to the DFT potential energy.
+    dft_call_threshold
+        Uncertainty threshold for whether to call DFT.
+    dft_add_threshold
+        Uncertainty threshold for whether to add an atom to the training set.
+    dft_xyz_fname
+        Name of the file in which to save the DFT results.
+        Should contain '*', which will be replaced with the current step.
+    std_xyz_fname
+        Name of the file in which to save ASE Atoms with per-atom uncertainties as charges.
+        Should contain '*', which will be replaced with the current step.
+    model_fname
+        Name of the saved model, must correspond to `pair_coeff`.
+    hyperparameter_optimization
+        Boolean function that determines whether to run hyperparameter optimization, as a function of this LMPOTF
+        object, the LAMMPS instance and the current step.
+    opt_bounds
+        Bounds for the hyperparameter optimization.
+    opt_method
+        Algorithm for the hyperparameter optimization.
+    opt_iterations
+        Max number of iterations for the hyperparameter optimization.
+    post_dft_callback
+        A function that is called after every DFT call. Receives this LMPOTF object and the current step.
+    wandb
+        The wandb object, which should already be initialized.
+    log_fname
+        An output file to which logging info is written.
+    """
+
+    def __init__(
+        self,
+        sparse_gp: SparseGP,
+        descriptors: List,
+        rcut: float,
+        type2number: Union[(int, List[int])],
+        dftcalc: object,
+        energy_correction: List[float] = 0.0,
+        force_training=True,
+        energy_training=True,
+        stress_training=True,
+        dft_call_threshold: float = 0.005,
+        dft_add_threshold: float = 0.0025,
+        dft_xyz_fname: Optional[str] = None,
+        std_xyz_fname: Optional[str] = None,
+        model_fname: str = "otf.flare",
+        hyperparameter_optimization: Callable[
+            (["LMPOTF", object, int], bool)
+        ] = lambda lmpotf, lmp, step: False,
+        opt_bounds: Optional[List[float]] = None,
+        opt_method: Optional[str] = "L-BFGS-B",
+        opt_iterations: Optional[int] = 50,
+        post_dft_callback: Callable[(["LMPOTF", int], None)] = lambda lmpotf, step: 0,
+        wandb: object = None,
+        log_fname: str = "otf.log",
+    ) -> object:
+        """
+
+        """
+        self.sparse_gp = sparse_gp
+        self.descriptors = np.atleast_1d(descriptors)
+        self.rcut = rcut
+        self.type2number = np.atleast_1d(type2number)
+        self.ntypes = len(self.type2number)
+        self.energy_correction = np.atleast_1d(energy_correction)
+        assert len(self.energy_correction) == self.ntypes
+        self.dftcalc = dftcalc
+        self.dft_call_threshold = dft_call_threshold
+        self.dft_add_threshold = dft_add_threshold
+        self.post_dft_callback = post_dft_callback
+        self.force_training = force_training
+        self.energy_training = energy_training
+        self.stress_training = stress_training
+        self.dft_calls = 0
+        self.last_dft_call = -100
+        self.dft_xyz_fname = dft_xyz_fname
+        self.std_xyz_fname = std_xyz_fname
+        self.model_fname = model_fname
+        self.hyperparameter_optimization = hyperparameter_optimization
+        self.opt_bounds = opt_bounds
+        self.opt_method = opt_method
+        self.opt_iterations = opt_iterations
+        self.wandb = wandb
+        logging.basicConfig(
+            filename=log_fname, level=(logging.DEBUG), format="%(asctime)s: %(message)s"
+        )
+        self.logger = logging.getLogger("lmpotf")
+
+        self.time_dft = 0.0
+        self.time_hyp_opt = 0.0
+        self.time_training = 0.0
+        self.time_predict_uncertainties = 0.0
+        self.time_prediction = 0.0
+
+    def save(self, fname):
+        self.sparse_gp.write_mapping_coefficients(fname, "LMPOTF", 0)
+
+    def step(self, lmpptr, evflag=0):
+        """
+        Function called by LAMMPS at every step.
+        This is the function that must be called by `fix python/invoke`.
+
+        Parameters
+        ----------
+        lmpptr : ptr
+            Pointer to running LAMMPS instance.
+        evflag : int
+            evflag given by LAMMPS, ignored.
+        """
+        try:
+            lmp = lammps(ptr=lmpptr)
+            natoms = lmp.get_natoms()
+            x = lmp.gather_atoms("x", 1, 3)
+            x = np.ctypeslib.as_array(x, shape=(natoms, 3)).reshape(natoms, 3)
+            step = int(lmp.get_thermo("step"))
+            boxlo, boxhi, xy, yz, xz, _, _ = lmp.extract_box()
+            cell = np.diag(np.array(boxhi) - np.array(boxlo))
+            cell[(1, 0)] = xy
+            cell[(2, 0)] = xz
+            cell[(2, 1)] = yz
+            types = lmp.gather_atoms("type", 0, 1)
+            types = np.ctypeslib.as_array(types, shape=natoms)
+            structure = Structure(cell, types - 1, x, self.rcut, self.descriptors)
+            if self.dft_calls == 0:
+                self.logger.info("Initial step, calling DFT")
+                pe, F = self.run_dft(cell, x, types, step, structure)
+                t0 = time.time()
+                self.sparse_gp.add_training_structure(structure)
+                self.sparse_gp.add_random_environments(structure, [int(natoms/4)])
+                self.sparse_gp.update_matrices_QR()
+                self.time_training += time.time() - t0
+                self.save(self.model_fname)
+            else:
+                self.logger.info(f"Step {step}")
+                sigma = self.sparse_gp.hyperparameters[0]
+                t0 = time.time()
+                self.sparse_gp.predict_local_uncertainties(structure)
+                self.time_predict_uncertainties += time.time() - t0
+                variances = structure.local_uncertainties[0]
+                stds = np.sqrt(np.abs(variances)) / sigma
+                if self.std_xyz_fname is not None:
+                    frame = ase.Atoms(
+                        positions=x,
+                        numbers=(self.type2number[types - 1]),
+                        cell=cell,
+                        pbc=True,
+                    )
+                    frame.set_array("charges", stds)
+                    ase.io.write(self.std_xyz_fname.replace("*", str(step)), frame, format="extxyz")
+                wandb_log = {"max_uncertainty": np.amax(stds)}
+                self.logger.info(f"Max uncertainty: {np.amax(stds)}")
+                call_dft = np.any(stds > self.dft_call_threshold)
+                if call_dft:
+                    t0 = time.time()
+                    self.sparse_gp.predict_DTC(structure)
+                    self.time_prediction += time.time() - t0
+                    predE = structure.mean_efs[0]
+                    predF = structure.mean_efs[1:-6].reshape((-1, 3))
+                    predS = structure.mean_efs[-6:]
+                    Fstd = np.sqrt(np.abs(structure.variance_efs[1:-6])).reshape(
+                        (-1, 3)
+                    )
+                    Estd = np.sqrt(np.abs(structure.variance_efs[0]))
+                    Sstd = np.sqrt(np.abs(structure.variance_efs[-6:]))
+                    wandb_log["max_F_uncertainty"] = np.amax(Fstd)
+                    self.logger.info(f"Max force uncertainty: {np.amax(Fstd)}")
+                    self.logger.info(f"DFT call #{self.dft_calls}")
+                    pe, F = self.run_dft(cell, x, types, step, structure)
+                    atoms_to_be_added = np.arange(natoms)[stds > self.dft_add_threshold]
+                    t0 = time.time()
+                    self.sparse_gp.add_training_structure(structure)
+                    self.sparse_gp.add_specific_environments(
+                        structure, atoms_to_be_added
+                    )
+                    self.sparse_gp.update_matrices_QR()
+                    self.time_training += time.time() - t0
+                    if self.hyperparameter_optimization(self, lmp, step):
+                        self.logger.info("Optimizing hyperparameters!")
+                        self.sparse_gp.compute_likelihood_stable()
+                        likelihood_before = self.sparse_gp.log_marginal_likelihood
+                        t0 = time.time()
+                        optimize_hyperparameters(
+                            (self.sparse_gp),
+                            bounds=(self.opt_bounds),
+                            method=(self.opt_method),
+                            max_iterations=(self.opt_iterations),
+                        )
+                        self.time_hyp_opt += time.time() - t0
+                        likelihood_after = self.sparse_gp.log_marginal_likelihood
+                        self.logger.info(
+                            f"Likelihood before/after: {likelihood_before:.2e} {likelihood_after:.2e}"
+                        )
+                        self.logger.info(
+                            f"Likelihood gradient: {self.sparse_gp.likelihood_gradient}"
+                        )
+                        self.logger.info(
+                            f"Hyperparameters: {self.sparse_gp.hyperparameters}"
+                        )
+                    self.save(self.model_fname)
+                    lmp.command(f"pair_coeff * * {self.model_fname}")
+                    wandb_log["Fmae"] = np.mean(np.abs(F - predF))
+                    wandb_log["Emae"] = np.abs(pe - predE) / natoms
+                    wandb_log["n_added"] = len(atoms_to_be_added)
+                    for qty in ("n_added", "Fmae", "Emae"):
+                        self.logger.info(f"{qty}: {wandb_log[qty]}")
+
+                if self.wandb is not None:
+                    wandb_log["uncertainties"] = self.wandb.Histogram(stds)
+                    wandb_log["Temp"] = lmp.get_thermo("temp")
+                    wandb_log["Press"] = lmp.get_thermo("press")
+                    wandb_log["PotEng"] = lmp.get_thermo("pe")
+                    wandb_log["Vol"] = lmp.get_thermo("vol")
+                    wandb_log["time_dft"] = self.time_dft
+                    wandb_log["time_training"] = self.time_training
+                    wandb_log["time_prediction"] = self.time_prediction
+                    wandb_log["time_predict_uncertainties"] = self.time_predict_uncertainties
+                    wandb_log["time_hyp_opt"] = self.time_hyp_opt
+                    if call_dft:
+                        wandb_log["Funcertainties"] = self.wandb.Histogram(Fstd.ravel())
+                        wandb_log["Ferror"] = self.wandb.Histogram(
+                            np.abs(F - predF).ravel()
+                        )
+                        wandb_log["logrelFerror"] = self.wandb.Histogram(
+                            np.log10(np.abs(F - predF)/np.abs(F)).ravel()
+                        )
+                    self.wandb.log(wandb_log, step=step)
+        except Exception as err:
+            try:
+                self.logger.exception("LMPOTF ERROR")
+                raise err
+            finally:
+                err = None
+                del err
+
+    def run_dft(self, cell, x, types, step, structure):
+        t0 = time.time()
+        atomic_numbers = self.type2number[types - 1]
+        frame = ase.Atoms(
+            positions=x,
+            numbers=atomic_numbers,
+            cell=cell,
+            calculator=(self.dftcalc),
+            pbc=True,
+        )
+        pe = frame.get_potential_energy()
+        pe -= np.sum(self.energy_correction[types - 1])
+        F = frame.get_forces()
+        stress = frame.get_stress(voigt=False)
+        if self.dft_xyz_fname is not None:
+            ase.io.write(self.dft_xyz_fname.replace("*", str(step)), frame, format="extxyz")
+        if self.force_training:
+            structure.forces = F.reshape(-1)
+        if self.energy_training:
+            structure.energy = np.array([pe])
+        if self.stress_training:
+            structure.stresses = transform_stress(stress)
+        self.dft_calls += 1
+        self.last_dft_call = step
+        self.post_dft_callback(self, step)
+
+        self.time_dft += time.time() - t0
+        return (pe, F)

--- a/flare/learners/otf.py
+++ b/flare/learners/otf.py
@@ -30,6 +30,7 @@ from flare.md.fake import FakeMD
 from ase import units
 from ase.io import read, write
 from ase.calculators.calculator import PropertyNotImplementedError
+from ase.calculators.cp2k import CP2K
 
 from flare.io.output import Output, compute_mae
 from flare.learners.utils import is_std_in_bound, get_env_indices
@@ -156,6 +157,10 @@ class OTF:
     ):
 
         self.atoms = FLARE_Atoms.from_ase_atoms(atoms)
+
+        # save ase atoms for later temporary generation of CP2K calculator
+        self.ase_atoms = deepcopy(atoms)
+
         if flare_calc is not None:
             self.atoms.calc = flare_calc
         self.md_engine = md_engine
@@ -186,7 +191,7 @@ class OTF:
             if isinstance(self.atoms.calc, SGP_Calculator):
                 assert self.atoms.calc.gp_model.variance_type == "local", \
                         "LAMMPS training only supports variance_type='local'"
-            
+
         self.md = MD(
             atoms=self.atoms, timestep=timestep, trajectory=trajectory, **md_kwargs
         )
@@ -578,6 +583,23 @@ class OTF:
         f = logging.getLogger(self.output.basename + "log")
         f.info("\nCalling DFT...\n")
 
+        # CP2K calculators cannot be pickled; solution is to just create a new instance
+        if type(self.dft_calc) == CP2K:
+            self.dft_calc.atoms = self.ase_atoms
+            self.dft_calc.write("tmp-cp2k")
+
+            # now re-initiate the CP2K calculator
+            cp2k_command = os.getenv('ASE_CP2K_COMMAND').split()[-1].split(os.sep)[-1]
+            self.atoms.calc = CP2K(restart="tmp-cp2k", command = cp2k_command)
+            self.atoms.calc.calculate(atoms=self.ase_atoms, properties=['forces', 'energy', 'stress'])
+            self.atoms.calc = deepcopy(self.ase_atoms)
+
+            # remove temporarily-generated file
+            os.remove("tmp-cp2k_params.ase")
+
+        else:
+            self.atoms.calc = deepcopy(self.dft_calc)
+
         # change from FLARE to DFT calculator
         self.atoms.calc = deepcopy(self.dft_calc)
 
@@ -849,6 +871,10 @@ class OTF:
         self.gp = None
         self.atoms.calc = None
 
+        # CP2K calculator isn't picklable. Temporarily set to None before copying.
+        cp2k_calc = self.dft_calc
+        self.dft_calc = None
+
         # Deepcopy OTF object.
         dct = deepcopy(dict(vars(self)))
 
@@ -870,7 +896,7 @@ class OTF:
         try:
             with open(self.dft_name, "wb") as f:
                 pickle.dump(self.dft_calc, f)
-        except AttributeError:
+        except (AttributeError, TypeError):
             with open(self.dft_name + ".json", "w") as f:
                 json.dump(self.dft_calc.todict(), f, cls=NumpyEncoder)
 

--- a/flare/learners/otf.py
+++ b/flare/learners/otf.py
@@ -189,8 +189,9 @@ class OTF:
         if self.md_engine == "PyLAMMPS":
             md_kwargs["output_name"] = output_name
             if isinstance(self.atoms.calc, SGP_Calculator):
-                assert self.atoms.calc.gp_model.variance_type == "local", \
-                        "LAMMPS training only supports variance_type='local'"
+                assert (
+                    self.atoms.calc.gp_model.variance_type == "local"
+                ), "LAMMPS training only supports variance_type='local'"
 
         self.md = MD(
             atoms=self.atoms, timestep=timestep, trajectory=trajectory, **md_kwargs
@@ -232,7 +233,9 @@ class OTF:
         if init_atoms is None:  # set atom list for initial dft run
             self.init_atoms = [int(n) for n in range(self.noa)]
         elif isinstance(init_atoms, int):
-            self.init_atoms = np.random.choice(len(self.atoms), size=init_atoms, replace=False)
+            self.init_atoms = np.random.choice(
+                len(self.atoms), size=init_atoms, replace=False
+            )
         else:
             # detect if there are duplicated atoms
             assert len(set(init_atoms)) == len(
@@ -428,7 +431,7 @@ class OTF:
                                 "dft_s_mae": s_mae,
                                 "dft_s_mav": s_mav,
                             },
-                            step = self.curr_step,
+                            step=self.curr_step,
                         )
 
             # write gp forces
@@ -589,9 +592,11 @@ class OTF:
             self.dft_calc.write("tmp-cp2k")
 
             # now re-initiate the CP2K calculator
-            cp2k_command = os.getenv('ASE_CP2K_COMMAND').split()[-1].split(os.sep)[-1]
-            self.atoms.calc = CP2K(restart="tmp-cp2k", command = cp2k_command)
-            self.atoms.calc.calculate(atoms=self.ase_atoms, properties=['forces', 'energy', 'stress'])
+            cp2k_command = os.getenv("ASE_CP2K_COMMAND").split()[-1].split(os.sep)[-1]
+            self.atoms.calc = CP2K(restart="tmp-cp2k", command=cp2k_command)
+            self.atoms.calc.calculate(
+                atoms=self.ase_atoms, properties=["forces", "energy", "stress"]
+            )
             self.atoms.calc = deepcopy(self.ase_atoms)
 
             # remove temporarily-generated file
@@ -813,14 +818,14 @@ class OTF:
                     "ke": self.KE,
                     "pe": self.atoms.get_potential_energy(),
                 },
-                step = self.curr_step,
+                step=self.curr_step,
             )
             if "stds" in self.atoms.calc.results:
                 wandb.log(
                     {
                         "maxunc": np.max(np.abs(self.atoms.calc.results["stds"])),
                     },
-                    step = self.curr_step,
+                    step=self.curr_step,
                 )
 
         if self.md_engine == "Fake" and not self.dft_step:
@@ -849,9 +854,8 @@ class OTF:
                         "s_mae": s_mae,
                         "s_mav": s_mav,
                     },
-                    step = self.curr_step,
+                    step=self.curr_step,
                 )
-
 
     def record_dft_data(self, structure, target_atoms):
         structure.info["target_atoms"] = np.array(target_atoms)

--- a/lammps_plugins/compute_flare_std_atom.cpp
+++ b/lammps_plugins/compute_flare_std_atom.cpp
@@ -405,6 +405,7 @@ void ComputeFlareStdAtom::read_file(char *filename) {
   MPI_Bcast(&cutoff, 1, MPI_DOUBLE, 0, world);
   MPI_Bcast(&radial_string_length, 1, MPI_INT, 0, world);
   MPI_Bcast(&cutoff_string_length, 1, MPI_INT, 0, world);
+  MPI_Bcast(&kernel_string_length, 1, MPI_INT, 0, world);
   MPI_Bcast(radial_string, radial_string_length + 1, MPI_CHAR, 0, world);
   MPI_Bcast(cutoff_string, cutoff_string_length + 1, MPI_CHAR, 0, world);
   MPI_Bcast(kernel_string, kernel_string_length + 1, MPI_CHAR, 0, world);
@@ -530,6 +531,7 @@ void ComputeFlareStdAtom::read_L_inverse(char *filename) {
   MPI_Bcast(&l_max, 1, MPI_INT, 0, world);
   MPI_Bcast(&n_kernels, 1, MPI_INT, 0, world);
   MPI_Bcast(&cutoff, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&kernel_string_length, 1, MPI_INT, 0, world);
   MPI_Bcast(&radial_string_length, 1, MPI_INT, 0, world);
   MPI_Bcast(&cutoff_string_length, 1, MPI_INT, 0, world);
   MPI_Bcast(radial_string, radial_string_length + 1, MPI_CHAR, 0, world);

--- a/lammps_plugins/kokkos/pair_flare_kokkos.cpp
+++ b/lammps_plugins/kokkos/pair_flare_kokkos.cpp
@@ -721,6 +721,12 @@ void PairFLAREKokkos<DeviceType>::coeff(int narg, char **arg)
 {
   PairFLARE::coeff(narg,arg);
 
+  if(!normalized)
+    error->all(FLERR, "for now, pair flare/kk only supports the normalized kernel");
+  if(power != 2)
+    error->all(FLERR, "for now, pair flare/kk only supports the power-2 kernel");
+  //TODO check chebyshev and quadratic
+
   n_harmonics = (l_max+1)*(l_max+1);
   n_radial = n_species * n_max;
   n_bond = n_radial * n_harmonics;
@@ -777,7 +783,7 @@ void PairFLAREKokkos<DeviceType>::init_style()
   if (memstr != NULL) {
     maxmem = std::atof(memstr) * 1.0e9;
   }
-  printf("FLARE will use up to %.2f GB of device memory, controlled by MAXMEM environment variable\n", maxmem/1.0e9);
+  if(comm->me==0 || comm->me==comm->nprocs-1) printf("FLARE will use up to %.2f GB of device memory, controlled by MAXMEM environment variable\n", maxmem/1.0e9);
 }
 
 

--- a/lammps_plugins/pair_flare.cpp
+++ b/lammps_plugins/pair_flare.cpp
@@ -364,10 +364,14 @@ void PairFLARE::read_file(char *filename) {
     cutoff_function = cos_cutoff;
 
   // Set the kernel
-  if (!strcmp(kernel_string, "NormalizedDotProduct")) {
+  if (strcmp(kernel_string, "NormalizedDotProduct") == 0) {
     normalized = true;
-  } else {
+  }
+  else if (strcmp(kernel_string, "DotProduct") == 0){
     normalized = false;
+  }
+  else {
+    error->all(FLERR, "Kernel string not recognized, expected <power> <kernel string>");
   }
 
   // Parse the beta vectors.

--- a/lammps_plugins/pair_flare.cpp
+++ b/lammps_plugins/pair_flare.cpp
@@ -193,9 +193,15 @@ void PairFLARE::allocate() {
 
   memory->create(setflag, n + 1, n + 1, "pair:setflag");
 
-  // Set the diagonal of setflag to 1 (otherwise pair.cpp will throw an error)
+  // Set the entire setflag to 1 (otherwise pair.cpp will throw an error)
+  // off-diagonal needed for hybrid/overlay (note: we only support pair_coeff * *)
   for (int i = 1; i <= n; i++)
-    setflag[i][i] = 1;
+    for (int j = 1; j <= n; j++)
+      setflag[i][j] = 1;
+
+  // Create cutsq array (used in pair.cpp)
+  memory->create(cutsq, n + 1, n + 1, "pair:cutsq");
+
 }
 
 /* ----------------------------------------------------------------------

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -143,7 +143,7 @@ def test_lammps_uncertainty(
     if n_species > n_types:
         pytest.skip()
 
-    if (power == 1) and ("kokkos" in os.environ.get("lmp")):
+    if (power == 1 or kernel_type=="DotProduct") and ("kokkos" in os.environ.get("lmp")):
         pytest.skip()
 
     os.chdir(rootdir)
@@ -211,7 +211,7 @@ pair_coeff * * {potential_file}
 ### run
 fix fix_nve all nve
 compute unc all flare/std/atom {coeff_str}
-dump dump_all all custom 1 traj.lammps id type x y z vx vy vz fx fy fz c_unc 
+dump dump_all all custom 1 traj.lammps id type x y z vx vy vz fx fy fz c_unc
 dump_modify dump_all sort id
 thermo_style custom step temp press cpu pxx pyy pzz pxy pxz pyz ke pe etotal vol lx ly lz atoms
 thermo_modify flush yes format float %23.16g


### PR DESCRIPTION
## Summary

Add fixes to `otf.py` to integrate CP2K with FLARE. Also may address issue 47 in flare_pp: https://github.com/mir-group/flare_pp/issues/47 

* Fix 1: Replace deepcopy with temporarily-generated instance of CP2K 
* Fix 2: Fix dump of dft calculator.  

## TODO (if any)

* Fix 2 supports write_mode = 0 in `train.yaml` and has not been tested for other write modes
* Fixes 1 and 2 work with CP2K versions 6.1 and 2023.1. 

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [Black](https://pypi.org/project/black/) on your local machine.
- [] Docstrings have been added in the [Sphinx docstring format](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html).
- [x] Type annotations are **highly** encouraged.
- [ ] Tests have been added for any new functionality or bug fixes.
- [ ] All existing tests pass.
- [ ] The version number in `flare/_version.py` is updated. We are using a version number format a.b.c
    - If this PR fixes bugs, update version number to a.b.c+1
    - If this PR adds new features, update version number to a.b+1.0
    - If this PR includes significant changes in framework or interface, update version number to a+1.0.0

Note that the CI system will run all the above checks. But it will be much more efficient if you already fix most errors prior to submitting the PR.