### PR TITLE
Update FakeDFT to only import relevant frame

### DIFF
--- a/flare/md/fake.py
+++ b/flare/md/fake.py
@@ -164,8 +164,7 @@ class FakeDFT(Calculator):
 
         step = atoms.info.get("step", 0)
 
-        fake_trajectory = read("All_Data.xyz", index=":", format="extxyz")
-        fake_frame = fake_trajectory[step]
+        fake_frame = read("All_Data.xyz", index=step, format="extxyz")
         assert np.allclose(atoms.positions, fake_frame.positions), (
             atoms.positions[0],
             fake_frame.positions[0],


### PR DESCRIPTION
The FakeDFT method appeared to be really slow for large input files.
This was because the calculate method in FakeDFT read the entire file each call and then selects the frame it needs.
Here, the calculate method was changed to only read the frame from the file it actually needs.
This speeds up the FakeDFT calculator significantly.
