### PR TITLE
Update output.py: fix time printing, with the time step with 0.5 fs

### DIFF
--- a/flare/io/output.py
+++ b/flare/io/output.py
@@ -214,7 +214,7 @@ class Output:
         else:
             string += f"\n*-Frame: {curr_step} "
 
-        string += f"\nSimulation Time: {(dt * curr_step):10.3f} ps \n"
+        string += f"\nSimulation Time: {(dt * curr_step):10.4f} ps \n"
         return string
 
     def write_md_config(


### PR DESCRIPTION
Time step is set to 0.5 fs inMD
Origin print :

*-Frame: 1
Simulation Time:      0.001 ps

updated print:
*-Frame: 1
Simulation Time:     0.0005 ps

