### PR TITLE
Update Type Hint for energy_correction

### DIFF
--- a/flare/learners/lmpotf.py
+++ b/flare/learners/lmpotf.py
@@ -76,7 +76,7 @@ class LMPOTF:
         rcut: float,
         type2number: Union[(int, List[int])],
         dftcalc: object,
-        energy_correction: List[float] = 0.0,
+        energy_correction: Union[(float, List[float])] = 0.0,
         force_training=True,
         energy_training=True,
         stress_training=True,


### PR DESCRIPTION

Adapted from the Pymatgen PR template.

## Summary

Fix the type hint, it can either be a list of float or a single float. so I change it to a union.

## Additional dependencies introduced (if any)

N/A

## TODO (if any)

N/A

## Checklist

N/A
