### PR TITLE
Switch to neigh half flag for Kokkos

### DIFF
--- a/.github/workflows/flare.yml
+++ b/.github/workflows/flare.yml
@@ -103,7 +103,7 @@ jobs:
 
     - name: Run LAMMPS tests with Kokkos
       run: |
-        export lmp="$(pwd)/lammps/build/lmp -k on t 4 -sf kk -pk kokkos newton on neigh full"
+        export lmp="$(pwd)/lammps/build/lmp -k on t 4 -sf kk -pk kokkos newton on neigh half"
         cd tests
         pytest test_lammps.py
 

--- a/lammps_plugins/README.md
+++ b/lammps_plugins/README.md
@@ -41,7 +41,7 @@ where `Si.txt` should be replaced by the name of your mapped model. Then run `lm
 ### Running on a GPU with Kokkos
 See the [LAMMPS documentation](https://docs.lammps.org/Speed_kokkos.html). In general, run
 ```
-lmp -k on g 1 -sf kk -pk kokkos newton on neigh full -in in.script
+lmp -k on g 1 -sf kk -pk kokkos newton on neigh half -in in.script
 ```
 When running with MPI, replace `g 1` with the number of GPUs *per node*.
 

--- a/lammps_plugins/kokkos/pair_flare_kokkos.cpp
+++ b/lammps_plugins/kokkos/pair_flare_kokkos.cpp
@@ -737,7 +737,7 @@ void PairFLAREKokkos<DeviceType>::init_style()
 
   // always request a full neighbor list
 
-  if (neighflag != FULL) {
+  if (neighflag != HALF) {
     error->all(FLERR,"Cannot use chosen neighbor list style with pair flare/kk");
   }
 

--- a/lammps_plugins/kokkos/pair_flare_kokkos.cpp
+++ b/lammps_plugins/kokkos/pair_flare_kokkos.cpp
@@ -737,8 +737,8 @@ void PairFLAREKokkos<DeviceType>::init_style()
 
   // always request a full neighbor list
 
-  if (neighflag != HALF) {
-    error->all(FLERR,"Cannot use chosen neighbor list style with pair flare/kk");
+  if (neighflag == FULL) {
+    error->all(FLERR,"pair flare/kk requires 'newton on neigh half'");
   }
 
   // get available memory from environment variable,

--- a/lammps_plugins/pair_flare.cpp
+++ b/lammps_plugins/pair_flare.cpp
@@ -239,7 +239,7 @@ void PairFLARE::coeff(int narg, char **arg) {
 void PairFLARE::init_style() {
   // Require newton on.
   if (force->newton_pair == 0)
-    error->all(FLERR, "Pair style requires newton pair on");
+    error->all(FLERR, "Pair style flare requires newton pair on");
 
   // Request a full neighbor list.
   neighbor->add_request(this, NeighConst::REQ_FULL);


### PR DESCRIPTION
As of a recent update to the LAMMPS development branch, LAMMPS does not allow the `neigh full newton on` combo. The full/half flag doesn't affect the actual neighbor list anyways, so I've updated the pair styles to allow for the half flag.