### PR TITLE
relax numpy requirement

### DIFF
--- a/flare/descriptors/env.py
+++ b/flare/descriptors/env.py
@@ -192,7 +192,7 @@ class AtomicEnvironment:
                     self.cut3b_mask = cutoffs_mask.get("cut3b_mask", None)
                     if "threebody_cutoff_list" in cutoffs_mask:
                         self.threebody_cutoff_list = np.array(
-                            cutoffs_mask["threebody_cutoff_list"], dtype=np.float
+                            cutoffs_mask["threebody_cutoff_list"], dtype=np.float64
                         )
 
     def compute_env(self):

--- a/flare/utils/parameter_helper.py
+++ b/flare/utils/parameter_helper.py
@@ -839,7 +839,7 @@ class ParameterHelper:
                 for ele in self.groups["specie"][idt]:
                     atom_n = atomic_numbers[ele]
                     if atom_n >= len(self.species_mask):
-                        new_mask = np.ones(atom_n, dtype=np.int) * (nspecie - 1)
+                        new_mask = np.ones(atom_n, dtype=np.int8) * (nspecie - 1)
                         new_mask[: len(self.species_mask)] = self.species_mask
                         self.species_mask = new_mask
                     self.species_mask[atom_n] = idt

--- a/flare/utils/parameters.py
+++ b/flare/utils/parameters.py
@@ -196,7 +196,7 @@ class Parameters:
 
                 # check mask has the right dimension and values
                 mask = param_dict[f"{kernel}_mask"]
-                param_dict[f"{kernel}_mask"] = nparray(mask, dtype=np.int)
+                param_dict[f"{kernel}_mask"] = nparray(mask, dtype=np.int8)
 
                 assert npmax(mask) < n
                 dim = Parameters.ndim[kernel]

--- a/flare/utils/parameters.py
+++ b/flare/utils/parameters.py
@@ -247,7 +247,7 @@ class Parameters:
 
             # Ensure typed correctly as numpy array
             param_dict["original_hyps"] = nparray(
-                param_dict["original_hyps"], dtype=np.float
+                param_dict["original_hyps"], dtype=np.float64
             )
             if (len(param_dict["original_hyps"]) - 1) not in param_dict["map"]:
                 assert (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy >=1.18, <1.23
+numpy
 scipy
 memory_profiler
 numba

--- a/tests/test_grid_kernel.py
+++ b/tests/test_grid_kernel.py
@@ -171,10 +171,10 @@ def get_reference(grid_env, species, parameter, kernel_name, same_hyps):
     )
     args = from_mask_to_args(hm["hyps"], hm["cutoffs"], None if same_hyps else hm)
 
-    energy_force = np.zeros(3, dtype=np.float)
-    # force_force = np.zeros(3, dtype=np.float)
-    # force_energy = np.zeros(3, dtype=np.float)
-    # energy_energy = np.zeros(3, dtype=np.float)
+    energy_force = np.zeros(3, dtype=np.float64)
+    # force_force = np.zeros(3, dtype=np.float64)
+    # force_energy = np.zeros(3, dtype=np.float64)
+    # energy_energy = np.zeros(3, dtype=np.float64)
     for i in range(3):
         energy_force[i] = force_en_kernel(env, grid_env, i + 1, *args)
         # force_energy[i] = force_en_kernel(env, grid_env, i, *args)


### PR DESCRIPTION
## Summary

* removes unspecified np.ints and np.floats (deprecated in recent versions of numpy)
* relaxes numpy requirement in requirements.txt

