### PR TITLE
Fixed train_hyps accepting tuple with "inf".

### DIFF
--- a/flare/learners/otf.py
+++ b/flare/learners/otf.py
@@ -95,8 +95,10 @@ class OTF:
             DFT is called. Defaults to 1.
         train_hyps (tuple, optional): Specifies the range of steps the
             hyperparameters of the GP are optimized. If the number of DFT
-            calls is in this range, the hyperparameters are frozen.
-            Defaults to (None, None) which means always training.
+            calls is ouside this range, the hyperparameters are kept fixed.
+            To always optimize hyperparameters use (0,"inf").
+            Defaults to (0, 1) which means it only optimizes on the first dft 
+            call.
         min_steps_with_model (int, optional): Minimum number of steps the
             model takes in between calls to DFT. Defaults to 0.
         dft_kwargs ([type], optional): Additional arguments which are
@@ -223,8 +225,9 @@ class OTF:
             self.max_atoms_added = max_atoms_added
 
         if train_hyps[1] == "inf":
-            train_hyps[1] = np.inf
-        self.train_hyps = train_hyps
+            self.train_hyps = (train_hyps[0], np.inf)
+        else:
+            self.train_hyps = train_hyps
 
         if init_atoms is None:  # set atom list for initial dft run
             self.init_atoms = [int(n) for n in range(self.noa)]
@@ -703,7 +706,7 @@ class OTF:
         self.output.write_wall_time(tic, task="Update GP")
 
         # train model
-        if self.train_hyps[0] <= self.dft_count <= self.train_hyps[1]:
+        if self.train_hyps[0] <= self.dft_count < self.train_hyps[1]:
             self.train_gp()
 
         # update mgp model
@@ -713,7 +716,7 @@ class OTF:
             self.output.write_wall_time(tic, task="Build Map")
 
         # write model
-        if self.train_hyps[0] <= self.dft_count <= self.train_hyps[1]:
+        if self.train_hyps[0] <= self.dft_count < self.train_hyps[1]:
             if self.write_model == 2:
                 self.write_gp()
         if self.write_model == 3:


### PR DESCRIPTION
Setting train_hyps = (i,"inf") would give an error as the tuple cannot be assigned new upper bound np.inf. Also changes bounds of dft_count to not include upper bound, as this seems more intuitive. Documentation in OTF class changed accordingly.

Adapted from the Pymatgen PR template.

## Summary

Include a summary of major changes in bullet points:

* Feature 1
* Feature 2
* Fix 1
* Fix 2

## Additional dependencies introduced (if any)

* List all new dependencies needed and justify why. While adding dependencies that bring
significantly useful functionality is perfectly fine, adding ones that 
add trivial functionality, e.g., to use one single easily implementable
function, is frowned upon. Provide a justification why that dependency is needed.

## TODO (if any)

If this is a work-in-progress, write something about what else needs 
to be done

* Feature 1 supports A, but not B.

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP]
in the pull request title.

Before a pull request can be merged, the following items must be checked:

- [ ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). 
      Run [Black](https://pypi.org/project/black/) on your local machine.
- [ ] Docstrings have been added in the [Sphinx docstring format](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html).
- [ ] Type annotations are **highly** encouraged.
- [ ] Tests have been added for any new functionality or bug fixes.
- [ ] All existing tests pass.
- [ ] The version number in `flare/_version.py` is updated. We are using a version number format a.b.c
    - If this PR fixes bugs, update version number to a.b.c+1
    - If this PR adds new features, update version number to a.b+1.0
    - If this PR includes significant changes in framework or interface, update version number to a+1.0.0

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR.
