### PR TITLE
bug fixes: Kuu_jitter, sparse_descriptor initialization

### DIFF
--- a/flare/bffs/sgp/sparse_gp.py
+++ b/flare/bffs/sgp/sparse_gp.py
@@ -522,6 +522,7 @@ class SGP_Wrapper:
 
         n_kern = len(kernels)
         new_gp = SparseGP(kernels, hyps[n_kern], hyps[n_kern + 1], hyps[n_kern + 2])
+        new_gp.Kuu_jitter = self.sparse_gp.Kuu_jitter
 
         # add training data
         sparse_indices = self.sparse_gp.sparse_indices

--- a/src/flare_pp/bffs/sparse_gp.cpp
+++ b/src/flare_pp/bffs/sparse_gp.cpp
@@ -386,8 +386,8 @@ void SparseGP ::update_Kuu(
 
     // Update sparse count.
     this->n_sparse += n_envs;
-    }
   }
+}
 
 void SparseGP ::update_Kuf(
     const std::vector<ClusterDescriptor> &cluster_descriptors) {

--- a/src/flare_pp/descriptors/descriptor.cpp
+++ b/src/flare_pp/descriptors/descriptor.cpp
@@ -60,7 +60,7 @@ ClusterDescriptor::ClusterDescriptor(const DescriptorValues &structure,
 }
 
 void ClusterDescriptor ::initialize_cluster(int n_types, int n_descriptors) {
-  if (n_clusters != 0)
+  if (descriptors.size() > 0)
     return;
 
   this->n_types = n_types;

--- a/tests/get_sgp.py
+++ b/tests/get_sgp.py
@@ -143,10 +143,11 @@ def get_updated_sgp(n_types=2, power=2, multiple_cutoff=False, kernel_type="Norm
     energy = training_structure.get_potential_energy()
     stress = training_structure.get_stress()
 
+    custom_range = [0] 
     sgp.update_db(
         training_structure,
         forces,
-        custom_range=(0,),
+        custom_range=custom_range,
         energy=energy,
         stress=stress,
         mode="specific",


### PR DESCRIPTION
Bug fixes: 

1. Kuu_jitter was not saved
2. The sparse descriptors initialization could be duplicated so its length is 1 longer than it is supposed to