### PR TITLE
Add helper function for single atom energy correction for lammps energy

### DIFF
--- a/flare/md/lammps.py
+++ b/flare/md/lammps.py
@@ -498,6 +498,10 @@ def add_single_atom_energies(lmp_energy, atoms, single_atom_energies, species_ma
     Returns:
         float: Energy with single atom contributions added
     """
+    # Return the original energy if no corrections are needed
+    if single_atom_energies is None:
+        return lmp_energy
+    
     for spec in atoms.numbers:
         coded_spec = species_map[spec]
         lmp_energy += single_atom_energies[coded_spec]
@@ -517,13 +521,12 @@ def check_sgp_match(atoms, sgp_calc, logger, specorder, command):
     lmp_stds = atoms.get_array("c_unc")
 
     # Add back single atom energies to lammps energy
-    if sgp_calc.gp_model.single_atom_energies is not None:
-        lmp_energy = add_single_atom_energies(
-            lmp_energy,
-            atoms,
-            sgp_calc.gp_model.single_atom_energies,
-            sgp_calc.gp_model.species_map,
-        )
+    lmp_energy = add_single_atom_energies(
+        lmp_energy,
+        atoms,
+        sgp_calc.gp_model.single_atom_energies,
+        sgp_calc.gp_model.species_map,
+    )
 
     # subtract the pressure from temperature
     kinetic_stress = get_kinetic_stress(atoms)
@@ -572,13 +575,12 @@ def check_sgp_match(atoms, sgp_calc, logger, specorder, command):
         lmp_energy = lmp_calc.results["energy"]
         
         # Add back single atom energies to lammps energy
-        if sgp_calc.gp_model.single_atom_energies is not None:
-            lmp_energy = add_single_atom_energies(
-                lmp_energy,
-                atoms,
-                sgp_calc.gp_model.single_atom_energies,
-                sgp_calc.gp_model.species_map,
-            )
+        lmp_energy = add_single_atom_energies(
+            lmp_energy,
+            atoms,
+            sgp_calc.gp_model.single_atom_energies,
+            sgp_calc.gp_model.species_map,
+        )
                 
         lmp_forces = lmp_calc.results["forces"]
         lmp_stress = lmp_calc.results["stress"]


### PR DESCRIPTION
This pull request introduces a utility function to ensure compatibility between LAMMPS and SGP energy calculations when single atom energies are present in the model.

## Changes

* [`flare/md/lammps.py`](diffhunk://#diff-17aa21d58ab5f781f2839d94e237b6133cb3bfe14452e1c7d54d935570da8bf6R483-R506): Added a new utility function `add_single_atom_energies()` to correctly handle energy offsets from single atom contributions
* Applied this function consistently in both instances of energy correction within `check_sgp_match()`
* Added clear documentation explaining that LAMMPS output energies do not inherently include single atom energy contributions
* Added test for the utility function

## Why This Change Is Needed

When using `pair_style flare` with LAMMPS, the potential energy reported by LAMMPS does not include the single atom energy contributions that are present in the SGP model. This can lead to inconsistencies when comparing energies between LAMMPS and SGP calculations, and may confuse users who directly use LAMMPS energies in post-processing.

The added utility function makes it easy to correctly apply these energy corrections and includes documentation to make users aware of this important consideration.
