### PR TITLE
Remove nptyping dependency

### DIFF
--- a/flare/bffs/mgp/mapxb.py
+++ b/flare/bffs/mgp/mapxb.py
@@ -735,7 +735,7 @@ class SingleMapXbody:
         """
         coefs = coefs.reshape([-1])
         for c, coef in enumerate(coefs):
-            f.write(" " + repr(coef))
+            f.write(f" {coef}")
             if c % 5 == 4 and c != len(coefs) - 1:
                 f.write("\n")
         f.write("\n")

--- a/flare/descriptors/env.py
+++ b/flare/descriptors/env.py
@@ -366,13 +366,9 @@ class AtomicEnvironment:
 
     def __str__(self):
         atom_type = self.ctype
-        neighbor_types = self.etypes
         n_neighbors = len(self.bond_array_2)
-        string = "Atomic Env. of Type {} surrounded by {} atoms of Types {}".format(
-            atom_type, n_neighbors, sorted(list(set(neighbor_types)))
-        )
-
-        return string
+        types = sorted({int(t) for t in self.etypes})
+        return f"Atomic Env. of Type {atom_type} surrounded by {n_neighbors} atoms of Types {types}"
 
     @property
     def force(self) -> "np.ndarray":

--- a/flare/io/output.py
+++ b/flare/io/output.py
@@ -425,6 +425,7 @@ class Output:
         self.write_wall_time(start_time)
 
     def add_atom_info(self, train_atoms, stds):
+        train_atoms = [int(atom) for atom in train_atoms]
         f = logging.getLogger(self.basename + "log")
         f.info(f"Adding atom {train_atoms} to the training set.")
         if len(train_atoms) > 0:

--- a/flare/utils/__init__.py
+++ b/flare/utils/__init__.py
@@ -39,7 +39,7 @@ class NumpyEncoder(JSONEncoder):
             ),
         ):
             return int(obj)
-        elif isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
+        elif isinstance(obj, (np.float16, np.float32, np.float64)):
             return float(obj)
         elif isinstance(obj, (np.ndarray,)):
             return obj.tolist()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mir-flare"
-version = "1.4.2"
+version = "1.4.3"
 description = "Fast Learning of Atomistic Rare Events"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 ]
 dependencies = [
     "ase",
-    "nptyping",
     "numba",
     "numpy",
     "pyyaml",


### PR DESCRIPTION
The unused nptyping dependency was causing numpy<2 to be required.

Also bumped the minor-minor version.