### PR TITLE
Cleaner Hyperparameter Optimization Logging

### DIFF
--- a/src/flare_pp/bffs/sparse_gp.cpp
+++ b/src/flare_pp/bffs/sparse_gp.cpp
@@ -747,8 +747,8 @@ void SparseGP ::compute_likelihood_stable() {
   }
 
   complexity_penalty = (1. / 2.) * (noise_det + Kuu_inv_det + sigma_inv_det);
-  std::cout << "like comp data " << complexity_penalty << " " << data_fit << std::endl;
-  std::cout << "noise_det Kuu_inv_det sigma_inv_det " << noise_det << " " << Kuu_inv_det << " " << sigma_inv_det << std::endl;
+  //std::cout << "like comp data " << complexity_penalty << " " << data_fit << std::endl;
+  //std::cout << "noise_det Kuu_inv_det sigma_inv_det " << noise_det << " " << Kuu_inv_det << " " << sigma_inv_det << std::endl;
   log_marginal_likelihood = complexity_penalty + data_fit + constant_term;
 }
 


### PR DESCRIPTION
During hyperparameter optimization with `optimize_hyperparameters` from `flare.bffs.sgp.sparse_gp`, things are sent to standard output at every evaluation of the likelihood. When used with other packages that also use standard output as their main way to log their progress, this can complicate the process of reading the overall output to only get the information desired. This pull request maintains the possibility of sending everything to standard output if the user desires so (for backward compatibility), but also allows users to stop sending things to standard output and send it into a Logging object instead. The main changes are explained as follows.

* In `flare/bffs/sgp/sparse_gp.py`, a `logger` argument is added to the `optimize_hyperparameters` function and other auxiliary functions such that the default value is `logger=None`. This allows for backward compatibility (all pre-existing code that call this function should not be affected in principle) and allows a user to pass in a logger (see [here](https://docs.python.org/3/library/logging.html)) to record the output in a specified log file for convenient perusal. Depending on how the logger is initialized, only the initial and final hyperparameters, likelihood and likelihood gradients are printed at the `info` level, while the `debug` level records this information for every evaluation of the likelihood and its gradient. 
* In `src/flare_pp/bffs/sparse_gp.cpp`, two lines that print things out to standard output (possibly for debugging purposes) are commented out. 