### PR TITLE
Fix pickling errors of CP2K within OTF training

### DIFF
--- a/.github/workflows/flare.yml
+++ b/.github/workflows/flare.yml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         omp: [OFF, ON]
         lapack: [OFF, ON]
-    name: "(OpenMP, Lapack) ="
+        python-version: ["3.7", "3.8"]
+    name: "(OpenMP, Lapack, Python) ="
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -30,6 +31,10 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install Sphinx and Breathe
       run: |
@@ -90,7 +95,7 @@ jobs:
     - name: Install LAMMPS
       run: |
         git clone --depth 1 https://github.com/lammps/lammps.git lammps
-        
+
         cd lammps/src
         cp pair_hybrid.* pair_lj_cut.* ..
         rm pair_*.cpp pair_*.h
@@ -103,7 +108,7 @@ jobs:
         rm KOKKOS/pair_*.*
         mv pair_kokkos.* KOKKOS/
         cd ../..
-       
+
         cd lammps_plugins
         ./install.sh $(pwd)/../lammps
         cd ..

--- a/.github/workflows/flare.yml
+++ b/.github/workflows/flare.yml
@@ -36,35 +36,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install Sphinx and Breathe
-      run: |
-        sudo apt-get update
-        sudo apt-get install python3-sphinx python3-sphinx-rtd-theme python3-breathe python3-nbsphinx
-
-    - name: Run Doxygen
-      uses: mattnotmitt/doxygen-action@v1.1.0
-      with:
-        # Path to Doxyfile
-        doxyfile-path: "./Doxyfile" # default is ./Doxyfile
-        # Working directory
-        working-directory: "./docs" # default is .
-
-    - name: Run Sphinx
-      run: |
-        cd docs
-        pwd
-        ls
-        make html
-
-    - name: Publish the docs
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        # Default Doxyfile build documentation to html directory.
-        # Change the directory if changes in Doxyfile
-        publish_dir: ./docs/build/html
-      if: github.event_name == 'pull_request' && matrix.lapack == 'on' && matrix.omp == 'on'
-
     - name: Build
       run: |
         sudo apt install liblapacke liblapacke-dev
@@ -140,6 +111,35 @@ jobs:
         export lmp="$(pwd)/lammps/build/lmp -k on t 4 -sf kk -pk kokkos newton on neigh full"
         cd tests
         pytest test_lammps.py
+
+    - name: Install Sphinx and Breathe
+      run: |
+        sudo apt-get update
+        sudo apt-get install python3-sphinx python3-sphinx-rtd-theme python3-breathe python3-nbsphinx
+
+    - name: Run Doxygen
+      uses: mattnotmitt/doxygen-action@v1.1.0
+      with:
+        # Path to Doxyfile
+        doxyfile-path: "./Doxyfile" # default is ./Doxyfile
+        # Working directory
+        working-directory: "./docs" # default is .
+
+    - name: Run Sphinx
+      run: |
+        cd docs
+        pwd 
+        ls  
+        make html
+
+    - name: Publish the docs
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        # Default Doxyfile build documentation to html directory.
+        # Change the directory if changes in Doxyfile
+        publish_dir: ./docs/build/html
+      if: github.event_name == 'pull_request' && matrix.lapack == 'on' && matrix.omp == 'on'
 
 #     - name: Run tutorial
 #       run: |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://github.com/mir-group/flare/actions/workflows/main.yml/badge.svg)](https://github.com/mir-group/flare/actions) [![documentation](https://readthedocs.org/projects/flare/badge/?version=latest)](https://readthedocs.org/projects/flare) [![pypi](https://img.shields.io/pypi/v/mir-flare)](https://pypi.org/project/mir-flare/) [![activity](https://img.shields.io/github/commit-activity/m/mir-group/flare)](https://github.com/mir-group/flare/commits/master) [![codecov](https://codecov.io/gh/mir-group/flare/branch/master/graph/badge.svg)](https://codecov.io/gh/mir-group/flare)
+[![Build Status](https://github.com/mir-group/flare/actions/workflows/flare.yml/badge.svg)](https://github.com/mir-group/flare/actions) [![pypi](https://img.shields.io/pypi/v/mir-flare)](https://pypi.org/project/mir-flare/) [![activity](https://img.shields.io/github/commit-activity/m/mir-group/flare)](https://github.com/mir-group/flare/commits/master) [![codecov](https://codecov.io/gh/mir-group/flare/branch/master/graph/badge.svg)](https://codecov.io/gh/mir-group/flare)
+
+***NOTE: This is the latest release [1.3.3](https://github.com/mir-group/flare/releases/tag/1.3.3) which includes significant changes compared to the previous version [0.2.4](https://github.com/mir-group/flare/releases/tag/0.2.4). Please check the updated tutorials and documentations from the links below.***
 
 # FLARE: Fast Learning of Atomistic Rare Events
 

--- a/flare/learners/otf.py
+++ b/flare/learners/otf.py
@@ -30,6 +30,7 @@ from flare.md.fake import FakeMD
 from ase import units
 from ase.io import read, write
 from ase.calculators.calculator import PropertyNotImplementedError
+from ase.calculators.cp2k import CP2K
 
 from flare.io.output import Output, compute_mae
 from flare.learners.utils import is_std_in_bound, get_env_indices
@@ -156,6 +157,10 @@ class OTF:
     ):
 
         self.atoms = FLARE_Atoms.from_ase_atoms(atoms)
+
+        # save ase atoms for later temporary generation of CP2K calculator
+        self.ase_atoms = deepcopy(atoms)
+
         if flare_calc is not None:
             self.atoms.calc = flare_calc
         self.md_engine = md_engine
@@ -186,7 +191,7 @@ class OTF:
             if isinstance(self.atoms.calc, SGP_Calculator):
                 assert self.atoms.calc.gp_model.variance_type == "local", \
                         "LAMMPS training only supports variance_type='local'"
-            
+
         self.md = MD(
             atoms=self.atoms, timestep=timestep, trajectory=trajectory, **md_kwargs
         )
@@ -578,6 +583,25 @@ class OTF:
         f = logging.getLogger(self.output.basename + "log")
         f.info("\nCalling DFT...\n")
 
+        # CP2K calculators cannot be pickled; solution is to just create a new instance
+        if type(self.dft_calc) == CP2K:
+            self.dft_calc.atoms = self.ase_atoms
+            self.dft_calc.write("tmp-cp2k")
+
+            # now re-initiate the CP2K calculator
+            cp2k_command = os.getenv('ASE_CP2K_COMMAND').split()[-1].split(os.sep)[-1]
+            self.atoms.calc = CP2K(restart="tmp-cp2k", command = cp2k_command)
+            self.atoms.calc.calculate(
+                atoms=self.ase_atoms, properties=['forces', 'energy', 'stress']
+            )
+            self.atoms.calc = deepcopy(self.ase_atoms)
+
+            # remove temporarily-generated file
+            os.remove("tmp-cp2k_params.ase")
+
+        else:
+            self.atoms.calc = deepcopy(self.dft_calc)
+
         # change from FLARE to DFT calculator
         self.atoms.calc = deepcopy(self.dft_calc)
 
@@ -849,6 +873,12 @@ class OTF:
         self.gp = None
         self.atoms.calc = None
 
+        # DFT calculator and ASE Atoms may not be picklable. Temporarily set to None before copying.
+        dft_calc = self.dft_calc
+        self.dft_calc = None
+        ase_atoms = self.ase_atoms
+        self.ase_atoms = None
+
         # Deepcopy OTF object.
         dct = deepcopy(dict(vars(self)))
 
@@ -858,6 +888,8 @@ class OTF:
         self.flare_calc = flare_calc
         self.gp = gp
         self.atoms.calc = flare_calc
+        self.dft_calc = dft_calc
+        self.ase_atoms = ase_atoms
 
         # write atoms and flare calculator to separate files
         write(self.atoms_name, self.atoms)
@@ -870,7 +902,7 @@ class OTF:
         try:
             with open(self.dft_name, "wb") as f:
                 pickle.dump(self.dft_calc, f)
-        except AttributeError:
+        except (AttributeError, TypeError):
             with open(self.dft_name + ".json", "w") as f:
                 json.dump(self.dft_calc.todict(), f, cls=NumpyEncoder)
 

--- a/flare/learners/otf.py
+++ b/flare/learners/otf.py
@@ -189,8 +189,9 @@ class OTF:
         if self.md_engine == "PyLAMMPS":
             md_kwargs["output_name"] = output_name
             if isinstance(self.atoms.calc, SGP_Calculator):
-                assert self.atoms.calc.gp_model.variance_type == "local", \
-                        "LAMMPS training only supports variance_type='local'"
+                assert (
+                    self.atoms.calc.gp_model.variance_type == "local"
+                ), "LAMMPS training only supports variance_type='local'"
 
         self.md = MD(
             atoms=self.atoms, timestep=timestep, trajectory=trajectory, **md_kwargs
@@ -232,7 +233,9 @@ class OTF:
         if init_atoms is None:  # set atom list for initial dft run
             self.init_atoms = [int(n) for n in range(self.noa)]
         elif isinstance(init_atoms, int):
-            self.init_atoms = np.random.choice(len(self.atoms), size=init_atoms, replace=False)
+            self.init_atoms = np.random.choice(
+                len(self.atoms), size=init_atoms, replace=False
+            )
         else:
             # detect if there are duplicated atoms
             assert len(set(init_atoms)) == len(
@@ -428,7 +431,7 @@ class OTF:
                                 "dft_s_mae": s_mae,
                                 "dft_s_mav": s_mav,
                             },
-                            step = self.curr_step,
+                            step=self.curr_step,
                         )
 
             # write gp forces
@@ -589,10 +592,10 @@ class OTF:
             self.dft_calc.write("tmp-cp2k")
 
             # now re-initiate the CP2K calculator
-            cp2k_command = os.getenv('ASE_CP2K_COMMAND').split()[-1].split(os.sep)[-1]
-            self.atoms.calc = CP2K(restart="tmp-cp2k", command = cp2k_command)
+            cp2k_command = os.getenv("ASE_CP2K_COMMAND").split()[-1].split(os.sep)[-1]
+            self.atoms.calc = CP2K(restart="tmp-cp2k", command=cp2k_command)
             self.atoms.calc.calculate(
-                atoms=self.ase_atoms, properties=['forces', 'energy', 'stress']
+                atoms=self.ase_atoms, properties=["forces", "energy", "stress"]
             )
             self.atoms.calc = deepcopy(self.ase_atoms)
 
@@ -815,14 +818,14 @@ class OTF:
                     "ke": self.KE,
                     "pe": self.atoms.get_potential_energy(),
                 },
-                step = self.curr_step,
+                step=self.curr_step,
             )
             if "stds" in self.atoms.calc.results:
                 wandb.log(
                     {
                         "maxunc": np.max(np.abs(self.atoms.calc.results["stds"])),
                     },
-                    step = self.curr_step,
+                    step=self.curr_step,
                 )
 
         if self.md_engine == "Fake" and not self.dft_step:
@@ -851,9 +854,8 @@ class OTF:
                         "s_mae": s_mae,
                         "s_mav": s_mav,
                     },
-                    step = self.curr_step,
+                    step=self.curr_step,
                 )
-
 
     def record_dft_data(self, structure, target_atoms):
         structure.info["target_atoms"] = np.array(target_atoms)

--- a/lammps_plugins/compute_flare_std_atom.cpp
+++ b/lammps_plugins/compute_flare_std_atom.cpp
@@ -405,6 +405,7 @@ void ComputeFlareStdAtom::read_file(char *filename) {
   MPI_Bcast(&cutoff, 1, MPI_DOUBLE, 0, world);
   MPI_Bcast(&radial_string_length, 1, MPI_INT, 0, world);
   MPI_Bcast(&cutoff_string_length, 1, MPI_INT, 0, world);
+  MPI_Bcast(&kernel_string_length, 1, MPI_INT, 0, world);
   MPI_Bcast(radial_string, radial_string_length + 1, MPI_CHAR, 0, world);
   MPI_Bcast(cutoff_string, cutoff_string_length + 1, MPI_CHAR, 0, world);
   MPI_Bcast(kernel_string, kernel_string_length + 1, MPI_CHAR, 0, world);
@@ -530,6 +531,7 @@ void ComputeFlareStdAtom::read_L_inverse(char *filename) {
   MPI_Bcast(&l_max, 1, MPI_INT, 0, world);
   MPI_Bcast(&n_kernels, 1, MPI_INT, 0, world);
   MPI_Bcast(&cutoff, 1, MPI_DOUBLE, 0, world);
+  MPI_Bcast(&kernel_string_length, 1, MPI_INT, 0, world);
   MPI_Bcast(&radial_string_length, 1, MPI_INT, 0, world);
   MPI_Bcast(&cutoff_string_length, 1, MPI_INT, 0, world);
   MPI_Bcast(radial_string, radial_string_length + 1, MPI_CHAR, 0, world);

--- a/lammps_plugins/kokkos/pair_flare_kokkos.cpp
+++ b/lammps_plugins/kokkos/pair_flare_kokkos.cpp
@@ -721,6 +721,12 @@ void PairFLAREKokkos<DeviceType>::coeff(int narg, char **arg)
 {
   PairFLARE::coeff(narg,arg);
 
+  if(!normalized)
+    error->all(FLERR, "for now, pair flare/kk only supports the normalized kernel");
+  if(power != 2)
+    error->all(FLERR, "for now, pair flare/kk only supports the power-2 kernel");
+  //TODO check chebyshev and quadratic
+
   n_harmonics = (l_max+1)*(l_max+1);
   n_radial = n_species * n_max;
   n_bond = n_radial * n_harmonics;
@@ -777,7 +783,7 @@ void PairFLAREKokkos<DeviceType>::init_style()
   if (memstr != NULL) {
     maxmem = std::atof(memstr) * 1.0e9;
   }
-  printf("FLARE will use up to %.2f GB of device memory, controlled by MAXMEM environment variable\n", maxmem/1.0e9);
+  if(comm->me==0 || comm->me==comm->nprocs-1) printf("FLARE will use up to %.2f GB of device memory, controlled by MAXMEM environment variable\n", maxmem/1.0e9);
 }
 
 

--- a/lammps_plugins/pair_flare.cpp
+++ b/lammps_plugins/pair_flare.cpp
@@ -358,10 +358,14 @@ void PairFLARE::read_file(char *filename) {
     cutoff_function = cos_cutoff;
 
   // Set the kernel
-  if (!strcmp(kernel_string, "NormalizedDotProduct")) {
+  if (strcmp(kernel_string, "NormalizedDotProduct") == 0) {
     normalized = true;
-  } else {
+  }
+  else if (strcmp(kernel_string, "DotProduct") == 0){
     normalized = false;
+  }
+  else {
+    error->all(FLERR, "Kernel string not recognized, expected <power> <kernel string>");
   }
 
   // Parse the beta vectors.

--- a/tests/test_lammps.py
+++ b/tests/test_lammps.py
@@ -143,7 +143,7 @@ def test_lammps_uncertainty(
     if n_species > n_types:
         pytest.skip()
 
-    if (power == 1) and ("kokkos" in os.environ.get("lmp")):
+    if (power == 1 or kernel_type=="DotProduct") and ("kokkos" in os.environ.get("lmp")):
         pytest.skip()
 
     os.chdir(rootdir)
@@ -211,7 +211,7 @@ pair_coeff * * {potential_file}
 ### run
 fix fix_nve all nve
 compute unc all flare/std/atom {coeff_str}
-dump dump_all all custom 1 traj.lammps id type x y z vx vy vz fx fy fz c_unc 
+dump dump_all all custom 1 traj.lammps id type x y z vx vy vz fx fy fz c_unc
 dump_modify dump_all sort id
 thermo_style custom step temp press cpu pxx pyy pzz pxy pxz pyz ke pe etotal vol lx ly lz atoms
 thermo_modify flush yes format float %23.16g


### PR DESCRIPTION
Add fixes to `otf.py` to integrate CP2K with FLARE. Also may address issue 47 in flare_pp: [mir-group/flare_pp#47](https://github.com/mir-group/flare_pp/issues/47) 

## Summary

• Fix 1: Replace deepcopy with temporarily-generated instance of CP2K
• Fix 2: Fix dump of dft calculator. 
• Supports `write_model = 4` for offline training 
• Tested with CP2K versions 6.1 and 2023.1 

## Checklist

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [Black](https://pypi.org/project/black/) on your local machine.
- [x] Type annotations are **highly** encouraged.
- [ ] Tests have been added for any new functionality or bug fixes.
- [ ] All existing tests pass.
- [ ] The version number in `flare/_version.py` is updated. We are using a version number format a.b.c
    - If this PR fixes bugs, update version number to a.b.c+1
    - If this PR adds new features, update version number to a.b+1.0
    - If this PR includes significant changes in framework or interface, update version number to a+1.0.0

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.
